### PR TITLE
Update psycopg2 to a version compatible with libssl-1.1.x

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -13,6 +13,8 @@
   pip: requirements={{ virtualenv }}/src/ckan/dev-requirements.txt virtualenv={{ virtualenv }} state=latest
   when: deployment_environment_id == "vagrant"
 
+- include: override_requirements.yml
+
 - name: Create CKAN paths
   file: path={{ item }} state=directory mode="0770" owner={{ www_user }} group={{ www_group }}
   with_items:

--- a/ansible/roles/ckan/tasks/override_requirements.yml
+++ b/ansible/roles/ckan/tasks/override_requirements.yml
@@ -1,0 +1,5 @@
+- name: Copy override requirements file
+  template: src=override_requirements.txt.j2 dest="{{ cache_path }}/override_requirements.txt" mode="0644" owner=root group=root
+
+- name: Install override requirements
+  pip: requirements="{{ cache_path }}/override_requirements.txt" virtualenv="{{ virtualenv }}" extra_args='--exists-action=w --timeout=30'

--- a/ansible/roles/ckan/templates/override_requirements.txt.j2
+++ b/ansible/roles/ckan/templates/override_requirements.txt.j2
@@ -1,0 +1,3 @@
+# psycopg2 < 2.8.2 does not work with libssl 1.1.x
+psycopg2==2.8.2
+


### PR DESCRIPTION
- Added `override_requirements.txt` to install pip packages over CKAN's requirements
- Install psycopg2 2.8.2 to fix libssl compatibility issues