### PR TITLE
LIKA-6: Custom default sorting solution for organizations via a helper

### DIFF
--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -158,7 +158,7 @@ class Apicatalog_OrganizationController(OrganizationController):
         q = c.q = request.params.get('q', '')
         sort_by = c.sort_by_selected = request.params.get('sort')
         if sort_by is None:
-            sort_by = c.sort_by_selected = 'title asc'
+            sort_by = 'title asc'
         try:
             self._check_access('site_read', context)
             self._check_access('group_list', context)

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
@@ -1,8 +1,24 @@
 {% ckan_extends %}
 
 
-{% set sorting = [(_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
+{% set sorting = [(_('Relevance'), ''), (_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}
 
 {% block organizations_search_form %}
     {% snippet 'snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search organizations...'), show_empty=request.params, no_bottom_border=true if c.page.items %}
+{% endblock %}
+
+{% block organizations_list %}
+  {% set items = h.custom_organization_list(request.params) %}
+  {% if items or request.params %}
+    {% if items %}
+      {% snippet "organization/snippets/organization_list.html", organizations=items %}
+    {% endif %}
+  {% else %}
+    <p class="empty">
+      {{ _('There are currently no organizations for this site') }}.
+      {% if h.check_access('organization_create') %}
+        {% link_for _('How about creating one?'), controller='organization', action='new' %}</a>.
+      {% endif %}
+    </p>
+  {% endif %}
 {% endblock %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/snippets/search_form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/snippets/search_form.html
@@ -6,7 +6,7 @@
         <label for="field-order-by">{{ _('Order by') }}</label>
         <select id="field-order-by" name="sort">
           {% for label, value in sorting %}
-            {% if label and value %}
+            {% if label %}
               <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
- Have empty organization list sorting value correspond to "alphabetically ascending, grouped descendingly by existence of data sets"
- Implement sorting in a separate helper that fetches all organizations and does sorting/paging manually
- Add the new default sorting schema as sorting by "Relevance"