### PR TITLE
LIKA-36: Allow clicking select box arrows and fix focus area

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/less/forms.less
+++ b/ckanext/ckanext-apicatalog_ui/less/forms.less
@@ -74,9 +74,7 @@ input[type=checkbox] {
   position: relative;
   select {
     color: @suomifi-text-base;
-    padding: 4px;
-    padding-right: 10px;
-    height:33px;
+    height: 33px;
     background-color: white;
     border: 1px solid @kapa-input-border;
     border-radius: 2px;
@@ -86,6 +84,7 @@ input[type=checkbox] {
   }
 
   &:after {
+    pointer-events: none;
     font-family: FontAwesome;
     content: "\f0d7";
     color: @suomifi-text-highlight;

--- a/ckanext/ckanext-apicatalog_ui/less/layout.less
+++ b/ckanext/ckanext-apicatalog_ui/less/layout.less
@@ -315,7 +315,6 @@
     border-radius: 0;
     font-size: 16px;
     line-height: 24px;
-    padding: 4px 12px;
   }
 
   input {


### PR DESCRIPTION
- Make the triangle `pointer-events: none` to allow clicking through it
- Remove text padding to fix element focus area