### PR TITLE
LIKA-61: Fix with_capacity leftover and access_restriction_level related errors

### DIFF
--- a/ansible/roles/ckan/files/patches/disable_leftover_with_capacity.patch
+++ b/ansible/roles/ckan/files/patches/disable_leftover_with_capacity.patch
@@ -1,0 +1,30 @@
+diff --git a/ckan/lib/dictization/model_dictize.py b/ckan/lib/dictization/model_dictize.py
+index 9acb15095..f0332436c 100644
+--- a/ckan/lib/dictization/model_dictize.py
++++ b/ckan/lib/dictization/model_dictize.py
+@@ -215,7 +215,9 @@ def package_dictize(pkg, context):
+                from_obj=pkg_tag.join(tag, tag.c.id == pkg_tag.c.tag_id)
+                ).where(pkg_tag.c.package_id == pkg.id)
+     result = execute(q, pkg_tag, context)
+-    result_dict["tags"] = d.obj_list_dictize(result, context,
++    dictize_context = context.copy()
++    dictize_context['with_capacity'] = False
++    result_dict["tags"] = d.obj_list_dictize(result, dictize_context,
+                                              lambda x: x["name"])
+     result_dict['num_tags'] = len(result_dict.get('tags', []))
+ 
+diff --git a/ckan/logic/action/get.py b/ckan/logic/action/get.py
+index 7c237603f..e41c18d9f 100644
+--- a/ckan/logic/action/get.py
++++ b/ckan/logic/action/get.py
+@@ -590,7 +590,9 @@ def group_list_authz(context, data_dict):
+         if package:
+             groups = set(groups) - set(package.get_groups())
+ 
+-    group_list = model_dictize.group_list_dictize(groups, context)
++    dictize_context = context.copy()
++    dictize_context['with_capacity'] = False
++    group_list = model_dictize.group_list_dictize(groups, dictize_context)
+     return group_list
+ 
+ 

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -35,6 +35,7 @@ ckan_patches:
   - { file: "fix_unicode_decode_error_in_error_page" } # https://github.com/ckan/ckan/pull/4727
   - { file: "fix-popped-wrong-app-context" } # CKAN issue #4431
   - { file: "reorder_bulk_process" } # https://github.com/ckan/ckan/pull/5147
+  - { file: "disable_leftover_with_capacity" }
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -124,7 +124,7 @@ class Apicatalog_RoutesPlugin(ckan.plugins.SingletonPlugin, ckan.lib.plugins.Def
             # 3) access_restriction_level is same_organization AND the logged in user's list of organizations contains
             #    the organization of the package
             allowed_resources = [resource for resource in result.get('resources', [])
-                                 if resource.get('access_restriction_level', '') == 'public' or
+                                 if resource.get('access_restriction_level', '') in ('', 'public') or
                                  (resource.get('access_restriction_level', '') == 'only_allowed_users'
                                   and c.user in resource.get('allowed_users', '').split(',')) or
                                  (resource.get('access_restriction_level', '') == 'same_organization' and
@@ -150,7 +150,7 @@ class Apicatalog_RoutesPlugin(ckan.plugins.SingletonPlugin, ckan.lib.plugins.Def
         #    the organization of the package
         allowed_resources = [resource for resource in data_dict.get('resources', [])
                              if 'access_restriction_level' not in resource or
-                             resource.get('access_restriction_level', '') == 'public' or
+                             resource.get('access_restriction_level', '') in ('', 'public') or
                              (resource.get('access_restriction_level', '') == 'only_allowed_users'
                               and c.user in resource.get('allowed_users', '').split(',')) or
                              (resource.get('access_restriction_level', '') == 'same_organization' and


### PR DESCRIPTION
- In some execution paths `with_capacity` remains in context when it should not. This causes some dictization functions to fail since their parameter format is determined by it
- `access_level_restriction` defaulted to never-visible, since empty value was not taken into account. This caused crashes when creating a new resource with default values, as the newly created resource was not visible to the code that created it