### PR TITLE
LIKA-62: Move missing ckanext-pages page button into content

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/pages_list.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/pages_list.html
@@ -4,8 +4,8 @@
   {% if h.check_access('ckanext_pages_update', {}) %}
   <div>
     {% link_for _('Add page'), controller='ckanext.pages.controller:PagesController', action='pages_edit', page='', class_='btn btn-primary', icon=h.pages_get_plus_icon() %}
-  {% endif %}
   </div>
+  {% endif %}
   <h1 class="hide-heading">{{ _('Pages') }}</h1>
   {% snippet 'ckanext_pages/snippets/pages_list.html', pages=c.page.items %}
   {{ c.page.pager() }}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/pages_list.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/pages_list.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  {% if h.check_access('ckanext_pages_update', {}) %}
+  <div>
+    {% link_for _('Add page'), controller='ckanext.pages.controller:PagesController', action='pages_edit', page='', class_='btn btn-primary', icon=h.pages_get_plus_icon() %}
+  {% endif %}
+  </div>
+  <h1 class="hide-heading">{{ _('Pages') }}</h1>
+  {% snippet 'ckanext_pages/snippets/pages_list.html', pages=c.page.items %}
+  {{ c.page.pager() }}
+{% endblock %}


### PR DESCRIPTION
- The block the button normally is in is not visible in current theme. Override template to move it into content.