### PR TITLE
LIKA-67: Add samesite flag to authentication token

### DIFF
--- a/ansible/roles/ckan/files/patches/add_samesite_flag.patch
+++ b/ansible/roles/ckan/files/patches/add_samesite_flag.patch
@@ -1,0 +1,33 @@
+diff --git a/ckan/lib/auth_tkt.py b/ckan/lib/auth_tkt.py
+index 36faea564..75c32824d 100644
+--- a/ckan/lib/auth_tkt.py
++++ b/ckan/lib/auth_tkt.py
+@@ -14,9 +14,10 @@ log = logging.getLogger(__name__)
+ 
+ class CkanAuthTktCookiePlugin(repoze_auth_tkt.AuthTktCookiePlugin):
+ 
+-    def __init__(self, httponly, *args, **kwargs):
++    def __init__(self, httponly, samesite, *args, **kwargs):
+         super(CkanAuthTktCookiePlugin, self).__init__(*args, **kwargs)
+         self.httponly = httponly
++        self.samesite = samesite
+ 
+     def _get_cookies(self, *args, **kwargs):
+         '''
+@@ -59,6 +60,8 @@ def make_plugin(secret=None,
+     httponly = config.get('who.httponly', True)
+     # Set secure based on config value. Default is False
+     secure = config.get('who.secure', False)
++    # Set samesite based on config value. Default is None
++    samesite = config.get('who.samesite', None)
+ 
+     # back to repoze boilerplate
+     if (secret is None and secretfile is None):
+@@ -77,6 +80,7 @@ def make_plugin(secret=None,
+     if userid_checker is not None:
+         userid_checker = resolveDotted(userid_checker)
+     plugin = CkanAuthTktCookiePlugin(_bool(httponly),
++                                     samesite,
+                                      secret,
+                                      cookie_name,
+                                      _bool(secure),

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -26,6 +26,7 @@ who.log_file = %(cache_dir)s/who_log.ini
 # Secure cookie & 4h timeout
 who.secure = True
 who.timeout = 14400
+who.samesite = Strict
 
 sqlalchemy.url = postgres://{{ database_ckan.username }}:{{ database_ckan.password }}@{{ database_ckan.host }}/{{ database_ckan.name }}
 

--- a/ansible/roles/ckan/templates/override_requirements.txt.j2
+++ b/ansible/roles/ckan/templates/override_requirements.txt.j2
@@ -1,3 +1,4 @@
 # psycopg2 < 2.8.2 does not work with libssl 1.1.x
 psycopg2==2.8.2
-
+beaker==1.10.1
+git+git://github.com/repoze/repoze.who.git#889ab5b

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -37,6 +37,7 @@ ckan_patches:
   - { file: "reorder_bulk_process" } # https://github.com/ckan/ckan/pull/5147
   - { file: "disable_leftover_with_capacity" }
   - { file: "fix_password_reset" }
+  - { file: "add_samesite_flag" }
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}


### PR DESCRIPTION
Beaker and repoze.who are updated for samesite flag support. repoze.who is locked specific commit as it has not released a new version to pypi yet.