### PR TITLE
LIKA-68: Switch from modified ckanext-pages to extending

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/open-data/ckanext-fluent.git
 [submodule "ckanext/ckanext-pages"]
 	path = ckanext/ckanext-pages
-	url = https://github.com/vrk-kpa/ckanext-pages.git
+	url = https://github.com/ckan/ckanext-pages.git
 [submodule "ckanext/ckanext-contact"]
 	path = ckanext/ckanext-contact
 	url = https://github.com/vrk-kpa/ckanext-contact.git

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -7,7 +7,7 @@ harvester_user: "{{ www_user }}"
 celery_user: "{{ www_user }}"
 
 # plugin order matters, when templates call super()
-ckan_plugins: text_view apicatalog_scheming scheming_datasets fluent apicatalog_ui pages apicatalog_admin_dashboard apicatalog_routes contact apicatalog_feed apicatalog_harvesterstatus harvest xroad_harvester wsdl_view validate_links saha paha webpage_view
+ckan_plugins: text_view apicatalog_scheming scheming_datasets fluent apicatalog_ui apicatalog_pages pages apicatalog_admin_dashboard apicatalog_routes contact apicatalog_feed apicatalog_harvesterstatus harvest xroad_harvester wsdl_view validate_links saha paha webpage_view
 
 redis_harvest_database: 0
 redis_celery_database: 1

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/pages.py
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/pages.py
@@ -1,0 +1,18 @@
+import ckan.plugins as plugins
+import ckan.plugins.toolkit as toolkit
+from ckanext.pages.interfaces import IPagesSchema
+
+class Apicatalog_PagesPlugin(plugins.SingletonPlugin):
+    plugins.implements(IPagesSchema)
+
+    #IPagesSchema
+    def update_pages_schema(self, schema):
+        schema.update({
+            'title_fi': [],
+            'title_sv': [],
+            'title_en': [],
+            'content_fi': [],
+            'content_sv': [],
+            'content_en': [],
+            })
+        return schema

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/base_form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/base_form.html
@@ -1,0 +1,33 @@
+{% ckan_extends %}
+
+{% block extra_pages_form %}
+  {{ form.input('title_fi', label=_('Title') + ' FI', value=data.title_fi, error=errors.title) }}
+  {{ form.input('title_sv', label=_('Title') + ' SV', value=data.title_sv, error=errors.title) }}
+  {{ form.input('title_en', label=_('Title') + ' EN', value=data.title_en, error=errors.title) }}
+
+  {% set editor = h.get_wysiwyg_editor() %}
+
+  {% if editor == 'medium' %}
+    {{ wysiwyg.editor('content_fi', id='field-content-fi', label=_('Content') + ' FI', placeholder=_('Enter content here'), value=data.content|safe, error=errors.content) }}
+    {{ wysiwyg.editor('content_sv', id='field-content-sv', label=_('Content') + ' SV', placeholder=_('Enter content here'), value=data.content|safe, error=errors.content) }}
+    {{ wysiwyg.editor('content_en', id='field-content-en', label=_('Content') + ' EN', placeholder=_('Enter content here'), value=data.content|safe, error=errors.content) }}
+  {% elif editor == 'ckeditor' %}
+    {% resource 'ckanext-pages/main' %}
+    <div class="control-group">
+        <label for="field-content-ck" class="control-label">{{ _('Content') }} FI</label>
+    </div>
+    <textarea id="field-content-ck" name="content_fi" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content_fi }}</textarea>
+    <div class="control-group">
+        <label for="field-content-ck" class="control-label">{{ _('Content') }} SV</label>
+    </div>
+    <textarea id="field-content-ck" name="content_sv" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content_sv }}</textarea>
+    <div class="control-group">
+        <label for="field-content-ck" class="control-label">{{ _('Content') }} EN</label>
+    </div>
+    <textarea id="field-content-ck" name="content_en" placeholder="{{_('My content')}}" data-module="ckedit" style="height:400px" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"> {{ data.content_en }}</textarea>
+  {% else %}
+    {{ form.markdown('content', id='field-content-fi', label=_('Content') + ' FI', placeholder=_('Enter content here'), value=data.content_fi, error=errors.content) }}
+    {{ form.markdown('content', id='field-content-sv', label=_('Content') + ' SV', placeholder=_('Enter content here'), value=data.content_sv, error=errors.content) }}
+    {{ form.markdown('content', id='field-content-en', label=_('Content') + ' EN', placeholder=_('Enter content here'), value=data.content_en, error=errors.content) }}
+  {% endif %}
+{% endblock extra_pages_form %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/page.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/page.html
@@ -1,7 +1,11 @@
 {% ckan_extends %}
 
+{% set lang = h.lang().split('_')[0] %}
+{% set page_title = c.page.get('title_' + lang) or c.page.title %}
+{% set page_content = c.page.get('content_' + lang) or c.page.content %}
+
 {% block subtitle %}
-	{{ c.page.title }}
+{{ page_title }}
 {% endblock %}
 
 {% block primary %}
@@ -10,16 +14,16 @@
 			{% if h.check_access('ckanext_pages_update') %}
 				{% link_for _('Edit'), controller='ckanext.pages.controller:PagesController', action='pages_edit', page='/' + c.page.name, class_='btn btn-primary pull-right', icon='edit' %}
 			{% endif %}
-			<h1 class="page-heading">{{ c.page.title }}</h1>
-			{% if c.page.content %}
+			<h1 class="page-heading">{{ page_title }}</h1>
+			{% if page_content %}
 				<div class="ckanext-pages-content">
 					{% set editor = h.get_wysiwyg_editor() %}
 					{% if editor %}
 						<div>
-							{{c.page.content|safe}}
+							{{page_content|safe}}
 						</div>
 					{% else %}
-						{{ h.render_content(c.page.content) }}
+						{{ h.render_content(page_content) }}
 					{% endif %}
 				</div>
 			{% else %}

--- a/ckanext/ckanext-apicatalog_ui/setup.py
+++ b/ckanext/ckanext-apicatalog_ui/setup.py
@@ -80,5 +80,6 @@ setup(
         [ckan.plugins]
         apicatalog_ui=ckanext.apicatalog_ui.plugin:Apicatalog_UiPlugin
         apicatalog_admin_dashboard=ckanext.apicatalog_ui.plugin:Apicatalog_AdminDashboardPlugin
+        apicatalog_pages=ckanext.apicatalog_ui.pages:Apicatalog_PagesPlugin
     ''',
 )


### PR DESCRIPTION
- Change from ckanext-pages fork to upstream
- Added schema extension to ckanext-pages into ckanext-apicatalog_ui to support multilingual content and titles
- Added template overrides to display multilingual content