### PR TITLE
Add mailhog to vagrant

### DIFF
--- a/ansible/deploy-all.yml
+++ b/ansible/deploy-all.yml
@@ -10,6 +10,12 @@
     - "vars/common.yml"
     - "vars/environment-specific/{{ deployment_environment_id }}.yml"
     - "{{ secrets_file_path }}"
+
+  pre_tasks:
+    - import_role:
+        name: mailhog
+      when: deployment_environment_id == 'vagrant'
+      tags: mailhog
   roles:
     - os-base
     - java8

--- a/ansible/roles/mailhog/.yamllint
+++ b/ansible/roles/mailhog/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/ansible/roles/mailhog/README.md
+++ b/ansible/roles/mailhog/README.md
@@ -1,0 +1,33 @@
+Ansible role mailhog
+=========
+
+This ansible role installs MailHog email testing tool for developers.
+
+Requirements
+------------
+None
+
+Role Variables
+--------------
+
+* **mailhog_install_dir**: Install directory for MailHog
+* **mailhog_version**: MailHog version
+* **mailhog_release_url**: URL where MailHog binary is downloaded from
+* **mailhog_mhsendmail_version**: MailHog sendmail version
+* **mailhog_mhsendmail_release_url**: URL where MailHog sendmail (mhsendmail) binary is downloaded from
+
+Dependencies
+------------
+None
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+         - mailhog
+
+License
+-------
+
+MIT

--- a/ansible/roles/mailhog/defaults/main.yml
+++ b/ansible/roles/mailhog/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for mailhog
+
+mailhog_install_dir: /opt/mailhog
+mailhog_version: 1.0.0
+mailhog_release_url: https://github.com/mailhog/MailHog/releases/download/v{{ mailhog_version }}/MailHog_linux_amd64
+mailhog_mhsendmail_version: 0.2.0
+mailhog_mhsendmail_release_url: https://github.com/mailhog/mhsendmail/releases/download/v{{ mailhog_mhsendmail_version }}/mhsendmail_linux_amd64

--- a/ansible/roles/mailhog/handlers/main.yml
+++ b/ansible/roles/mailhog/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# handlers file for mailhog
+
+- name: restart mailhog
+  systemd:
+    name: mailhog
+    state: restarted
+
+- name: restart mailhog and run daemon reload
+  systemd:
+    name: mailhog
+    state: restarted
+    daemon_reload: true

--- a/ansible/roles/mailhog/meta/main.yml
+++ b/ansible/roles/mailhog/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  description: Ansible role for MailHog
+  license: MIT
+
+  min_ansible_version: 2.7.5
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+
+  galaxy_tags:
+    - development
+    - mail
+    - mailhog
+
+dependencies: []

--- a/ansible/roles/mailhog/molecule/default/INSTALL.rst
+++ b/ansible/roles/mailhog/molecule/default/INSTALL.rst
@@ -1,0 +1,17 @@
+*******
+Vagrant driver installation guide
+*******
+
+Requirements
+============
+
+* Vagrant
+* Virtualbox, Parallels, VMware Fusion, VMware Workstation or VMware Desktop
+* python-vagrant
+
+Install
+=======
+
+.. code-block:: bash
+
+    $ sudo pip install python-vagrant

--- a/ansible/roles/mailhog/molecule/default/molecule.yml
+++ b/ansible/roles/mailhog/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: xenialxerus
+    box: bento/ubuntu-16.04
+  - name: bionicbeaver
+    box: bento/ubuntu-18.04
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/ansible/roles/mailhog/molecule/default/playbook.yml
+++ b/ansible/roles/mailhog/molecule/default/playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: mailhog

--- a/ansible/roles/mailhog/molecule/default/prepare.yml
+++ b/ansible/roles/mailhog/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+      changed_when: false

--- a/ansible/roles/mailhog/molecule/default/tests/test_default.py
+++ b/ansible/roles/mailhog/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/ansible/roles/mailhog/tasks/main.yml
+++ b/ansible/roles/mailhog/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# tasks file for mailhog
+
+- name: Create group for mailhog user
+  group:
+    name: mailhog
+    system: true
+    state: present
+
+- name: Create mailhog user
+  user:
+    name: mailhog
+    system: true
+    create_home: false
+    state: present
+
+
+- name: Ensure mailhog directory exists
+  file:
+    path: "{{ mailhog_install_dir }}"
+    owner: mailhog
+    group: mailhog
+    state: directory
+    mode: 0755
+
+- name: Download mailhog and mhsendmail
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    owner: mailhog
+    group: mailhog
+    mode: 0755
+  with_items:
+    - url: "{{ mailhog_release_url }}"
+      dest: "{{ mailhog_install_dir }}/mailhog"
+    - url: "{{ mailhog_mhsendmail_release_url }}"
+      dest: "{{ mailhog_install_dir }}/mhsendmail"
+  notify: restart mailhog
+
+- name: Create systemd service file for mailhog
+  template:
+    src: mailhog.service.j2
+    dest: /etc/systemd/system/mailhog.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart mailhog and run daemon reload
+
+- name: Enable and start mailhog service
+  systemd:
+    name: mailhog
+    state: started
+    enabled: true
+    daemon_reload: true

--- a/ansible/roles/mailhog/templates/mailhog.service.j2
+++ b/ansible/roles/mailhog/templates/mailhog.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=MailHog email testing tool for developers
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart={{ mailhog_install_dir }}/mailhog
+StandardOutput=journal
+Restart=on-failure
+User=mailhog
+Group=mailhog
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mailhog/vars/main.yml
+++ b/ansible/roles/mailhog/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for mailhog

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -57,7 +57,7 @@ ckan_admins:
 
 email_domain: vagrant
 email:
-  smtp_server: localhost
+  smtp_server: localhost:1025
   from: no-reply@{{ email_domain }}
   error_recipient: vagrant@localhost
   error_from: error@{{ email_domain }}


### PR DESCRIPTION
The role is copied from [opendata](https://github.com/vrk-kpa/opendata), only other changes are in deploy-all.yml and vagrant variables to send mail to mailhog itself.