### PR TITLE
LIKA-128: Add auth function for modifying users

### DIFF
--- a/ansible/roles/ckan/files/patches/remove_is_sysadmin_or_user_itself_check.patch
+++ b/ansible/roles/ckan/files/patches/remove_is_sysadmin_or_user_itself_check.patch
@@ -1,0 +1,56 @@
+diff --git a/ckan/controllers/user.py b/ckan/controllers/user.py
+index 1bfb2ca2eb..fb6a3dccb9 100644
+--- a/ckan/controllers/user.py
++++ b/ckan/controllers/user.py
+@@ -316,11 +316,6 @@ def edit(self, id=None, data=None, errors=None, error_summary=None):
+ 
+         user_obj = context.get('user_obj')
+ 
+-        if not (authz.is_sysadmin(c.user)
+-                or c.user == user_obj.name):
+-            abort(403, _('User %s not authorized to edit %s') %
+-                  (str(c.user), id))
+-
+         errors = errors or {}
+         vars = {'data': data, 'errors': errors, 'error_summary': error_summary}
+ 
+diff --git a/ckan/views/user.py b/ckan/views/user.py
+index 87c3af1e10..7457507416 100644
+--- a/ckan/views/user.py
++++ b/ckan/views/user.py
+@@ -251,10 +251,6 @@ def get(self, id=None, data=None, errors=None, error_summary=None):
+             base.abort(404, _(u'User not found'))
+         user_obj = context.get(u'user_obj')
+ 
+-        if not (authz.is_sysadmin(g.user) or g.user == user_obj.name):
+-            msg = _(u'User %s not authorized to edit %s') % (g.user, id)
+-            base.abort(403, msg)
+-
+         errors = errors or {}
+         vars = {
+             u'data': data,
+
+diff --git a/ckan/controllers/user.py b/ckan/controllers/user.py
+index fb6a3dccb9..e2a39a064a 100644
+--- a/ckan/controllers/user.py
++++ b/ckan/controllers/user.py
+@@ -324,7 +324,6 @@ def edit(self, id=None, data=None, errors=None, error_summary=None):
+                                         'user': c.user},
+                                        data_dict)
+
+-        c.is_myself = True
+         c.show_email_notifications = asbool(
+             config.get('ckan.activity_streams_email_notifications'))
+         c.form = render(self.edit_user_form, extra_vars=vars)
+diff --git a/ckan/views/user.py b/ckan/views/user.py
+index 7457507416..c6ccb6ef65 100644
+--- a/ckan/views/user.py
++++ b/ckan/views/user.py
+@@ -264,7 +264,6 @@ def get(self, id=None, data=None, errors=None, error_summary=None):
+             u'user': g.user
+         }, data_dict)
+
+-        extra_vars[u'is_myself'] = True
+         extra_vars[u'show_email_notifications'] = asbool(
+             config.get(u'ckan.activity_streams_email_notifications'))
+         vars.update(extra_vars)

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -120,6 +120,7 @@ ckanext.forcetranslation.domain = ckan
 
 
 ckanext.apicatalog_routes.allowed_user_creators = {{ allowed_user_creators | default([]) | join(" ")  }}
+ckanext.apicatalog_routes.allowed_user_editors = {{ allowed_user_editors | default([]) | join(" ")  }}
 
 ofs.impl = pairtree
 

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -31,6 +31,7 @@ ckan_patches:
   - { file: "fix_unicode_decode_error_in_error_page" } # https://github.com/ckan/ckan/pull/4727
   - { file: "reorder_bulk_process" } # https://github.com/ckan/ckan/pull/5147
   - { file: "disable_leftover_with_capacity" }
+  - { file: "remove_is_sysadmin_or_user_itself_check" } # https://github.com/ckan/ckan/pull/5405
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -116,3 +116,6 @@ ckan_plugins:
 
 allowed_user_creators:
   - paha
+
+allowed_user_editors:
+  - paha

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -114,3 +114,6 @@ ckan_plugins:
 
 allowed_user_creators:
   - paha
+
+allowed_user_editors:
+  - paha

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
@@ -3,7 +3,7 @@ import logging
 log = logging.getLogger(__name__)
 
 from ckan.logic.auth import get, update
-from ckan.plugins.toolkit import check_access, auth_allow_anonymous_access, _
+from ckan.plugins.toolkit import check_access, auth_allow_anonymous_access, _, chained_auth_function
 
 from ckan.lib.base import config
 from ckan.common import c
@@ -38,3 +38,22 @@ def create_user_to_organization(context, data_dict=None):
         "success": False,
         "msg": _("User {user} not authorized to create users via the API").format(user=context.get('user'))
     }
+
+@chained_auth_function
+def user_create(next_auth, context, data_dict=None):
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    if context.get('user') and context.get('user') in users_allowed_to_create_users:
+        return {"success": True}
+
+@chained_auth_function
+def user_update(next_auth, context, data_dict=None):
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    if context.get('user') and context.get('user') in users_allowed_to_create_users:
+        return {"success": True}
+
+@chained_auth_function
+def user_show(next_auth, context, data_dict=None):
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    if context.get('user') and context.get('user') in users_allowed_to_create_users:
+        context['keep_email'] = True
+        return {"success": True}

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
@@ -43,7 +43,7 @@ def create_user_to_organization(context, data_dict=None):
 
 @chained_auth_function
 def user_create(next_auth, context, data_dict=None):
-    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_editors', [])
     if context.get('user') and context.get('user') in users_allowed_to_create_users:
         return {"success": True}
 
@@ -51,7 +51,7 @@ def user_create(next_auth, context, data_dict=None):
 
 @chained_auth_function
 def user_update(next_auth, context, data_dict=None):
-    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_editors', [])
     if context.get('user_obj'):
         sysadmin_field = context.get('user_obj').sysadmin
     else:
@@ -69,7 +69,7 @@ def user_update(next_auth, context, data_dict=None):
 
 @chained_auth_function
 def user_show(next_auth, context, data_dict=None):
-    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_creators', [])
+    users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_editors', [])
 
     if context.get('user') and context.get('user') in users_allowed_to_create_users \
             and context['user_obj'].sysadmin is False:

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -93,7 +93,10 @@ class Apicatalog_RoutesPlugin(ckan.plugins.SingletonPlugin, ckan.lib.plugins.Def
                 'read_members': auth.read_members,
                 'group_edit_permissions': auth.read_members,
                 'send_reset_link': admin_only,
-                'create_user_to_organization': auth.create_user_to_organization
+                'create_user_to_organization': auth.create_user_to_organization,
+                'user_create': auth.user_create,
+                'user_update': auth.user_update,
+                'user_show': auth.user_show
                 }
 
     # IPermissionLabels

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/user/edit_user_form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/user/edit_user_form.html
@@ -24,9 +24,17 @@
 
     <fieldset>
         <legend>{{ _('Change password') }}</legend>
+
+        {% if is_sysadmin %}
+            {% set label = _('Sysadmin Password') %}
+        {% elif is_myself  %}
+            {% set label = _('Old Password') %}
+        {% else %}
+            {% set label = _('Your Password') %}
+        {% endif %}
         {{ form.input('old_password',
                   type='password',
-                  label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
+                  label=label,
                   id='field-password-old',
                   value=data.oldpassword,
                   error=errors.oldpassword,


### PR DESCRIPTION
Includes modification to core controllers where edit form is assumed to be used by sysadmin or the user itself.

New auth functions check that the modified user are not sysadmins.