### PR TITLE
LIKA-130: Fix internal server error in password reset

### DIFF
--- a/ansible/roles/ckan/files/patches/retain_allow_anonymous_access_in-chained_auth.patch
+++ b/ansible/roles/ckan/files/patches/retain_allow_anonymous_access_in-chained_auth.patch
@@ -1,0 +1,19 @@
+diff --git a/ckan/authz.py b/ckan/authz.py
+index 270125512..09eb9b227 100644
+--- a/ckan/authz.py
++++ b/ckan/authz.py
+@@ -114,8 +114,12 @@ class AuthFunctions:
+                 else:
+                     # fallback to chaining off the builtin auth function
+                     prev_func = self._functions[name]
+-                fetched_auth_functions[name] = (
+-                    functools.partial(func, prev_func))
++
++                wrapped_func = functools.partial(func, prev_func)
++                if getattr(func, 'auth_allow_anonymous_access', False):
++                    wrapped_func.auth_allow_anonymous_access = True
++
++                fetched_auth_functions[name] = wrapped_func
+ 
+         # Use the updated ones in preference to the originals.
+         self._functions.update(fetched_auth_functions)

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -32,6 +32,7 @@ ckan_patches:
   - { file: "reorder_bulk_process" } # https://github.com/ckan/ckan/pull/5147
   - { file: "disable_leftover_with_capacity" }
   - { file: "remove_is_sysadmin_or_user_itself_check" } # https://github.com/ckan/ckan/pull/5405
+  - { file: "retain_allow_anonymous_access_in-chained_auth" }
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
@@ -50,6 +50,7 @@ def user_create(next_auth, context, data_dict=None):
     return next_auth(context, data_dict)
 
 @chained_auth_function
+@auth_allow_anonymous_access
 def user_update(next_auth, context, data_dict=None):
     users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_editors', [])
     if context.get('user_obj'):
@@ -68,6 +69,7 @@ def user_update(next_auth, context, data_dict=None):
     return next_auth(context, data_dict)
 
 @chained_auth_function
+@auth_allow_anonymous_access
 def user_show(next_auth, context, data_dict=None):
     users_allowed_to_create_users = config.get('ckanext.apicatalog_routes.allowed_user_editors', [])
 


### PR DESCRIPTION
User show and user update require auth_allow_anonymous_access and chained auth function do not retain them. There is a related ckan issue ckan/ckan#4597