### PR TITLE
LIKA-133: Added configurable member editor privileges

### DIFF
--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/auth.py
@@ -1,7 +1,7 @@
 import logging
 
 from ckan import authz
-from paste.deploy.converters import aslist
+from ckan.plugins.toolkit import aslist
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -96,7 +96,12 @@ class Apicatalog_RoutesPlugin(ckan.plugins.SingletonPlugin, ckan.lib.plugins.Def
                 'create_user_to_organization': auth.create_user_to_organization,
                 'user_create': auth.user_create,
                 'user_update': auth.user_update,
-                'user_show': auth.user_show
+                'user_show': auth.user_show,
+                'member_create': auth.member_create,
+                'member_delete': auth.member_delete,
+                'organization_member_create': auth.organization_member_create,
+                'organization_member_delete': auth.organization_member_delete,
+                'group_show': auth.group_show
                 }
 
     # IPermissionLabels


### PR DESCRIPTION
- Added CKAN configuration variable `ckanext.apicatalog_routes.allowed_user_editors` that contains a list of users allowed to view and edit organization members for all organizations