### PR TITLE
LIKA-174: Reorganize organization search inputs

### DIFF
--- a/ansible/roles/ckan-translations/files/ckan.pot
+++ b/ansible/roles/ckan-translations/files/ckan.pot
@@ -5313,3 +5313,6 @@ msgstr ""
 
 msgid "Company language"
 msgstr ""
+
+msgid "Show only service providers"
+msgstr ""

--- a/ansible/roles/ckan-translations/files/en_GB/LC_MESSAGES/en_GB.po
+++ b/ansible/roles/ckan-translations/files/en_GB/LC_MESSAGES/en_GB.po
@@ -5535,3 +5535,6 @@ msgstr ""
 
 msgid "Company language"
 msgstr ""
+
+msgid "Show only service providers"
+msgstr ""

--- a/ansible/roles/ckan-translations/files/fi/LC_MESSAGES/fi.po
+++ b/ansible/roles/ckan-translations/files/fi/LC_MESSAGES/fi.po
@@ -3,9 +3,9 @@
 # This file is distributed under the same license as the ckan project.
 # 
 # Translators:
-# Teemu Erkkola <teemu.erkkola@iki.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
+# Teemu Erkkola <teemu.erkkola@iki.fi>, 2020
 # apoikola <antti.poikola@gmail.com>, 2013,2015
 # floapps <jaakko.louhio@floapps.com>, 2012
 # Hami Kekkonen <hami.kekkonen@hel.fi>, 2013,2015
@@ -24,7 +24,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-06-23 20:40+0000\n"
 "PO-Revision-Date: 2020-01-17 07:06+0000\n"
-"Last-Translator: Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020\n"
+"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -5589,3 +5589,6 @@ msgstr ""
 
 msgid "Company language"
 msgstr ""
+
+msgid "Show only service providers"
+msgstr "Näytä vain palveluntarjoajat"

--- a/ansible/roles/ckan-translations/files/sv/LC_MESSAGES/sv.po
+++ b/ansible/roles/ckan-translations/files/sv/LC_MESSAGES/sv.po
@@ -5550,3 +5550,6 @@ msgstr ""
 
 msgid "Company language"
 msgstr ""
+
+msgid "Show only service providers"
+msgstr ""

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
@@ -36,17 +36,8 @@
   </section>
   <section class="module module-shallow">
     <div class="sorter-wrapper with-search">
-        {% snippet 'snippets/search_form_without_title.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Type in name of organization'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = sorting %}
         {% set sorting_selected = c.sort_by_selected or '' %}
-        {% if request.params.with_datasets %}
-            <a href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected) }}">
-                {{ _('Show organizations without APIs') }}
-            </a>
-        {% else %}
-            <a href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected, with_datasets=True) }}">
-                {{ _('Show only organizations with APIs') }}
-            </a>
-        {% endif %}
+        {% snippet 'organization/snippets/search_form.html', form_id='organization-search-form', type='organization', query=c.q, sorting_selected=sorting_selected, count=c.page.item_count, placeholder=_('Type in name of organization'), show_empty=request.params, no_bottom_border=true if c.page.items, sorting = sorting %}
     </div>
   </section>
 {% endblock %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/snippets/search_form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/snippets/search_form.html
@@ -1,0 +1,19 @@
+{% extends 'snippets/search_form_without_title.html' %}
+
+{% block search_input %}
+  {{ super() }}
+  <label for="apis-selection">{{ _('Show only service providers') }}</label>
+  <div>
+  {% if request.params.with_datasets %}
+      <a name="apis-selection" href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected) }}">
+          {{ _('Show organizations without APIs') }}
+      </a>
+      <input type="hidden" name="with_datasets" value="True"></input>
+  {% else %}
+      <a name="apis-selection" href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected, with_datasets=True) }}">
+          {{ _('Show only organizations with APIs') }}
+      </a>
+  {% endif %}
+  </div>
+{% endblock %}
+

--- a/ckanext/ckanext-apicatalog_ui/less/layout.less
+++ b/ckanext/ckanext-apicatalog_ui/less/layout.less
@@ -385,8 +385,8 @@
   }
 
   &.with-search {
-    div.form-select {
-      margin-top: 25px;
+    div {
+      margin-bottom: 25px;
     }
   }
 }


### PR DESCRIPTION
- Move "Show organizations without APIs" seach filter above sorting
- Fix a bug when changing sorting while filtering by existence of APIs