### PR TITLE
LIKA-157: multilingual organization email address lists

### DIFF
--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/commands/migrate.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/commands/migrate.py
@@ -78,7 +78,10 @@ def migrations():
     return [('1.49.0', '1.50.0', no_changes),
             ('1.50.0', '1.51.0', migrate_1_50_0_to_1_51_0),
             ('1.51.0', '1.52.0', no_changes),
-            ('1.52.0', '1.53.0', migrate_1_52_0_to_1_53_0)
+            ('1.52.0', '1.53.0', migrate_1_52_0_to_1_53_0),
+            ('1.53.0', '1.54.0', no_changes),
+            ('1.54.0', '1.54.1', no_changes),
+            ('1.54.1', '1.55.0', migrate_1_54_1_to_1_55_0),
             ]
 
 
@@ -118,6 +121,24 @@ def migrate_1_52_0_to_1_53_0(ctx, config, dryrun):
 
     apply_patches(package_patches=package_patches, resource_patches=resource_patches,
                   organization_patches=organization_patches, dryrun=dryrun)
+
+
+def migrate_1_54_1_to_1_55_0(ctx, config, dryrun):
+    def is_json_object(s):
+        if isinstance(s, dict):
+            return True
+        try:
+            return isinstance(json.loads(s), dict)
+        except ValueError:
+            return False
+
+    organization_patches = [{'id': org['id'],
+                             'email_address': {lang: [org['email_address']]
+                                               for lang in ['fi', 'sv', 'en']}}
+                            for org in org_generator()
+                            if 'email_address' in org
+                            and not is_json_object(org['email_address'])]
+    apply_patches(organization_patches=organization_patches, dryrun=dryrun)
 
 
 #

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/plugin.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/plugin.py
@@ -49,7 +49,9 @@ class Apicatalog_SchemingPlugin(plugins.SingletonPlugin):
             'create_fluent_tags': validators.create_fluent_tags,
             'convert_to_json_compatible_str_if_str': validators.convert_to_json_compatible_str_if_str,
             'mark_as_modified_in_catalog_if_changed': validators.mark_as_modified_in_catalog_if_changed,
-            'override_field_with_default_translation': validators.override_field_with_default_translation
+            'override_field_with_default_translation': validators.override_field_with_default_translation,
+            'fluent_list': validators.fluent_list,
+            'fluent_list_output': validators.fluent_list_output,
             }
 
     def get_helpers(self):

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/presets.json
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/presets.json
@@ -78,6 +78,16 @@
       }
     },
     {
+      "preset_name": "fluent_list",
+      "values": {
+        "form_snippet": "fluent_list.html",
+        "display_snippet": "fluent_list.html",
+        "error_snippet": "fluent_text.html",
+        "validators": "fluent_list",
+        "output_validators": "fluent_list_output"
+      }
+    },
+    {
       "preset_name": "fluent_core_markdown_translated",
       "values": {
         "form_snippet": "fluent_markdown.html",

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/organization.json
@@ -58,14 +58,9 @@
     {
       "field_name": "email_address",
       "label": "Email address",
-      "display_snippet": "email.html",
-      "validators": "ignore_missing",
-      "display_email_name_field": "email_address_description"
-    },
-    {
-      "field_name": "email_address_description",
-      "label": "Email address description",
-      "validators": "ignore_missing"
+      "preset": "fluent_list",
+      "validators": "fluent_list ignore_missing",
+      "display_snippet": "fluent_email_list.html"
     },
     {
       "field_name": "webpage_address",

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/display_snippets/fluent_email_list.html
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/display_snippets/fluent_email_list.html
@@ -1,0 +1,7 @@
+{% for value in h.scheming_language_text(data[field.field_name]) %}
+  {% set email_address = value[field.display_email_address_field] if field.display_email_address_field and value[field.display_email_address_field] else value %}
+  {% set email_name = value[field.display_email_name_field] if field.display_email_name_field and value[field.display_email_name_field] else value %}
+  {{ h.mail_to(email_address=email_address, name=email_name) }}
+  {%- if not loop.last %}, {% endif %}
+ {% endfor %}
+

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/display_snippets/fluent_list.html
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/display_snippets/fluent_list.html
@@ -1,0 +1,2 @@
+{{ ', '.join(h.scheming_language_text(data[field.field_name])) }}
+

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/form_snippets/fluent_list.html
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/form_snippets/fluent_list.html
@@ -1,0 +1,21 @@
+{% import 'macros/form.html' as form %}
+
+{%- for lang in h.fluent_form_languages(field, entity_type, object_type, schema) -%}
+  {% call form.input(
+    field.field_name + '-' + lang,
+    id='field-' + field.field_name + '-' + lang,
+    label=h.fluent_form_label(field, lang),
+    placeholder=h.scheming_language_text(field.form_placeholder, lang),
+    value=', '.join(data[field.field_name + '-' + lang]
+        or data.get(field.field_name, {}).get(lang, [])),
+    error=errors[field.field_name + '-' + lang],
+    classes=['control-medium'],
+    attrs=field.form_attrs if 'form_attrs' in field else {},
+    is_required=h.scheming_field_required(field)
+    ) %}
+    {%- snippet 'scheming/form_snippets/fluent_help_text.html',
+      field=field,
+      lang=lang -%}
+  {% endcall %}
+{%- endfor -%}
+

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
@@ -7,10 +7,8 @@ import ckan.plugins.toolkit as toolkit
 import ckan.logic.validators as validators
 import json
 import plugin
-from logging import getLogger
-from pprint import pformat
 
-log = getLogger(__name__)
+
 missing = toolkit.missing
 get_action = toolkit.get_action
 


### PR DESCRIPTION
- Implemented fluent_list scheming preset
- Modified organization data model: changed email_address into fluent_list with email customizations
- Created a migration from single emails to multilingual lists of emails
- Implemented update_xroad_organizations multilingual email list support