### PR TITLE
Refactor Vagrantfile and add certificate configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,20 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Pre-provisioner shell script installs Ansible into the guest and continues
-# to provision rest of the system in the guest. Works also on Windows.
-$script = <<SCRIPT
-if [ ! -f /vagrant_bootstrap_done.info ]; then
-  sudo apt-get update
-  sudo apt-get -y dist-upgrade
-  sudo apt-get -y install libffi-dev libssl-dev python-dev python-pip build-essential
-  sudo pip install setuptools -U
-  sudo pip install markupsafe ansible
-  sudo touch /vagrant_bootstrap_done.info
-fi
-cd /src/ansible && ansible-playbook -i inventories/vagrant deploy-all.yml
-SCRIPT
-
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -27,13 +13,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     case RUBY_PLATFORM
     when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
       # Fix Windows file rights, otherwise Ansible tries to execute files
-      server.vm.synced_folder "./", "/src", :mount_options => ["dmode=755","fmode=644"]
+      server.vm.synced_folder "./", "/vagrant", :mount_options => ["dmode=755","fmode=644"]
     else
       # Basic VM synced folder mount
-      server.vm.synced_folder "", "/src"
+      server.vm.synced_folder "", "/vagrant"
     end
 
-    server.vm.provision "shell", inline: $script
+    server.vm.provision "ansible_local" do |ansible|
+       ansible.playbook = "ansible/deploy-all.yml"
+       ansible.verbose = "v"
+       ansible.inventory_path = "ansible/inventories/vagrant"
+       ansible.config_file = "ansible/ansible.cfg"
+       ansible.limit = "all"
+    end
     server.vm.provider "virtualbox" do |vbox|
       vbox.gui = false
       vbox.memory = 2048

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
 allow_world_readable_tmpfiles = True
+stdout_callback=yaml
+show_custom_stats = true

--- a/ansible/roles/ckan-extension/tasks/main.yml
+++ b/ansible/roles/ckan-extension/tasks/main.yml
@@ -25,7 +25,7 @@
   when: deployment_environment_id == "vagrant"
 
 - name: Symlink extension sources from host machine (Vagrant)
-  file: src="/src/ckanext/{{ ckanext }}" path="{{ ckanext_sync_path }}/{{ ckanext }}" state=link
+  file: src="/vagrant/ckanext/{{ ckanext }}" path="{{ ckanext_sync_path }}/{{ ckanext }}" state=link
   when: deployment_environment_id == "vagrant"
 
 #

--- a/ansible/roles/ckan-ui/defaults/main.yml
+++ b/ansible/roles/ckan-ui/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
-apicatalog_ui_path: "/src/ckanext/ckanext-apicatalog_ui"
+apicatalog_ui_path: "/vagrant/ckanext/ckanext-apicatalog_ui"
 apicatalog_ui_ckanext_path: "{{ apicatalog_ui_path }}/ckanext/apicatalog_ui"

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -39,6 +39,45 @@
     - /etc/ckan/default
     - "{{ ckan_public_source_path }}"
 
+- name: Find public certificate status
+  stat: path={{ server_path }}/{{ xroad_securityserver_public_cert_filename }}
+  register: ss_public_cert
+
+- name: Register warning about public certificate
+  set_stats:
+    data:
+      warnings: '{{ warnings | default([]) + ["[WARNING] You need to add the public SSL certificate manually to {{ server_path }}/{{ xroad_securityserver_public_cert_filename }}"] }}'
+  when: ss_public_cert.stat.exists==False
+
+
+- name: Make sure public cert has proper file permissions
+  file:
+    dest: "{{ server_path }}/{{ xroad_securityserver_public_cert_filename }}"
+    owner: "{{ www_user }}"
+    group: "{{ www_user }}"
+    mode: "0600"
+  when: ss_public_cert.stat.exists
+
+- name: Find private certificate status
+  stat: path={{ server_path }}/{{ xroad_securityserver_private_cert_filename }}
+  register: ss_private_cert
+
+- name: Register warning about private certificate
+  set_stats:
+    data:
+      warnings: '{{ warnings | default([]) + ["[WARNING] You need to add the private SSL certificate manually to {{ server_path }}/{{ xroad_securityserver_private_cert_filename }}"]  }}'
+  when: ss_private_cert.stat.exists==False
+
+
+- name: Make sure private cert has proper file permissions
+  file:
+    dest: "{{ server_path }}/{{ xroad_securityserver_private_cert_filename }}"
+    owner: "{{ www_user }}"
+    group: "{{ www_user }}"
+    mode: "0600"
+  when: ss_private_cert.stat.exists
+
+
 - name: Copy CKAN configuration
   template: src={{ item.src }} dest={{ item.dest }} mode={{ item.mode }} owner={{ item.owner }} group={{ item.group }}
   with_items:

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -133,7 +133,9 @@ ckanext.apicatalog_routes.allowed_member_editors = {{ allowed_member_editors | d
 
 ckanext.xroad_integration.xroad_catalog_address = https://{{ xroad.securityserver.host }}:{{ xroad.securityserver.port }}/r1/{{ xroad.service_id | replace('.', '/') }}{% if xroad.service_name %}/{{ xroad.service_name }}{% endif %}
 
+ckanext.xroad_integration.xroad_catalog_certificate = {{ server_path }}/{{ xroad_securityserver_public_cert_filename }}
 ckanext.xroad_integration.xroad_client_id = {{ xroad.client_id | replace('.', '/') }}
+ckanext.xroad_integration.xroad_client_certificate = {{ server_path }}/{{ xroad_securityserver_private_cert_filename }}
 
 ofs.impl = pairtree
 

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -42,3 +42,6 @@ files_created_by_patches:
 search_engine_robots_filename: robots_disallowed.txt
 
 ckan_harvester_status_email_recipients: "{{ secret.ckan_harvester_status_email_recipients }}"
+
+xroad_securityserver_public_cert_filename: "{{ xroad.securityserver.alias }}.crt"
+xroad_securityserver_private_cert_filename: "{{ xroad.securityserver.alias }}.p12"


### PR DESCRIPTION
* Refactors Vagrantfile to use ansible_local instead of custom shell script
* Mounts host directories to default vagrant instead of src
* Adds X-Road rest service certificate check to ansible but does not fail play if they are missing, instead it notifies about them like so

![image](https://user-images.githubusercontent.com/830663/99662792-65f11680-2a6e-11eb-90cc-44f3b11dd0eb.png)
