### PR TITLE
Update rest path in qa and store number of other services to db

### DIFF
--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -67,6 +67,7 @@ xroad:
     port: 443
   client_id: FI-TEST.GOV.0245437-2.APICatalogClient
   service_id: FI-TEST.GOV.0920632-0.ServiceList
+  service_name: api-docs/api
 
 elk:
   logstash:


### PR DESCRIPTION
Uses openapi described apis instead of manually configured ones.