### PR TITLE
LIKA-223: Clear old broken links from db

### DIFF
--- a/ansible/roles/ckan/tasks/database.yml
+++ b/ansible/roles/ckan/tasks/database.yml
@@ -34,6 +34,9 @@
 - name: Initialize Link Validation database
   shell: ./bin/paster --plugin=ckanext-validate_links links initdb "--config={{ ckan_ini }}" chdir={{ virtualenv }}
 
+- name: Migrate Link Validation database
+  shell: ./bin/paster --plugin=ckanext-validate_links links migrate "--config={{ ckan_ini }}" chdir={{ virtualenv }}
+
 - name: Initialize service permission application database
   shell: ./bin/paster --plugin=ckanext-apply_permissions_for_service apply_permissions init "--config={{ ckan_ini }}" chdir={{ virtualenv }}
   when: "'apply_permissions_for_service' in ckan_plugins"

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/commands/validate_links.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/commands/validate_links.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from urllib2 import urlopen, URLError, HTTPError
+from urllib2 import urlopen, URLError, HTTPError, build_opener
 import urlparse as parse
 import re
 
@@ -72,9 +72,11 @@ class ValidateLinks(CkanCommand):
 
         external_urls = get_external_children(site_url, site_map)
         url_errors = {}
+        opener = build_opener()
+        opener.addheaders = [('User-Agent', 'Liityntakatalogi link validator')]
         for url in sorted(external_urls):
             try:
-                urlopen(url)
+                opener.open(url)
             except HTTPError as e:
                 referrers = find_referrers(url, site_map)
                 url_errors[url] = referrers

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/commands/validate_links.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/commands/validate_links.py
@@ -45,12 +45,17 @@ class ValidateLinks(CkanCommand):
             self.initdb()
         elif cmd == 'crawl':
             self.crawl()
+        elif cmd == 'clear':
+            self.clear()
 
     def initdb(self):
         from ckanext.validate_links.model import setup as db_setup
         db_setup()
 
     def crawl(self):
+        # Clear previous results
+        self.clear()
+
         site_url = config.get('ckan.site_url')
         crawl_url_blacklist_regex = re.compile(r'/activity/')
         crawl_content_type_whitelist_regex = re.compile(r'text/html')
@@ -97,6 +102,9 @@ class ValidateLinks(CkanCommand):
             admin = User.get('admin')
             mailer.mail_user(admin, 'URL errors', '\n\n'.join('%s\n%s' % (u, '\n'.join('  - %s' % r for r in rs)) for u, rs in url_errors.iteritems()))
 
+    def clear(self):
+        from ckanext.validate_links.model import clear_tables
+        clear_tables()
 
 def find_referrers(url, site_map):
     results = []

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -4,9 +4,10 @@ import logging
 import datetime
 
 from sqlalchemy import Table, Column, ForeignKey, types
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import relation
 
-from ckan.model.meta import metadata, mapper
+from ckan.model.meta import metadata, mapper, Session
 from ckan.model.types import make_uuid
 from ckan.model.domain_object import DomainObject
 
@@ -72,3 +73,14 @@ def define_tables():
                'result': relation(LinkValidationResult, backref='referrers'),
                }
            )
+
+
+def clear_tables():
+    Session.query(LinkValidationReferrer).delete()
+    Session.query(LinkValidationResult).delete()
+    try:
+        Session.commit()
+    except InvalidRequestError:
+        Session.rollback()
+        log.error("Clearing LinkValidation tables failed")
+    log.info("LinkValidation tables cleared")

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -90,5 +90,5 @@ def migrate():
     q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_result';"
     current_cols = list([m[0] for m in Session.execute(q)])
     if "reason" not in current_cols:
-        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason character varying NOT NULL")
+        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason character varying NOT NULL default 'Reason was not stored in database.'")
         Session.commit()

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -54,6 +54,7 @@ def define_tables():
         Column('type', types.UnicodeText, default=None),
         Column('timestamp', types.DateTime, default=datetime.datetime.utcnow),
         Column('url', types.UnicodeText, nullable=False),
+        Column('reason', types.UnicodeText, nullable=False),
     )
     link_validation_result_table = Table('link_validation_result', metadata,
                                          *link_validation_result_columns)
@@ -84,3 +85,10 @@ def clear_tables():
         Session.rollback()
         log.error("Clearing LinkValidation tables failed")
     log.info("LinkValidation tables cleared")
+
+def migrate():
+    q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_result';"
+    current_cols = list([m[0] for m in Session.execute(q)])
+    if "reason" not in current_cols:
+        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason character varying")
+        Session.commit()

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -90,5 +90,5 @@ def migrate():
     q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_result';"
     current_cols = list([m[0] for m in Session.execute(q)])
     if "reason" not in current_cols:
-        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason character varying")
+        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason character varying NOT NULL")
         Session.commit()

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/templates/admin/broken_links.html
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/templates/admin/broken_links.html
@@ -4,21 +4,23 @@
 <table class="table">
   <thead>
     <tr>
-      <th>{{ _('URL') }}</th>
+      <th>{{_('URL') }}</th>
       <th>{{ _('Referrers') }}</th>
+      <th>{{ _('Reason') }}</th>
     </tr>
   </thead>
   <tbody>
     {% for r in results %}
     <tr>
-      <td><a href="{{ r.url }}">{{ r.url }}</a></td>
+      <td><a href="{{ r.url }}">{{r.url }}</a></td>
       <td>
         <ul class="list-unstyled">
           {% for ref in r.referrers %}
-          <li><a href="{{ ref.url }}">{{ ref.url }}</a></li>
+          <li><a href="{{ ref.url }}">{{ref.url }}</a></li>
           {% endfor %}
         </ul>
       </td>
+      <td>{{ r.reason }}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
* Adds clear command to cli, which clears all broken links from db.
* Calls clear before crawl as old results might not be relevant anymore.
* Add user agent to requests.
* Adds Reason for failure to the database and view.
* Add migrate command to add reason column to database.