### PR TITLE
LIKA-287: remove conflicting tag styling

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/snippets/tags.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/snippets/tags.html
@@ -9,7 +9,7 @@
                         'action': 'search',
                         'vocab_' + field + '_' + lang: tag }) %}
                     <li>
-                        <a class="{% block tag_list_item_class %}tag{% endblock %}" href="{{ h.call_toolkit_function('url_for',[], tag_dict) }}">
+                        <a class="{% block tag_list_item_class %}{% endblock %}" href="{{ h.call_toolkit_function('url_for',[], tag_dict) }}">
                             {{ h.truncate(tag, 22) }}
                         </a>
                     </li>


### PR DESCRIPTION
- CKAN styles tags using `.tag` on tag content, but suomifi theme uses `.tag-list > li`. Removed `.tag` to only style the list items, not the contents.