### PR TITLE
LIKA-336: One item main nav extra menu

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
@@ -64,17 +64,25 @@
                     <use xlink:href="/base/images/external-link-icon.svg#path-1"></use>
                   </svg></a></li>
 
+                  {% set lang = h.lang().split('_')[0] %}
                   {% set submenu_content = h.get_submenu_content() %}
-                  {% if submenu_content | length > 0 %}
+                  {% if submenu_content | length > 1 %}
                   <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ _('More options') }}<span class="caret"></span></a>
                        <ul class="dropdown-menu">
                            {% for page in submenu_content %}
                                {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
-                            <li>{{ h.literal('<a href="/{}/{}">{}</a>'.format(type_, page.name, page.title)) }}</li>
+                               {% set page_title = page.get('title_' + lang) or page.title %}
+                               <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(type_, lang, page.name, page_title)) }}</li>
                            {% endfor %}
                        </ul>
                   </li>
+                  {% elif submenu_content | length == 1 %}
+                      {% set page = submenu_content[0] %}
+                      {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
+                      {% set page_title = page.get('title_' + lang) or page.title %}
+                      <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(type_, lang, page.name, page_title)) }}</li>
                   {% endif %}
+
                 {% if c.userobj %}
                   {% snippet 'home/snippets/apicatalog_profile_items.html', class="visible-xs" %}
                 {% else %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
@@ -72,7 +72,7 @@
                            {% for page in submenu_content %}
                                {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
                                {% set page_title = page.get('title_' + lang) or page.title %}
-                               <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(type_, lang, page.name, page_title)) }}</li>
+                               <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(lang, type_, page.name, page_title)) }}</li>
                            {% endfor %}
                        </ul>
                   </li>
@@ -80,7 +80,7 @@
                       {% set page = submenu_content[0] %}
                       {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
                       {% set page_title = page.get('title_' + lang) or page.title %}
-                      <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(type_, lang, page.name, page_title)) }}</li>
+                      <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(lang, type_, page.name, page_title)) }}</li>
                   {% endif %}
 
                 {% if c.userobj %}

--- a/ckanext/ckanext-apicatalog_ui/less/masthead.less
+++ b/ckanext/ckanext-apicatalog_ui/less/masthead.less
@@ -195,6 +195,8 @@
   }
 
   .main-navigation {
+    white-space: nowrap;
+
     a {
       color: @mastheadLinkColor;
       padding: 8px 0;


### PR DESCRIPTION
- If main nav "more" menu has only one item, show it without the menu
- Show correct language title for menu items
- Allow main nav overflow instead of wrapping