### PR TITLE
LIKA-200: Added command for processing user_for_organization applications

### DIFF
--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/commands.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/commands.py
@@ -19,6 +19,31 @@ from ckan.lib.cli import (
 
 import itertools
 
+apicatalog_admin_group = paster_click_group(
+    summary=u'Administration related commands.'
+)
+
+
+@apicatalog_admin_group.command(
+    u'create-organization-users',
+    help='Creates users based on records uploaded to create_user_to_organization endpoint'
+)
+@click_config_option
+@click.pass_context
+@click.option(u'--retry', is_flag=True)
+def create_organization_users(ctx, config, retry):
+    load_config(config or ctx.obj['config'])
+    result = t.get_action('create_organization_users')({'ignore_auth': True}, {'retry': retry}).get('result', {})
+    created = result.get('created', [])
+    invalid = result.get('invalid', [])
+    ambiguous = result.get('ambiguous', [])
+    duplicate = result.get('duplicate', [])
+    print('Created users: %s' % ', '.join(created))
+    print('Duplicate users: %s' % ', '.join(duplicate))
+    print('Unknown business ids: %s' % ', '.join(invalid))
+    print('Ambiguous business ids: %s' % ', '.join(ambiguous))
+
+
 apicatalog_harvest_group = paster_click_group(
     summary=u'Harvester related commands.'
 )

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -262,7 +262,14 @@ def create_organization_users(context, data_dict):
             continue
 
         log.info('Inviting user %s to organization %s (%s)', application.email, organization['title'], organization['id'])
-        user = user_invite(context, {'email': application.email, 'group_id': organization['id'], 'role': 'editor'})
+        try:
+            user = user_invite(context, {'email': application.email, 'group_id': organization['id'], 'role': 'editor'})
+        except ValidationError as e:
+            log.warn(e)
+            continue
+        except NotFound as e:
+            log.warn(e)
+            continue
 
         application.mark_done()
         created.append(user.get('name'))

--- a/ckanext/ckanext-apicatalog_routes/setup.py
+++ b/ckanext/ckanext-apicatalog_routes/setup.py
@@ -85,5 +85,6 @@ setup(
         [paste.paster_command]
         apicatalog-harvest = ckanext.apicatalog_routes.commands:apicatalog_harvest_group
         apicatalog_db = ckanext.apicatalog_routes.commands:apicatalog_database_group
+        apicatalog_admin = ckanext.apicatalog_routes.commands:apicatalog_admin_group
     ''',
 )


### PR DESCRIPTION
- Implemented `UserForOrganization`methods for querying pending and previously failed instances
- New admin-only action `create_organization_users` to match account applications into organizations and sending user invites
- Added a paster command for running the added action with a human-readable summary