### PR TITLE
LIKA-200: organization-user-add cronjob & role change

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -124,7 +124,7 @@
   cron: name="Fetch X-Road Services" special_time=daily job="{{ virtualenv }}/bin/paster --plugin=ckanext-xroad_integration xroad fetch_service_list -c {{ ckan_ini }}"
 
 - name: Ensure create organization users cronjob
-  cron: name="Create organization users" special_time=hourly job="{{ virtualenv }}/bin/paster --plugin=ckanext-apicatalog_routes apicatalog_admin create-organization-users --retry -c {{ ckan_ini }}"
+  cron: name="Create organization users" special_time=daily job="{{ virtualenv }}/bin/paster --plugin=ckanext-apicatalog_routes apicatalog_admin create-organization-users --retry -c {{ ckan_ini }}"
 
 
 - name: Send harvester status report emails as a cron job

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -123,6 +123,9 @@
 - name: Ensure fetch xroad services cronjob
   cron: name="Fetch X-Road Services" special_time=daily job="{{ virtualenv }}/bin/paster --plugin=ckanext-xroad_integration xroad fetch_service_list -c {{ ckan_ini }}"
 
+- name: Ensure create organization users cronjob
+  cron: name="Create organization users" special_time=hourly job="{{ virtualenv }}/bin/paster --plugin=ckanext-apicatalog_routes apicatalog_admin create-organization-users --retry -c {{ ckan_ini }}"
+
 
 - name: Send harvester status report emails as a cron job
   cron:

--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -263,7 +263,7 @@ def create_organization_users(context, data_dict):
 
         log.info('Inviting user %s to organization %s (%s)', application.email, organization['title'], organization['id'])
         try:
-            user = user_invite(context, {'email': application.email, 'group_id': organization['id'], 'role': 'editor'})
+            user = user_invite(context, {'email': application.email, 'group_id': organization['id'], 'role': 'admin'})
         except ValidationError as e:
             log.warn(e)
             continue


### PR DESCRIPTION
- Create organization users through api as organization admins
- Added a cronjob for processing users for organizations