### PR TITLE
LIKA-141: Move pages db initialization to cli

### DIFF
--- a/ansible/roles/ckan/tasks/database.yml
+++ b/ansible/roles/ckan/tasks/database.yml
@@ -46,3 +46,6 @@
 
 - name: Initialize xroad errors database
   shell: ./bin/paster --plugin=ckanext-xroad_integration xroad init_db "--config={{ ckan_ini }}" chdir={{ virtualenv }}
+
+- name: Initialize pages database
+  shell: ./bin/paster --plugin=ckanext-pages pages initdb "--config={{ ckan_ini }}" chdir={{ virtualenv }}


### PR DESCRIPTION
* Updates ckanext-pages
* Moves pages database initialization to cli (https://github.com/ckan/ckanext-pages/pull/112)
* Adds cli initdb to ansible.