### PR TITLE
Fix errors in logs

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/apicatalog_header.html
@@ -72,7 +72,7 @@
                            {% for page in submenu_content %}
                                {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
                                {% set page_title = page.get('title_' + lang) or page.title %}
-                               <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(lang, type_, page.name, page_title)) }}</li>
+                               <li>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
                            {% endfor %}
                        </ul>
                   </li>
@@ -80,7 +80,7 @@
                       {% set page = submenu_content[0] %}
                       {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
                       {% set page_title = page.get('title_' + lang) or page.title %}
-                      <li>{{ h.literal('<a href="/{}/{}/{}">{}</a>'.format(lang, type_, page.name, page_title)) }}</li>
+                      <li>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
                   {% endif %}
 
                 {% if c.userobj %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/base_form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/ckanext_pages/base_form.html
@@ -12,7 +12,7 @@
     {{ wysiwyg.editor('content_sv', id='field-content-sv', label=_('Content') + ' SV', placeholder=_('Enter content here'), value=data.content|safe, error=errors.content) }}
     {{ wysiwyg.editor('content_en', id='field-content-en', label=_('Content') + ' EN', placeholder=_('Enter content here'), value=data.content|safe, error=errors.content) }}
   {% elif editor == 'ckeditor' %}
-    {% resource 'ckanext-pages/main' %}
+    {% resource 'pages/main' %}
     <div class="control-group">
         <label for="field-content-ck" class="control-label">{{ _('Content') }} FI</label>
     </div>


### PR DESCRIPTION
* Pages resource path changed in python3 migration.
* Template rendering fails on UnicodeDecodeError when there is "{}".format(someunicodevariable)