### PR TITLE
LIKA-361: Fix provider_orgs parameter in pagination

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/organization/index.html
@@ -43,5 +43,9 @@
 {% endblock %}
 
 {% block page_pagination %}
-    {{ org_list.page.pager(q=q or '', sort=c.sort_by_selected or '', with_datasets=org_list.with_datasets or '', symbol_previous="<span aria-hidden='true'>«</span><span class='sr-only'>" + _('Previous') + "</span>", symbol_next="<span aria-hidden='true'>»</span><span class='sr-only'>" + _('Next') + "</span>" ) }}
+    {{ org_list.page.pager(q=q or '',
+    sort=c.sort_by_selected or '',
+    provider_orgs=org_list.provider_orgs or '',
+    symbol_previous="<span aria-hidden='true'>«</span><span class='sr-only'>" + _('Previous') + "</span>",
+    symbol_next="<span aria-hidden='true'>»</span><span class='sr-only'>" + _('Next') + "</span>" ) }}
 {% endblock %}


### PR DESCRIPTION
`with_datasets` parameter was changed in to `provider_orgs` in https://github.com/vrk-kpa/api-catalog/pull/74 