### PR TITLE
LIKA-356: Move try another search terms info to main content

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/search.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/search.html
@@ -6,10 +6,16 @@
 <p>{% trans %}If you wish to implement a service that is listed in the API Catalogue, read our <a href="https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5f182709341bb40241fa9713">instructions on implementing services</a> and contact the service provider.{% endtrans %}</p>
 <div class="result-count">{{ _('{0} datasets').format(c.page.item_count) }}</div>
 {% endblock %}
-
 {% block primary_content %}
+  {% set show_empty=request.params %}
+  {% set count=c.page.item_count %}
   <section id="main_content" class="module">
     <div class="module-content">
+      {% if show_empty and count == 0 and not error %}
+        {% trans %}
+          <p class="extra">Please try another search.</p>
+        {% endtrans %}
+      {% endif %}
       {% block form %}{% endblock %}
       {% block package_search_results_list %}
       <div class="fill-module">
@@ -60,7 +66,7 @@
             ]
           %}
 
-          {% snippet 'snippets/search_form_without_input.html', form_id='dataset-facet-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+          {% snippet 'snippets/search_form_without_input.html', form_id='dataset-facet-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, error=c.query_error, fields=c.fields %}
         </div>
     </div>
 {{ super()}}


### PR DESCRIPTION
LIKA-356: Hide info text about trying different search terms from sidebar and add it into main content area