### PR TITLE
LIKA-382: Fix organization list truncation

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/plugin.py
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/plugin.py
@@ -24,7 +24,7 @@ from ckanext.scheming.helpers import lang
 import ckan.lib.helpers as h
 from ckan.lib.plugins import DefaultTranslation
 
-from .utils import package_generator
+from .utils import package_generator, organization_generator
 import ckanext.apicatalog_ui.admindashboard as admindashboard
 
 standard_library.install_aliases()
@@ -308,13 +308,16 @@ def custom_organization_list(params):
         context['user_id'] = toolkit.c.userobj.id
         context['user_is_admin'] = toolkit.c.userobj.sysadmin
 
-    data_dict_page_results = {
+    organization_list_options = {
+        'q': q,
         'all_fields': True,
         'include_extras': True,
-        'q': q,
-        'sort': sort_by,
+        'sort': sort_by
     }
-    results = toolkit.get_action('organization_list')(context, data_dict_page_results)
+
+    # FIXME: Fetching every organization with all fields to filter for paging, could this be improved?
+
+    results = list(organization_generator(context, organization_list_options))
 
     provider_orgs = params.get('provider_orgs', '').lower() in ('true', '1', 'yes')
     if provider_orgs:
@@ -350,7 +353,7 @@ def get_statistics():
                'with_private': True}
 
     packages = toolkit.get_action('package_search')(context, {})
-    organizations = toolkit.get_action('organization_list')(context, {"all_fields": True, "include_extras": True})
+    organizations = list(organization_generator(context, {"all_fields": True, "include_extras": True}))
     provider_organizations = [o for o in organizations if o.get('xroad_member_type', '') == 'provider']
 
     result_dict = {

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/utils.py
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/utils.py
@@ -18,3 +18,29 @@ def package_generator(context, query='*:*', page_size=1000, dataset_type='datase
         # Stop iteration all query results have been looped through
         if data["count"] < (index + page_size):
             return
+
+
+def organization_generator(context, options={}, page_size=None):
+    if page_size is None:
+        # Default value for ckan.group_and_organization_list_max is 25
+        page_size = toolkit.config.get('ckan.group_and_organization_list_max', 25)
+
+    organization_list = toolkit.get_action('organization_list')
+
+    # Loop through all items. Each page has {page_size} items.
+    # Stop iteration when all items have been looped.
+    for index in itertools.count(start=0, step=page_size):
+        data_dict = options.copy()
+        data_dict.update({'limit': page_size, 'offset': index})
+        organizations = organization_list(context, data_dict)
+
+        # Empty page, previous must have been the last one
+        if not organizations:
+            return
+
+        for organization in organizations:
+            yield organization
+
+        # Incomplete page, must be the last one
+        if len(organizations) < page_size:
+            return


### PR DESCRIPTION
- Added `organization_generator` that works like `package_generator` to fetch organizations in multiple batches while defaulting to page size set by `ckan.group_and_organization_list_max`
- Use `organization_generator` in organization listings and statistics