### PR TITLE
LIKA-331: Only editors and admins can apply service access

### DIFF
--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/package/read.html
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/templates/scheming/package/read.html
@@ -15,7 +15,9 @@
 {% endblock %}
 
 {% block content_action %}
-  {% if h.organizations_available() and h.is_extension_loaded('apply_permissions_for_service') and not h.check_access('package_update', {'id':pkg.id }) %}
+  {% if h.check_access('service_permission_application_create', {})
+     and h.is_extension_loaded('apply_permissions_for_service')
+     and not h.check_access('package_update', {'id':pkg.id }) %}
     {% snippet 'apply_permissions_for_service/snippets/request_access_button.html', subsystem_id=pkg.name %}
   {% endif %}
   {{ super() }}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/macros/form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/macros/form.html
@@ -13,7 +13,6 @@
 {% endmacro %}
 
 {% macro input_multiple(name, id='', label='', value='', placeholder='', type='text', error="", classes=[], attrs={}, is_required=false, description="", add_input='') %}
-  {% resource 'apicatalog_ui/javascript/multiple_input.js' %}
   {% do classes.append('control-medium') %}
   {%- set extra_html = caller() if caller -%}
   {% call input_block(id or name, label or name, error, classes, control_classes=["editor"], extra_html=extra_html, is_required=is_required, description=description) %}

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/snippets/multiselect.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/snippets/multiselect.html
@@ -27,8 +27,6 @@
     {% set class = 'placeholder' %}
 {% endif %}
 
-{% resource 'apicatalog_ui/javascript/multiselect.js' %}
-
 <div
     class="multiselect multiselect-{{name}} mb-3"
     data-module="multiselect"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -14,4 +14,5 @@ def service_permission_settings(context, data_dict):
 
 
 def service_permission_application_create(context, data_dict):
-    return {'success': True}
+    editor_or_admin_orgs = toolkit.get_action('organization_list_for_user')(context, {'permission': 'create_dataset'})
+    return {'success': len(editor_or_admin_orgs) > 0}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -10,7 +10,7 @@
     {% else %}
       <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
     {% endif %}
-    <li>{% link_for h.dataset_display_name(pkg)|truncate(30), controller='package', action='read', id=pkg.name %}</li>
+    <li>{% link_for h.dataset_display_name(pkg)|truncate(30), controller='dataset', action='read', id=pkg.name %}</li>
     {% if service %}
     <li>{% link_for h.resource_display_name(service)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=service.id %}</li>
     {% endif %}


### PR DESCRIPTION
- Fix the "request access" button visibility to depend on authorization to create service permission applications
- Modify `service_permission_application_create` auth function to only allow users that could create datasets to some organization (editors and admins)