### PR TITLE
LIKA-369: Limit viewing permission applications to org members

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -16,9 +16,6 @@ def service_permission_application_show(context, data_dict):
     if organization_id in [org.get('id') for org in membership_organizations]:
         return {'success': True}
 
-    import logging
-    log = logging.getLogger(__name__)
-    log.info("Failed")
     return {'success': False,
             "msg": toolkit._("User not authorized to view permission application.")}
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -1,4 +1,5 @@
 from ckan.plugins import toolkit
+from ckanext.apply_permissions_for_service import model
 
 
 def service_permission_application_list(context, data_dict):
@@ -6,7 +7,20 @@ def service_permission_application_list(context, data_dict):
 
 
 def service_permission_application_show(context, data_dict):
-    return {'success': True}
+
+    permission_application_id = toolkit.get_or_bust(data_dict, 'id')
+    application = model.ApplyPermission.get(permission_application_id).as_dict()
+    organization_id = application.get('organization')
+    membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
+
+    if organization_id in [org.get('id') for org in membership_organizations]:
+        return {'success': True}
+
+    import logging
+    log = logging.getLogger(__name__)
+    log.info("Failed")
+    return {'success': False,
+            "msg": toolkit._("User not authorized to view permission application.")}
 
 
 def service_permission_settings(context, data_dict):

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -20,15 +20,15 @@
           <div class="select-wrapper">
             {{ form.select('deliveryMethod', label=_('Delivery method for access requests'), options=[
             {'value': 'none', 'text': _('Disable access requests for this API')},
-            {'value': 'api', 'text': _('Ticketing service API call')},
+            {'value': 'email', 'text': _('E-mail')},
             {'value': 'file', 'text': _('Upload your access request file')},
             {'value': 'web', 'text': _('Access is requested on a web page managed by my organization')},
             ], is_required=True, selected=(settings.delivery_method or 'none')) }}
           </div>
           <div data-mutex-field="deliveryMethod">
-            <div data-mutex-value="api">
-              {{ form.input('api', label=_('Endpoint URL'), value=settings.api) }}
-            </div>
+             <div data-mutex-value="email">
+                  {{ form.input('email', label=_('Email address'), value=settings.email) }}
+             </div>
             <div data-mutex-value="file">
               {% set is_upload = settings.file_url and not settings.file_url.startswith('http') %}
               {% set is_url = settings.file_url and settings.file_url.startswith('http') %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li>{% link_for h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title'), named_route='apply_permissions.view_permission_application', id=application.id%}</li>
+  <li>{% link_for h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title'), named_route='apply_permissions.view_permission_application', application_id=application.id%}</li>
 {% endblock %}
 
 {% block prelude %}


### PR DESCRIPTION
Limits permission for viewing permission applications.
Replaces sending requests with api to email.
Fixes breadcrumb build failure.