### PR TITLE
LIKA-389: Fix asset name clash with ckanext-xroad_integration

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/fanstatic/webassets.yml
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/fanstatic/webassets.yml
@@ -46,7 +46,7 @@ chartjs_css:
   contents:
     - xroad_stats/css/Chart.css
 
-xroad_stats_js:
+xroad_statistics_js:
   filters: rjsmin
   output: ckanext-apicatalog_ui/%(version)s_xroad-statistics.js
   extra:
@@ -56,7 +56,7 @@ xroad_stats_js:
   contents:
     - xroad_stats/js/xroad_statistics.js
 
-xroad_stats_css:
+xroad_statistics_css:
   output: ckanext-apicatalog_ui/%(version)s_xroad-statistics.css
   extra:
     preload:

--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/admin/xroad_statistics.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/admin/xroad_statistics.html
@@ -2,8 +2,8 @@
 
 {% block primary_content %}
 
-{% asset "apicatalog_ui/xroad_stats_js" %}
-{% asset "apicatalog_ui/xroad_stats_css" %}
+{% asset "apicatalog_ui/xroad_statistics_js" %}
+{% asset "apicatalog_ui/xroad_statistics_css" %}
 
 {% set xroad_stats = h.fetch_xroad_statistics() %}
 <div class="container" style="max-width: 100%;">


### PR DESCRIPTION
- Rename xroad_stats_* bundles to xroad_statistics_* to avoid bundle name clash with ckanext-xroad_integration