### PR TITLE
LIKA-400: Add ignore auth to getting activities

### DIFF
--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/helpers.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/helpers.py
@@ -26,7 +26,7 @@ def get_announcements(count=3, offset=0):
                 data['organization'] = organization_show({}, {'id': organization_id})
 
             elif activity_type in ('new package', 'changed package', 'deleted package'):
-                package_data = activity_show({}, {'id': activity.get('id'), 'include_data': True})\
+                package_data = activity_show({'ignore_auth': True}, {'id': activity.get('id'), 'include_data': True})\
                     .get('data', {}).get('package', {})
                 if package_data.get('private', False):
                     return None


### PR DESCRIPTION
Showing activity details are restricted when public details are false.

https://github.com/ckan/ckan/blob/da5dbd26da3f6d60d5ba4189b1f28619e6c2b835/ckan/logic/auth/get.py#L274-L278