### PR TITLE
LIKA-416: Fix 404 error when allowed organizations list is empty

### DIFF
--- a/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
+++ b/ckanext/ckanext-apicatalog_routes/ckanext/apicatalog_routes/plugin.py
@@ -107,7 +107,8 @@ class Apicatalog_RoutesPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
 
         if pkg_dict.get('access_restriction_level') and \
                 pkg_dict.get('access_restriction_level') == 'only_allowed_organizations':
-            allowed_organizations = [o.strip() for o in pkg_dict.get('allowed_organizations', "").split(',')]
+            allowed_organizations = [o.strip() for o in pkg_dict.get('allowed_organizations', "").split(',')
+                                     if pkg_dict.get('allowed_organizations', "")]
             for org_name in allowed_organizations:
                 organization_dict = get_action('organization_show')(context, {'id': org_name})
                 labels.append(u'allowed_organization_members-%s' % organization_dict['id'])


### PR DESCRIPTION
Admin lost access to subsystem as the labeling function caused an error on list with an empty string on it.