### PR TITLE
LIKA-422: Use prod environment for news in all environments

### DIFF
--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -85,7 +85,7 @@ elk:
 
 content:
   news:
-    endpoint_url: "https://palveluhallinta.suomi.fi/api/articles/importantTopical"
+    endpoint_url: "https://palveluhallinta.suomi.fi/api/articles/importantTopical?newsTypes"
     url_template: "https://palveluhallinta.suomi.fi/{language}/ajankohtaista/uutiset/{id}"
     ssl_verify: true
 

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -80,9 +80,9 @@ elk:
 
 content:
   news:
-    endpoint_url: "https://palveluhallinta.test.suomi.fi/api/articles/importantTopical"
-    url_template: "https://palveluhallinta.test.suomi.fi/{language}/ajankohtaista/uutiset/{id}"
-    ssl_verify: false
+    endpoint_url: "https://palveluhallinta.suomi.fi/api/articles/importantTopical?newsTypes"
+    url_template: "https://palveluhallinta.suomi.fi/{language}/ajankohtaista/uutiset/{id}"
+    ssl_verify: true
 
 debug_enabled: false
 

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -94,9 +94,9 @@ elk:
 
 content:
   news:
-    endpoint_url: "https://palveluhallinta.test.suomi.fi/api/articles/importantTopical"
-    url_template: "https://palveluhallinta.test.suomi.fi/{language}/ajankohtaista/uutiset/{id}"
-    ssl_verify: false
+    endpoint_url: "https://palveluhallinta.suomi.fi/api/articles/importantTopical?newsTypes"
+    url_template: "https://palveluhallinta.suomi.fi/{language}/ajankohtaista/uutiset/{id}"
+    ssl_verify: true
 
 debug_enabled: true
 


### PR DESCRIPTION
Test environment for news has been down for awhile https://palveluhallinta.test.suomi.fi/api/articles/importantTopical, this PR replaces news source to production environment in all environments.