### PR TITLE
LIKA-369: Limit viewing permission applications to receiving and applying org members

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -55,8 +55,6 @@ def service_permission_application_create(context, data_dict):
     usage_description = data_dict.get('usage_description')
     request_date = data_dict.get('request_date') or None
 
-
-
     # Need sysadmin privileges to see permission_application_settings
     sysadmin_context = {'ignore_auth': True, 'use_cache': False}
     package = tk.get_action('package_show')(sysadmin_context, {'id': subsystem_id})

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -21,9 +21,12 @@ def service_permission_application_create(context, data_dict):
 
     errors = {}
 
-    organization = data_dict.get('organization')
-    if organization is None or organization == "":
+    organization_id = data_dict.get('organization_id')
+    if organization_id is None or organization_id == "":
         errors['organization_id'] = _('Missing value')
+    target_organization_id = data_dict.get('target_organization_id')
+    if target_organization_id is None or target_organization_id == "":
+        errors['target_organization_id'] = _('Missing value')
     business_code = data_dict.get('business_code')
     if business_code is None or business_code == "":
         errors['business_code'] = _('Missing value')
@@ -52,12 +55,15 @@ def service_permission_application_create(context, data_dict):
     usage_description = data_dict.get('usage_description')
     request_date = data_dict.get('request_date') or None
 
+
+
     # Need sysadmin privileges to see permission_application_settings
     sysadmin_context = {'ignore_auth': True, 'use_cache': False}
     package = tk.get_action('package_show')(sysadmin_context, {'id': subsystem_id})
     owner_org = tk.get_action('organization_show')(context, {'id': package['owner_org']})
 
-    application_id = model.ApplyPermission.create(organization=organization,
+    application_id = model.ApplyPermission.create(organization_id=organization_id,
+                                                  target_organization_id=target_organization_id,
                                                   business_code=business_code,
                                                   contact_name=contact_name,
                                                   contact_email=contact_email,
@@ -93,7 +99,7 @@ def service_permission_application_create(context, data_dict):
             log.info('Sending permission application notification email to {}'.format(email_address))
             application = model.ApplyPermission.get(application_id).as_dict()
             email_subject = u'{} pyytää lupaa käyttää Suomi.fi-palveluväylässä tarjoamaasi palvelua'.format(
-                application['organization'])
+                application['organization']['title'])
             email_content = tk.render('apply_permissions_for_service/notification_email.html',
                                       extra_vars={'application': application})
             try:

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -10,12 +10,10 @@ def service_permission_application_show(context, data_dict):
 
     permission_application_id = toolkit.get_or_bust(data_dict, 'id')
     application = model.ApplyPermission.get(permission_application_id).as_dict()
-    organization = application.get('organization')
-    target_organization = application.get('target_organization')
     membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
 
     if any(True for x in [org.get('id') for org in membership_organizations]
-           if x in (organization['id'], target_organization['id'])):
+           if x in (application['organization']['id'], application['target_organization']['id'])):
         return {'success': True}
 
     return {'success': False,

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -16,9 +16,6 @@ def service_permission_application_show(context, data_dict):
     if organization_id in [org.get('id') for org in membership_organizations]:
         return {'success': True}
 
-    import logging
-    log = logging.getLogger(__name__)
-    log.info("Failed")
     return {'success': False,
             "msg": toolkit._("User not authorized to view permission application.")}
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -12,7 +12,7 @@ def service_permission_application_show(context, data_dict):
     application = model.ApplyPermission.get(permission_application_id).as_dict()
     membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
 
-    if any(True for x in [org.get('id') for org in membership_organizations]
+    if any(True for x in (org.get('id') for org in membership_organizations)
            if x in (application['organization']['id'], application['target_organization']['id'])):
         return {'success': True}
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -10,17 +10,12 @@ def service_permission_application_show(context, data_dict):
 
     permission_application_id = toolkit.get_or_bust(data_dict, 'id')
     application = model.ApplyPermission.get(permission_application_id).as_dict()
-    organization_id = application.get('organization')
+    organization = application.get('organization')
     target_organization = application.get('target_organization')
     membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
-    print(organization_id)
-    print(target_organization)
 
-    if any(True for x in [org.get('id') for org in membership_organizations] if x in (organization_id, target_organization)):
-        print("good job")
+    if any(True for x in [org.get('id') for org in membership_organizations] if x in (organization['id'], target_organization['id'])):
         return {'success': True}
-    #if organization_id in [org.get('id') for org in membership_organizations]:
-    #    return {'success': True}
 
     return {'success': False,
             "msg": toolkit._("User not authorized to view permission application.")}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -14,7 +14,8 @@ def service_permission_application_show(context, data_dict):
     target_organization = application.get('target_organization')
     membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
 
-    if any(True for x in [org.get('id') for org in membership_organizations] if x in (organization['id'], target_organization['id'])):
+    if any(True for x in [org.get('id') for org in membership_organizations]
+           if x in (organization['id'], target_organization['id'])):
         return {'success': True}
 
     return {'success': False,

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -11,10 +11,16 @@ def service_permission_application_show(context, data_dict):
     permission_application_id = toolkit.get_or_bust(data_dict, 'id')
     application = model.ApplyPermission.get(permission_application_id).as_dict()
     organization_id = application.get('organization')
+    target_organization = application.get('target_organization')
     membership_organizations = toolkit.get_action('organization_list_for_user')(context, {'permission': 'read'})
+    print(organization_id)
+    print(target_organization)
 
-    if organization_id in [org.get('id') for org in membership_organizations]:
+    if any(True for x in [org.get('id') for org in membership_organizations] if x in (organization_id, target_organization)):
+        print("good job")
         return {'success': True}
+    #if organization_id in [org.get('id') for org in membership_organizations]:
+    #    return {'success': True}
 
     return {'success': False,
             "msg": toolkit._("User not authorized to view permission application.")}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -36,8 +36,8 @@ class ApplyPermission(Base):
     request_date = Column(types.Date)
 
     @classmethod
-    def create(cls, organization_id, target_organization_id, business_code, contact_name, contact_email, ip_address_list, subsystem_code,
-               subsystem_id, service_code_list, usage_description, request_date):
+    def create(cls, organization_id, target_organization_id, business_code, contact_name, contact_email,
+               ip_address_list, subsystem_code, subsystem_id, service_code_list, usage_description, request_date):
 
         apply_permission = ApplyPermission(organization_id=organization_id,
                                            target_organization_id=target_organization_id,
@@ -77,7 +77,6 @@ class ApplyPermission(Base):
 
         application_dict['target_organization'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['target_organization_id']})
-
 
         return application_dict
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -22,7 +22,8 @@ class ApplyPermission(Base):
     __tablename__ = 'apply_permission'
 
     id = Column(types.UnicodeText, primary_key=True, default=make_uuid)
-    organization = Column(types.UnicodeText, nullable=False)
+    organization_id = Column(types.UnicodeText, nullable=False)
+    target_organization_id = Column(types.UnicodeText, nullable=False)
     business_code = Column(types.UnicodeText, nullable=False)
     contact_name = Column(types.UnicodeText, nullable=False)
     contact_email = Column(types.UnicodeText, nullable=False)
@@ -35,10 +36,12 @@ class ApplyPermission(Base):
     request_date = Column(types.Date)
 
     @classmethod
-    def create(cls, organization, business_code, contact_name, contact_email, ip_address_list, subsystem_code,
+    def create(cls, organization_id, target_organization_id, business_code, contact_name, contact_email, ip_address_list, subsystem_code,
                subsystem_id, service_code_list, usage_description, request_date):
 
-        apply_permission = ApplyPermission(organization=organization, business_code=business_code,
+        apply_permission = ApplyPermission(organization_id=organization_id,
+                                           target_organization_id=target_organization_id,
+                                           business_code=business_code,
                                            contact_name=contact_name,
                                            contact_email=contact_email,
                                            ip_address_list=ip_address_list,
@@ -68,6 +71,13 @@ class ApplyPermission(Base):
             {'ignore_auth': True}, {'id': application_dict['subsystem']['owner_org']})
         application_dict['services'] = [toolkit.get_action('resource_show')(
             {'ignore_auth': True}, {'id': service}) for service in application_dict['service_code_list']]
+
+        application_dict['organization'] = toolkit.get_action('organization_show')(
+            {'ignore_auth': True}, {'id': application_dict['organization_id']})
+
+        application_dict['target_organization'] = toolkit.get_action('organization_show')(
+            {'ignore_auth': True}, {'id': application_dict['target_organization_id']})
+
 
         return application_dict
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -72,6 +72,8 @@
     </tbody>
   </table>
 
+  {{ form.hidden('target_organization_id', org.id) }}
+
   {% set service_options = [] %}
   {% set service_selected = values.service_code_list or ([service_id] if service_id else []) %}
   {% for res in pkg.resources %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -8,7 +8,7 @@
   {% set subsystem_title =  h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') %}
   <p>Hei,</p>
 
-  <p>{{ application.organization }} pyytää lupaa käyttää Suomi.fi-palveluväylässä tarjoamaasi palvelua {{ subsystem_title }}.</p>
+  <p>{{ application.organization['title'] }} pyytää lupaa käyttää Suomi.fi-palveluväylässä tarjoamaasi palvelua {{ subsystem_title }}.</p>
 
   <p><strong>Lupaa pyydetään palveluusi:</strong>
     <ul>
@@ -22,7 +22,7 @@
 
   <p><strong>Luvan pyytäjän tiedot:</strong>
     <ul>
-      <li>Organisaatio: {{ application.organization }}</li>
+      <li>Organisaatio: {{ application.organization['title'] }}</li>
       <li>Yritystunnus: {{ application.business_code }}</li>
       <li>Yhteyshenkilö: {{ application.contact_name }} </li>
       <li>Yhteyshenkilön sähköposti: {{ application.contact_email }}</li>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -15,7 +15,7 @@
   <h3>{{ _('Applicant information') }}</h3>
   <table class="table">
     <tbody>
-      <tr><th>{{ _('Organization') }}</th><td>{{ application.organization }}</td></tr>
+      <tr><th>{{ _('Organization') }}</th><td>{{ h.get_translated(application.member, 'title') }}</td></tr>
       <tr><th>{{ _('Business code') }}</th><td>{{ application.business_code }}</td></tr>
       <tr><th>{{ _('Contact name') }}</th><td>{{ application.contact_name }}</td></tr>
       <tr><th>{{ _('Contact email') }}</th><td>{{ application.contact_email }}</td></tr>
@@ -37,7 +37,7 @@
   <h3>{{ _('Details of the service and API you are applying to access') }}</h3>
   <table class="table">
     <tbody>
-      <tr><th>{{ _('Organization name') }}</th><td>{{ h.get_translated(application.member, 'title') }}</td></tr>
+      <tr><th>{{ _('Organization name') }}</th><td>{{ h.get_translated(application.target_organization, 'title') }}</td></tr>
       <tr><th>{{ _('Subsystem') }}</th><td>{{ h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') }}</td></tr>
       <tr>
         <th>{{ _('Service code') }}</th>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -15,7 +15,7 @@
   <h3>{{ _('Applicant information') }}</h3>
   <table class="table">
     <tbody>
-      <tr><th>{{ _('Organization') }}</th><td>{{ h.get_translated(application.member, 'title') }}</td></tr>
+      <tr><th>{{ _('Organization') }}</th><td>{{ h.get_translated(application.organization, 'title') }}</td></tr>
       <tr><th>{{ _('Business code') }}</th><td>{{ application.business_code }}</td></tr>
       <tr><th>{{ _('Contact name') }}</th><td>{{ application.contact_name }}</td></tr>
       <tr><th>{{ _('Contact email') }}</th><td>{{ application.contact_email }}</td></tr>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -42,10 +42,10 @@ def new_post(context, subsystem_id):
             }
 
     try:
-        organization = toolkit.get_action('organization_show')(context, {'id': form.get('organization')})
+        organization = toolkit.get_action('organization_show')(context, {'id': form['organization']})
         data_dict['organization_id'] = organization['id']
         toolkit.get_action('service_permission_application_create')(context, data_dict)
-    except toolkit.ValidationError as e:
+    except (toolkit.ValidationError, KeyError) as e:
         return new_get(context, subsystem_id, e.error_dict, values=data_dict)
 
     return toolkit.render('apply_permissions_for_service/sent.html')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -29,7 +29,7 @@ def index():
 def new_post(context, subsystem_id):
     form = toolkit.request.form
     data_dict = {
-            'organization': form.get('organization'),
+            'target_organization_id': form.get('target_organization_id'),
             'business_code': form.get('businessCode'),
             'contact_name': form.get('contactName'),
             'contact_email': form.get('contactEmail'),
@@ -42,6 +42,8 @@ def new_post(context, subsystem_id):
             }
 
     try:
+        organization = toolkit.get_action('organization_show')(context, {'id': form.get('organization')})
+        data_dict['organization_id'] = organization['id']
         toolkit.get_action('service_permission_application_create')(context, data_dict)
     except toolkit.ValidationError as e:
         return new_get(context, subsystem_id, e.error_dict, values=data_dict)


### PR DESCRIPTION
* Modifies the database schema to store both applicant organization and target organization to handle permissions for each.
* Adds lookup for applicant and target organization to auth check.
* Adds the whole organizations to model dictize to handle what is shown on the UI.