### PR TITLE
LIKA-369: Use name instead of title in permission application organizations

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -34,7 +34,7 @@
   <p>* Required field</p>
   {% set user_org = user_managed_organizations[0] if user_managed_organizations else {} %}
   {# TODO: Should probably be organization select component ? #}
-  {{ form.input('organization', label=_('Organization'), is_required=True, value=values.organization or user_org.title or '') }}
+  {{ form.input('organization', label=_('Organization'), is_required=True, value=values.organization or user_org.name or '') }}
   {{ form.input('businessCode', label=_('Business code'), is_required=True, value=values.business_code or user_org.xroad_member_code or '') }}
 
   {{ form.input('contactName', label=_('Contact name'), is_required=True, value=values.contact_name or user.fullname) }}


### PR DESCRIPTION
Searching for organization fails when search with title, it only accepts id or name.

Selecting the requesting organization needs to be solved though.