### PR TITLE
LIKA-455: Add template to robots.txt and block some bots

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -167,9 +167,13 @@
     hour: "0"
     job: "find /tmp/default/sessions -type f -mtime +3 -print -exec rm {} ';'"
 
-- name: Disallow robots
-  template: src={{ search_engine_robots_filename }} dest={{ virtualenv }}/src/ckan/ckan/public/robots.txt owner=root group=root mode=0644
-  when: not robots_allowed
+- name: Modify allowed robots
+  template:
+    src: robots.txt.j2
+    dest: "{{ virtualenv }}/src/ckan/ckan/public/robots.txt"
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Update supervisor configuration
   shell: supervisorctl update

--- a/ansible/roles/ckan/templates/robots.txt.j2
+++ b/ansible/roles/ckan/templates/robots.txt.j2
@@ -1,0 +1,15 @@
+User-agent: *
+{% if not robots_allowed %}
+Disallow: /
+{% else %}
+Disallow: /dataset/rate/
+Disallow: /revision/
+Disallow: /dataset/*/history
+Disallow: /api/
+Crawl-Delay: 10
+{% endif %}
+
+{% for bot in blocked_bots %}
+User-agent: {{ bot }}
+Disallow: /
+{% endfor %}

--- a/ansible/roles/ckan/templates/robots_disallowed.txt
+++ b/ansible/roles/ckan/templates/robots_disallowed.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -42,7 +42,6 @@ files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckanext/textview/theme/public/vendor/highlight.js'}
   - { file: '/usr/lib/ckan/default/src/ckan/changes/6340.bugfix' }
 
-search_engine_robots_filename: robots_disallowed.txt
 
 ckan_harvester_status_email_recipients: "{{ secret.ckan_harvester_status_email_recipients }}"
 ckan_fault_recipients: "{{ secret.ckan_fault_recipients }}"
@@ -54,3 +53,8 @@ xroad_securityserver_private_cert_filename: "{{ xroad.securityserver.alias }}.p1
 
 ckan_wsgi_script: /etc/ckan/default/wsgi.py
 ckan_uwsgi_conf: /etc/ckan/default/ckan-uwsgi.ini 
+
+blocked_bots:
+  - PetalBot
+  - AhrefsBot
+  - SemrushBot


### PR DESCRIPTION
# Description
Adds a template for modifying robots.txt and block some bots that appear to crawl production.

## Jira ticket reference: [LIKA-455](https://jira.dvv.fi/browse/LIKA-455)

## What has changed:
Following bots are bloked:
* Petalbot
* Ahrefsbot
* Semrushbot

## Checklist  

[ ] Contains schema changes.
[ ] Schema changes require migration of existing data.
[ ] Contains migration script for existing data.
[ ] Changes should be covered by tests.
[ ] Changes are covered by tests.

### Does this have a design impact ?
[ ] Yes 
[x] No

