### PR TITLE
LIKA-440: Prevent adding non-existent organizations to allowed organizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: Code Quality
 
-on:
-  push:
-    paths:
-      - "**.py"
+on: [push, pull_request, workflow_dispatch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           python-version: '3.6'
       - name: Install requirements
-          run: pip install flake8 pycodestyle
+        run: pip install flake8 pycodestyle
       - name: Check syntax
-          run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
       - name: Run flake8
         run: flake8 . --count --max-line-length=127 --statistics --exclude ckan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+        run: flake8 ckanext --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
       - name: Run flake8
-        run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
+        run: flake8 ckanext --count --max-line-length=127 --statistics --exclude ckan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "2.7"
+          python-version: '3.6'
+      - name: Install requirements
+          run: pip install flake8 pycodestyle
+      - name: Check syntax
+          run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
       - name: Run flake8
-        uses: julianwachholz/flake8-action@v1.1.0
-        with:
-          checkName: "Python Lint"
-          path: ckanext
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: flake8 . --count --max-line-length=127 --statistics --exclude ckan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,6 @@ name: Code Quality
 
 on: [push, pull_request, workflow_dispatch]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   lint:
     name: Python Lint

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/plugin.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/plugin.py
@@ -54,6 +54,7 @@ class Apicatalog_SchemingPlugin(plugins.SingletonPlugin):
             'override_field_with_default_translation': validators.override_field_with_default_translation,
             'fluent_list': validators.fluent_list,
             'fluent_list_output': validators.fluent_list_output,
+            'ignore_non_existent_organizations': validators.ignore_non_existent_organizations,
             }
 
     def get_helpers(self):

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/presets.json
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/presets.json
@@ -18,12 +18,13 @@
     {
       "preset_name": "apicatalog_organization_string_autocomplete",
       "values": {
-        "validators": "ignore_missing lower_if_exists tag_string_convert",
+        "validators": "ignore_missing lower_if_exists ignore_non_existent_organizations",
         "classes": ["control-full"],
         "form_attrs": {
           "data-module": "autocomplete",
           "data-module-tags": "",
-          "data-module-source": "/api/2/util/organization/autocomplete?q=?"
+          "data-module-source": "/api/2/util/organization/autocomplete?q=?",
+          "data-module-createtags": "false"
         }
       }
     },

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/dataset.json
@@ -138,8 +138,7 @@
       "field_name": "allowed_organizations",
       "label": "Allowed Organizations",
       "classes": ["control-full"],
-      "preset": "apicatalog_organization_string_autocomplete",
-      "validators": "ignore_missing"
+      "preset": "apicatalog_organization_string_autocomplete"
     }
   ],
   "resource_fields": [
@@ -305,8 +304,7 @@
       "field_name": "allowed_organizations",
       "label": "Allowed Organizations",
       "classes": ["control-full"],
-      "preset": "apicatalog_organization_string_autocomplete",
-      "validators": "ignore_missing"
+      "preset": "apicatalog_organization_string_autocomplete"
     }
   ]
 }

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
@@ -13,7 +13,7 @@ from . import plugin
 
 missing = toolkit.missing
 get_action = toolkit.get_action
-
+ObjectNotFound = toolkit.ObjectNotFound
 
 try:
     from ckanext.scheming.validation import (
@@ -309,3 +309,23 @@ def fluent_list_output(value):
     except ValueError:
         # plain string in the db, return as is so it can be migrated
         return value
+
+def ignore_non_existent_organizations(value):
+
+    existing_organizations = []
+
+    if isinstance(value, str):
+        orgs = [tag.strip()
+                for tag in value.split(',')
+                if tag.strip()]
+    else:
+        orgs = value
+
+    for org in orgs:
+        try:
+            get_action('organization_show')({}, {'id': org})
+            existing_organizations.append(org)
+        except ObjectNotFound:
+            pass
+
+    return ','.join(existing_organizations)

--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/validators.py
@@ -310,6 +310,7 @@ def fluent_list_output(value):
         # plain string in the db, return as is so it can be migrated
         return value
 
+
 def ignore_non_existent_organizations(value):
 
     existing_organizations = []


### PR DESCRIPTION
# Description
Prevents adding non-existent organizations in UI by not accepting them in selection and ignores them in the backend code if they are added through api.

## Jira ticket reference: [LIKA-440](https://jira.dvv.fi/browse/LIKA-440)

## What has changed:
Adds createtags false in the component to prevent selecting non-existent. Adds a new validator to ignore them in backend.

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

