### PR TITLE
LIKA-377: Add link for list applications view in profile menu

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/home/snippets/apicatalog_profile_items.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/home/snippets/apicatalog_profile_items.html
@@ -40,6 +40,13 @@
     <span class="text">{{ _('Blog') }}</span>
   </a>
 </li>
+
+<li class="{{ class }}">
+  <a href="{{ h.url_for('apply_permissions.list_permission_applications') }}" title="{{ _('Blog') }}">
+    <i class="fa fa-file-text-o"></i>
+    <span class="text">{{ _('Service access applications') }}</span>
+  </a>
+</li>
 <!-- /ckanext_pages -->
 
 {% block header_account_logged %}


### PR DESCRIPTION
# Description
Makes permission request applications available from ui-link (instead of remembering correct url and writing it directly on browser)

## Jira ticket reference: [LIKA-377](https://jira.dvv.fi/browse/LIKA-377)

## What has changed:
- Added link in profile menu

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.

![Screenshot from 2022-04-01 10-30-42](https://user-images.githubusercontent.com/13560443/161216432-d42933c5-3d40-4388-9984-94b8a741549a.png)
