### PR TITLE
LIKA-473: Add file upload field back to dataset resources schema

### DIFF
--- a/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog_scheming/ckanext/apicatalog_scheming/schemas/dataset.json
@@ -159,6 +159,12 @@
       "display_snippet": null
     },
     {
+      "field_name": "url",
+      "label": "URL",
+      "preset": "resource_url_upload_ex",
+      "final": true
+    },
+    {
       "field_name": "description_translated",
       "label": "Attachment description",
       "extra_label": "A general, concise, and easy-to-understand description of the organization",


### PR DESCRIPTION
# Description
Adds file upload field back to the dataset resource schema.

## Jira ticket reference: [LIKA-473](https://jira.dvv.fi/browse/LIKA-473)

## What has changed:
- Dataset schema, added url field back for resource

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

