### PR TITLE
LIKA-433: Implement a new view for previewing an permission application form

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/macros/form.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/macros/form.html
@@ -98,3 +98,54 @@
   {% if is_upload_enabled %}</div>{% endif %}
 
 {% endmacro %}
+
+
+{#
+  Creates all the markup required for an select element. Handles matching labels to
+  inputs and error messages.
+  
+  A field should be a dict with a "value" key and an optional "text" key which
+  will be displayed to the user. We use a dict to easily allow extension in
+  future should extra options be required.
+  
+  name        - The name of the form parameter.
+  id          - The id to use on the input and label. Convention is to prefix with 'field-'.
+  label       - The human readable label.
+  options     - A list/tuple of fields to be used as <options>.
+    selected    - The value of the selected <option>.
+      error       - A list of error strings for the field or just true to highlight the field.
+      classes     - An array of classes to apply to the form-group.
+      is_required - Boolean of whether this input is requred for the form to validate
+  
+      Examples:
+  
+      {% import 'macros/form.html' as form %}
+      {{ form.select('year', label=_('Year'), options=[{'value':2010, 'text': 2010},{'value': 2011, 'text': 2011}], selected=2011, error=errors.year) }}
+  
+      Or only with values if they are the same as text:
+      {{ form.select('year', label=_('Year'), options=[{'value':2010},{'value': 2011}], selected=2011, error=errors.year) }}
+  
+      Complete example:
+      {{ form.select('the_data_type', id='the_data_type', label=_('Data Type'), options=[
+          {'value': '0', 'text': _('[Choose Data Type]')}
+          , {'value': '1', 'text': _('Private data')}
+          , {'value': '2', 'text': _('Not private data')}
+      ], selected=data.the_data_type if data.the_data_type else '0', is_required=true) }}
+  
+      #}
+      {% macro select_with_description(name, id='', label='', options='', selected='', error='', classes=[], attrs={'class': 'form-control'}, is_required=false, description=None) %}
+        {% set classes = (classes|list) %}
+        {% do classes.append('control-select') %}
+    
+        {%- set extra_html = caller() if caller -%}
+        {% call input_block(id or name, label or name, error, classes, extra_html=extra_html, is_required=is_required) %}
+        {% if description %}
+          <p class="input-block-description">{{ description }}</p>
+        {% endif %}
+          <select id="{{ id or name }}" name="{{ name }}" {{ attributes(attrs) }}>
+            {% for option in options %}
+              <option value="{{ option.value }}"{% if option.value == selected %} selected{% endif %}>{{ option.text or option.value }}</option>
+            {% endfor %}
+          </select>
+        {% endcall %}
+      {% endmacro %}

--- a/ckanext/ckanext-apicatalog_ui/less/components.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components.less
@@ -1,4 +1,5 @@
 @import "components/apply-permissions-for-service";
+@import "components/banner";
 @import "components/button";
 @import "components/drag-n-drop-uploader";
 @import "components/tags";

--- a/ckanext/ckanext-apicatalog_ui/less/components/apply-permissions-for-service.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components/apply-permissions-for-service.less
@@ -26,3 +26,8 @@
 .btn.btn--preview {
     margin-left: auto;
 }
+
+.additional_application_info_step {
+    margin-top: 40px;
+    margin-bottom: 25px;
+}

--- a/ckanext/ckanext-apicatalog_ui/less/components/apply-permissions-for-service.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components/apply-permissions-for-service.less
@@ -22,3 +22,7 @@
         }
     }
 }
+
+.btn.btn--preview {
+    margin-left: auto;
+}

--- a/ckanext/ckanext-apicatalog_ui/less/components/banner.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components/banner.less
@@ -1,0 +1,11 @@
+.banner-status {
+    &.banner-status--info {
+        color: @white;
+        background-color: @suomifi-brand-base;
+        padding: @gutterSmallY @gutterSmallX;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: @gutterSmallY;
+    }
+}

--- a/ckanext/ckanext-apicatalog_ui/less/components/button.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components/button.less
@@ -23,6 +23,7 @@
 
     &.btn-outline-white {
         color: @white;
+        background-color: transparent;
         border-color: @white
     }
 }

--- a/ckanext/ckanext-apicatalog_ui/less/components/button.less
+++ b/ckanext/ckanext-apicatalog_ui/less/components/button.less
@@ -2,7 +2,7 @@
     border-radius: @border-radius__button;
     font-weight: normal;
 
-    &&-primary {
+    &.btn-primary {
         background: linear-gradient(0deg, @suomifi-highlight-dark, @suomifi-highlight-base);
         border-color: @suomifi-highlight-base;
 
@@ -11,13 +11,18 @@
         }
     }
 
-    &-icon--right {
+    .btn-icon--right {
         margin-left: @grid-gutter-width / 4;
     }
 
-    &&-outline-primary {
+    &.btn-outline-primary {
         background: none;
         border-color: @suomifi-highlight-base;
         color: @suomifi-highlight-base;
+    }
+
+    &.btn-outline-white {
+        color: @white;
+        border-color: @white
     }
 }

--- a/ckanext/ckanext-apicatalog_ui/less/forms.less
+++ b/ckanext/ckanext-apicatalog_ui/less/forms.less
@@ -81,7 +81,14 @@ label {
 
 
 label.checkbox {
+  display: flex;
+  align-items: center;
   padding-left:20px;
+
+  input[type=checkbox] {
+    top: 0;
+    margin-top: 0;
+  }
 }
 
 input[type=radio],

--- a/ckanext/ckanext-apicatalog_ui/less/module.less
+++ b/ckanext/ckanext-apicatalog_ui/less/module.less
@@ -149,6 +149,7 @@
   &__actions {
     margin-left: -@grid-gutter-width / 4;
     margin-right: -@grid-gutter-width / 4;
+    display: flex;
 
     .btn {
       margin-left: @grid-gutter-width / 4;

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-01 07:44+0000\n"
+"POT-Creation-Date: 2022-04-12 07:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,17 +19,18 @@ msgstr ""
 "Generated-By: Babel 2.7.0\n"
 
 #: ckanext/apply_permissions_for_service/views.py:26
-#: ckanext/apply_permissions_for_service/views.py:115
-#: ckanext/apply_permissions_for_service/views.py:126
-#: ckanext/apply_permissions_for_service/views.py:211
+#: ckanext/apply_permissions_for_service/views.py:121
+#: ckanext/apply_permissions_for_service/views.py:132
+#: ckanext/apply_permissions_for_service/views.py:141
+#: ckanext/apply_permissions_for_service/views.py:230
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:78
+#: ckanext/apply_permissions_for_service/views.py:80
 msgid "This API is not accepting access applications."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:199
+#: ckanext/apply_permissions_for_service/views.py:218
 msgid "Changes saved successfully"
 msgstr ""
 
@@ -92,12 +93,12 @@ msgstr ""
 msgid "Apply for permission to use API {}"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:28
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
 msgid "API access application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:29
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
 "Use this form to apply for a permission to use a service that is available in"
 " the National Data Exchange Layer. Your application will be submitted to the "
@@ -105,116 +106,147 @@ msgid ""
 "Valtori is automatically notified of the needed firewall configurations."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
 msgid "Applicant information"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:32
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
 "Your contact infomation and organization details are prefilled based on "
 "information provided when your organization joined the National Data Exchange"
 " layer. Modify the prefilled information if necessary."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:38
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
 msgid "Business code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:40
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:20
 msgid "Contact name"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:41
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:56
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:21
 msgid "Contact email"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:66
+msgid ""
+"Applying organization acts as an intermediary on behalf of the organizations "
+"using the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
+msgid "Information about the organization consuming the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+msgid "Organization using the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
+msgid "Y-number"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
 msgid "Details of your Security Server and Subsystem"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:45
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:93
 msgid ""
 "Fill in the details of the Security Server and subsystem that you are "
 "applying permission for, and need the firewall opened to."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
 msgid "IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Write the IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Select one or several IP addresses of your organization's security servers"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:102
 msgid "Add an IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:58
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:63
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
 msgid "Details of the service and API you are applying to access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
 msgid "Organization name"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
 msgid "Subsystem"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:83
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Service code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:83
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 msgid "Select one or several APIs you are applying to access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:84
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
 msgid "Explain how the service will be used"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:84
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 msgid "Reason for requesting access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
 msgid "Date when access is needed"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:94
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
 msgid "Send access application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:95
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:144
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:57
 msgid "Cancel"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
+msgid "Preview permission application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
+msgid "You are previewing permission from applicants point of view"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
+msgid "Exit from preview"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
@@ -277,11 +309,15 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:58
+msgid "Preview application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:62
 msgid "Permission request alternatives:"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:63
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:64
 msgid ""
 "<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
 "<li>Request permission to use a subsystem by using the predefined electronic "
@@ -332,21 +368,5 @@ msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:41
-msgid "Applying organization acts as an intermediary on behalf of the organizations using the services"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:51
-msgid "Information about the organization consuming the services"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:64
-msgid "Y-number"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
-msgid "Organization using the services"
 msgstr ""
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-12 07:39+0000\n"
+"POT-Creation-Date: 2022-04-22 12:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/views.py:121
 #: ckanext/apply_permissions_for_service/views.py:132
 #: ckanext/apply_permissions_for_service/views.py:141
-#: ckanext/apply_permissions_for_service/views.py:230
+#: ckanext/apply_permissions_for_service/views.py:252
 msgid "Not authorized to see this page"
 msgstr ""
 
@@ -30,7 +30,7 @@ msgstr ""
 msgid "This API is not accepting access applications."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:218
+#: ckanext/apply_permissions_for_service/views.py:240
 msgid "Changes saved successfully"
 msgstr ""
 
@@ -185,6 +185,12 @@ msgid "Add an IP address"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
+msgid ""
+"Select the subsystem of your organization for which you want to apply "
+"permission"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
 msgstr ""
@@ -227,12 +233,12 @@ msgstr ""
 msgid "Date when access is needed"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:142
 msgid "Send access application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:144
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:57
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Cancel"
 msgstr ""
 
@@ -281,43 +287,48 @@ msgid "Disable access requests for this API"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
-msgid "E-mail"
+msgid "Application in API Catalogue"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
-msgid "Upload your access request file"
+msgid "Organisation’s downloadable application (PDF)"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
-msgid "Access is requested on a web page managed by my organization"
+msgid "Link to the access licence application on the organisation's website"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
-msgid "Email address"
+msgid "Email"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:38
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
+msgid "Request additional info with an attachment"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
 msgid "Add your file"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:51
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
 msgid "Webpage URL"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:56
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
 msgid "Save"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:58
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
 msgid "Preview application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:62
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
 msgid "Permission request alternatives:"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:64
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
 msgid ""
 "<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
 "<li>Request permission to use a subsystem by using the predefined electronic "
@@ -342,23 +353,23 @@ msgstr ""
 msgid "Additional info"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:4
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
 msgid "Sending additional info"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
 msgid "Requested subsystem is managed by a company that requires additional info"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
 msgid "1. Download file and fill required information"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:14
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
 msgid "Download"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:17
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
 msgid "2. Add completed file into the application"
 msgstr ""
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/en_GB/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/en_GB/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -1,8 +1,8 @@
 # Translations template for ckanext-apply_permissions_for_service.
-# Copyright (C) 2021 ORGANIZATION
+# Copyright (C) 2022 ORGANIZATION
 # This file is distributed under the same license as the
 # ckanext-apply_permissions_for_service project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # 
 # Translators:
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-09 13:01+0000\n"
+"POT-Creation-Date: 2022-04-22 12:20+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
 "Last-Translator: Bert Viikmäe, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -25,30 +25,36 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/apply_permissions_for_service/views.py:27
-#: ckanext/apply_permissions_for_service/views.py:96
-#: ckanext/apply_permissions_for_service/views.py:107
-#: ckanext/apply_permissions_for_service/views.py:191
+#: ckanext/apply_permissions_for_service/views.py:26
+#: ckanext/apply_permissions_for_service/views.py:121
+#: ckanext/apply_permissions_for_service/views.py:132
+#: ckanext/apply_permissions_for_service/views.py:141
+#: ckanext/apply_permissions_for_service/views.py:252
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:59
+#: ckanext/apply_permissions_for_service/views.py:80
 msgid "This API is not accepting access applications."
 msgstr "This subsystem is not accepting access applications."
 
-#: ckanext/apply_permissions_for_service/views.py:179
+#: ckanext/apply_permissions_for_service/views.py:240
 msgid "Changes saved successfully"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/logic/action.py:26
-#: ckanext/apply_permissions_for_service/logic/action.py:29
-#: ckanext/apply_permissions_for_service/logic/action.py:32
-#: ckanext/apply_permissions_for_service/logic/action.py:35
-#: ckanext/apply_permissions_for_service/logic/action.py:38
-#: ckanext/apply_permissions_for_service/logic/action.py:41
-#: ckanext/apply_permissions_for_service/logic/action.py:44
-#: ckanext/apply_permissions_for_service/logic/action.py:47
+#: ckanext/apply_permissions_for_service/logic/action.py:27
+#: ckanext/apply_permissions_for_service/logic/action.py:30
+#: ckanext/apply_permissions_for_service/logic/action.py:33
+#: ckanext/apply_permissions_for_service/logic/action.py:36
+#: ckanext/apply_permissions_for_service/logic/action.py:39
+#: ckanext/apply_permissions_for_service/logic/action.py:42
+#: ckanext/apply_permissions_for_service/logic/action.py:45
+#: ckanext/apply_permissions_for_service/logic/action.py:48
+#: ckanext/apply_permissions_for_service/logic/action.py:51
 msgid "Missing value"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/logic/auth.py:20
+msgid "User not authorized to view permission application."
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
@@ -94,12 +100,12 @@ msgstr ""
 msgid "Apply for permission to use API {}"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:28
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
 msgid "API access application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:29
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
 "Use this form to apply for a permission to use a service that is available "
 "in the National Data Exchange Layer. Your application will be submitted to "
@@ -113,117 +119,156 @@ msgstr ""
 "be informed of any approved access rights requests so the necessary "
 "firewalls are opened."
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
 msgid "Applicant information"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:32
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
 "Your contact infomation and organization details are prefilled based on "
 "information provided when your organization joined the National Data "
 "Exchange layer. Modify the prefilled information if necessary."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:38
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
 msgid "Business code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:40
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:20
 msgid "Contact name"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:41
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:56
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:21
 msgid "Contact email"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:66
+msgid ""
+"Applying organization acts as an intermediary on behalf of the organizations"
+" using the services"
+msgstr ""
+"Applying organization acts as an intermediary on behalf of the organizations"
+" using the services"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
+msgid "Information about the organization consuming the services"
+msgstr "Information about the organization consuming the services"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+msgid "Organization using the services"
+msgstr "Organization using the services"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
+msgid "Y-number"
+msgstr "Y-number"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
 msgid "Details of your Security Server and Subsystem"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:45
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:93
 msgid ""
 "Fill in the details of the Security Server and subsystem that you are "
 "applying permission for, and need the firewall opened to."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
 msgid "IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Write the IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid ""
 "Select one or several IP addresses of your organization's security servers"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:102
 msgid "Add an IP address"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:58
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
+msgid ""
+"Select the subsystem of your organization for which you want to apply "
+"permission"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:63
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
 msgid "Details of the service and API you are applying to access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
 msgid "Organization name"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
 msgid "Subsystem"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Service code"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 msgid "Select one or several APIs you are applying to access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
 msgid "Explain how the service will be used"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 msgid "Reason for requesting access"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:83
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
 msgid "Date when access is needed"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:87
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:142
 msgid "Send access application"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:88
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Cancel"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
+msgid "Preview permission application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
+msgid "You are previewing permission from applicants point of view"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
+msgid "Exit from preview"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
@@ -261,61 +306,91 @@ msgid "Disable access requests for this API"
 msgstr "Disable access requests for this subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
-msgid "Ticketing service API call"
+msgid "Application in API Catalogue"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
-msgid "Upload your access request file"
+msgid "Organisation’s downloadable application (PDF)"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
-msgid "Access is requested on a web page managed by my organization"
-msgstr "Link to requesting permission on the organisation's website"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
-msgid "Endpoint URL"
+msgid "Link to the access licence application on the organisation's website"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:38
-msgid "Add your file"
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
+msgid "Email"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
+msgid "Request additional info with an attachment"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
+msgid "Add your file"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
 msgid "Webpage URL"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
 msgid "Save"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:59
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+msgid "Preview application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
 msgid "Permission request alternatives:"
 msgstr "Access request options:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-msgid "Permission request alternatives instructions"
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
+msgid ""
+"<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
+"<li>Request permission to use a subsystem by using the predefined electronic"
+" form in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Organisation’s downloadable application (PDF)</p> <ul> <li>Upload "
+"your organisation's own PDF form to the API Catalogue that can be used to "
+"request permission to use the subsystem. The applicant must download the "
+"form from the API Catalogue and send the completed form to the email address"
+" you specified.</li> <li>In the form, explain to which email address the "
+"form should be returned to.</li> <li>Access requests sent in this way will "
+"not appear in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Link to the access licence application on the organisation's "
+"website</p> <ul> <li>Enter the URL for your organisation’s web page where "
+"the person requesting access can apply for access to your organisation’s "
+"services.</li> <li>Access requests sent in this way will not appear in the "
+"API Catalogue.</li> </ul> <p>For more information on the administration of "
+"access rights, see the instructions in the <a target=\"_blank\" "
+"href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
+msgid "Additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
+msgid "Sending additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
 msgid ""
-"<p style=\"font-weight: bold;\">Application in API "
-"Catalogue</p><ul><li>Request permission to use a subsystem by using the "
-"predefined electronic form in the API Catalogue.</li></ul><p style=\"font-"
-"weight: bold;\">Organisation’s downloadable application "
-"(PDF)</p><ul><li>Upload your organisation's own PDF form to the API "
-"Catalogue that can be used to request permission to use the subsystem. The "
-"applicant must download the form from the API Catalogue and send the "
-"completed form to the email address you specified.</li><li>In the form, "
-"explain to which email address the form should be returned "
-"to.</li><li>Access requests sent in this way will not appear in the API "
-"Catalogue.</li></ul><p style=\"font-weight: bold;\">Link to the access "
-"licence application on the organisation's website</p><ul><li>Enter the URL "
-"for your organisation’s web page where the person requesting access can "
-"apply for access to your organisation’s services.</li><li>Access requests "
-"sent in this way will not appear in the API Catalogue.</li></ul><p>For more "
-"information on the administration of access rights, see the instructions in "
-"the<a target=\"_blank\" href=\"https://liityntakatalogi.suomi.fi/\">API "
-"Catalogue.</a></p>"
+"Requested subsystem is managed by a company that requires additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
+msgid "1. Download file and fill required information"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
+msgid "Download"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
+msgid "2. Add completed file into the application"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:5
@@ -325,23 +400,3 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
 msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:41
-msgid ""
-"Applying organization acts as an intermediary on behalf of the organizations"
-" using the services"
-msgstr ""
-"Applying organization acts as an intermediary on behalf of the organizations"
-" using the services"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:51
-msgid "Information about the organization consuming the services"
-msgstr "Information about the organization consuming the services"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:64
-msgid "Y-number"
-msgstr "Y-number"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
-msgid "Organization using the services"
-msgstr "Organization using the services"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/fi/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/fi/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -1,8 +1,8 @@
 # Translations template for ckanext-apply_permissions_for_service.
-# Copyright (C) 2021 ORGANIZATION
+# Copyright (C) 2022 ORGANIZATION
 # This file is distributed under the same license as the
 # ckanext-apply_permissions_for_service project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # 
 # Translators:
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2020
@@ -10,15 +10,16 @@
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2021
 # Bert Viikmäe, 2022
+# Pasi Laakso <pasi.laakso@gofore.com>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-09 13:01+0000\n"
+"POT-Creation-Date: 2022-04-22 12:20+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
-"Last-Translator: Bert Viikmäe, 2022\n"
+"Last-Translator: Pasi Laakso <pasi.laakso@gofore.com>, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -27,31 +28,37 @@ msgstr ""
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/apply_permissions_for_service/views.py:27
-#: ckanext/apply_permissions_for_service/views.py:96
-#: ckanext/apply_permissions_for_service/views.py:107
-#: ckanext/apply_permissions_for_service/views.py:191
+#: ckanext/apply_permissions_for_service/views.py:26
+#: ckanext/apply_permissions_for_service/views.py:121
+#: ckanext/apply_permissions_for_service/views.py:132
+#: ckanext/apply_permissions_for_service/views.py:141
+#: ckanext/apply_permissions_for_service/views.py:252
 msgid "Not authorized to see this page"
 msgstr "Tämän sivun näyttäminen ei ole sallittu"
 
-#: ckanext/apply_permissions_for_service/views.py:59
+#: ckanext/apply_permissions_for_service/views.py:80
 msgid "This API is not accepting access applications."
 msgstr "Tämä alijärjestelmä ei ota vastaan käyttölupahakemuksia."
 
-#: ckanext/apply_permissions_for_service/views.py:179
+#: ckanext/apply_permissions_for_service/views.py:240
 msgid "Changes saved successfully"
 msgstr "Muutokset tallennettu onnistuneesti"
 
-#: ckanext/apply_permissions_for_service/logic/action.py:26
-#: ckanext/apply_permissions_for_service/logic/action.py:29
-#: ckanext/apply_permissions_for_service/logic/action.py:32
-#: ckanext/apply_permissions_for_service/logic/action.py:35
-#: ckanext/apply_permissions_for_service/logic/action.py:38
-#: ckanext/apply_permissions_for_service/logic/action.py:41
-#: ckanext/apply_permissions_for_service/logic/action.py:44
-#: ckanext/apply_permissions_for_service/logic/action.py:47
+#: ckanext/apply_permissions_for_service/logic/action.py:27
+#: ckanext/apply_permissions_for_service/logic/action.py:30
+#: ckanext/apply_permissions_for_service/logic/action.py:33
+#: ckanext/apply_permissions_for_service/logic/action.py:36
+#: ckanext/apply_permissions_for_service/logic/action.py:39
+#: ckanext/apply_permissions_for_service/logic/action.py:42
+#: ckanext/apply_permissions_for_service/logic/action.py:45
+#: ckanext/apply_permissions_for_service/logic/action.py:48
+#: ckanext/apply_permissions_for_service/logic/action.py:51
 msgid "Missing value"
 msgstr "Puuttuva arvo"
+
+#: ckanext/apply_permissions_for_service/logic/auth.py:20
+msgid "User not authorized to view permission application."
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:4
@@ -98,12 +105,12 @@ msgstr "Pyydä käyttölupaa"
 msgid "Apply for permission to use API {}"
 msgstr "Pyydä lupaa käyttää alijärjestelmää {}"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:28
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
 msgid "API access application"
 msgstr "Alijärjestelmän käyttölupahakemus"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:29
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
 "Use this form to apply for a permission to use a service that is available "
 "in the National Data Exchange Layer. Your application will be submitted to "
@@ -111,18 +118,19 @@ msgid ""
 "approved, Valtori is automatically notified of the needed firewall "
 "configurations."
 msgstr ""
-"Tällä lomakkeella voit hakea organisaatiollesi lupaa käyttää lupaa käyttää "
-"alijärjestelmän palveluita Suomi.fi-palveluväylässä. Yhteystiedot välitetään"
-" käyttölupahakemuksen mukana sille organisaatiolle, jonka alijärjestelmään "
-"pyydät käyttölupaa. Hyväksytystä käyttöluvasta tiedotetaan Valtorille "
-"tarvittavia palomuuriavauksia varten."
+"Tällä lomakkeella voit hakea organisaatiollesi lupaa käyttää alijärjestelmän"
+" palveluita Suomi.fi-palveluväylässä. Voit myös hakea lupaa välitoimijana "
+"toisen organisaation puolesta. Yhteystiedot välitetään käyttölupahakemuksen "
+"mukana sille organisaatiolle, jonka alijärjestelmään pyydät käyttölupaa. "
+"Hyväksytystä käyttöluvasta tiedotetaan Valtorille tarvittavia "
+"palomuuriavauksia varten."
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
 msgid "Applicant information"
 msgstr "Hakijan tiedot"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:32
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
 "Your contact infomation and organization details are prefilled based on "
 "information provided when your organization joined the National Data "
@@ -132,32 +140,52 @@ msgstr ""
 "täytettyjen tietojen perusteella. Voit muokata esitäytettyjä tietoja "
 "tarvittaessa."
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
 msgid "Organization"
 msgstr "Organisaatio"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:38
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
 msgid "Business code"
 msgstr "Y-tunnus"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:40
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:20
 msgid "Contact name"
 msgstr "Yhteyshenkilön nimi"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:41
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:56
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:21
 msgid "Contact email"
 msgstr "Yhteyshenkilön sähköposti"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:66
+msgid ""
+"Applying organization acts as an intermediary on behalf of the organizations"
+" using the services"
+msgstr ""
+"Hakijaorganisaatio toimii välitoimijana palveluita käyttävän organisaatioin "
+"puolesta"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
+msgid "Information about the organization consuming the services"
+msgstr "Palveluita käyttävän organisaation tiedot"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+msgid "Organization using the services"
+msgstr "Palveluita käyttävä organisaatio"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
+msgid "Y-number"
+msgstr "Y-tunnus"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
 msgid "Details of your Security Server and Subsystem"
 msgstr "Organisaatiosi liityntäpalvelimen ja alijärjestelmän tiedot"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:45
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:93
 msgid ""
 "Fill in the details of the Security Server and subsystem that you are "
 "applying permission for, and need the firewall opened to."
@@ -165,77 +193,96 @@ msgstr ""
 "Täydennä alle sen liityntäpalvelminen IP osoite ja alijärjestelmän tiedot "
 "joille haet käyttölupaa ja palomuuriavausta. "
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
 msgid "IP address"
 msgstr "IP-osoite"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Write the IP address"
 msgstr "Kirjoita IP-osoite"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid ""
 "Select one or several IP addresses of your organization's security servers"
 msgstr "Valitse yksi tai useampi organisaatiosi liityntäpalvelimen IP-osoite"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:102
 msgid "Add an IP address"
 msgstr "Lisää IP-osoite"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:58
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
+msgid ""
+"Select the subsystem of your organization for which you want to apply "
+"permission"
+msgstr "Valitse organisaatiosi alijärjestelmä, jolle käyttölupa halutaan"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
 msgstr "Alijärjestelmän tunnus"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:63
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
 msgid "Details of the service and API you are applying to access"
 msgstr ""
 "Valitse yksi tai useampi alijärjestelmän palvelu, jolle pyydät käyttölupaa"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
 msgid "Organization name"
 msgstr "Organisaation nimi"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
 msgid "Subsystem"
 msgstr "Alijärjestelmä"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Service code"
 msgstr "Palvelun tunnus"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 msgid "Select one or several APIs you are applying to access"
 msgstr ""
 "Valitse yksi tai useampi alijärjestelmän rajapinta, jolle pyydät käyttölupaa"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
 msgid "Explain how the service will be used"
 msgstr "Kerro, mihin tarkoitukseen lupaa pyydetään"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 msgid "Reason for requesting access"
 msgstr "Kirjoita perustelu"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:83
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
 msgid "Date when access is needed"
 msgstr "Mistä alkaen alijärjestelmää tarvitaan"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:87
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:142
 msgid "Send access application"
 msgstr "Lähetä käyttölupahakemus"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:88
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Cancel"
 msgstr "Peruuta"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
+msgid "Preview permission application"
+msgstr "Käyttölupahakemuksen esikatselu"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
+msgid "You are previewing permission from applicants point of view"
+msgstr "Esikatselet käyttölupahakemusta hakijan näkökulmasta"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
+msgid "Exit from preview"
+msgstr "Lopeta esikatselu"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:13
@@ -248,11 +295,11 @@ msgstr "Hakemus lähetetty onnistuneesti"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:6
 msgid "Exit the settings"
-msgstr ""
+msgstr "Keskeytä muokkaus"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:13
 msgid "Subsystem permission"
-msgstr ""
+msgstr "Lupapyyntöjen asetukset"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:14
 msgid ""
@@ -272,69 +319,74 @@ msgid "Disable access requests for this API"
 msgstr "Alijärjestelmälle ei voi tehdä lupapyyntöjä"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
-msgid "Ticketing service API call"
-msgstr "Rajapinnan kautta omaan asianhallintajärjestelmääni"
+msgid "Application in API Catalogue"
+msgstr "Liityntäkatalogin valmis lupahakemus"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
-msgid "Upload your access request file"
-msgstr ""
+msgid "Organisation’s downloadable application (PDF)"
+msgstr "Oma lupahakemus"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
-msgid "Access is requested on a web page managed by my organization"
-msgstr "Linkki lupahakemukseen organisaation sivuilla"
+msgid "Link to the access licence application on the organisation's website"
+msgstr "Linkki lupahakemukseen organisaation sivulla"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
-msgid "Endpoint URL"
-msgstr "Palvelun URL"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:38
-msgid "Add your file"
+msgid "Email"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
+msgid "Request additional info with an attachment"
+msgstr "Pyydä lisätietoja liitetiedostona"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
+msgid "Add your file"
+msgstr "Lisää tiedosto"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
 msgid "Webpage URL"
 msgstr "Verkkosivuston URL"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
 msgid "Save"
 msgstr "Tallenna"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:59
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+msgid "Preview application"
+msgstr "Esikatsele hakemusta"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
 msgid "Permission request alternatives:"
 msgstr "Lupapyyntövaihtoehdot:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-msgid "Permission request alternatives instructions"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
 msgid ""
-"<p style=\"font-weight: bold;\">Application in API "
-"Catalogue</p><ul><li>Request permission to use a subsystem by using the "
-"predefined electronic form in the API Catalogue.</li></ul><p style=\"font-"
-"weight: bold;\">Organisation’s downloadable application "
-"(PDF)</p><ul><li>Upload your organisation's own PDF form to the API "
-"Catalogue that can be used to request permission to use the subsystem. The "
-"applicant must download the form from the API Catalogue and send the "
-"completed form to the email address you specified.</li><li>In the form, "
-"explain to which email address the form should be returned "
-"to.</li><li>Access requests sent in this way will not appear in the API "
-"Catalogue.</li></ul><p style=\"font-weight: bold;\">Link to the access "
-"licence application on the organisation's website</p><ul><li>Enter the URL "
-"for your organisation’s web page where the person requesting access can "
-"apply for access to your organisation’s services.</li><li>Access requests "
-"sent in this way will not appear in the API Catalogue.</li></ul><p>For more "
-"information on the administration of access rights, see the instructions in "
-"the<a target=\"_blank\" href=\"https://liityntakatalogi.suomi.fi/\">API "
-"Catalogue.</a></p>"
+"<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
+"<li>Request permission to use a subsystem by using the predefined electronic"
+" form in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Organisation’s downloadable application (PDF)</p> <ul> <li>Upload "
+"your organisation's own PDF form to the API Catalogue that can be used to "
+"request permission to use the subsystem. The applicant must download the "
+"form from the API Catalogue and send the completed form to the email address"
+" you specified.</li> <li>In the form, explain to which email address the "
+"form should be returned to.</li> <li>Access requests sent in this way will "
+"not appear in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Link to the access licence application on the organisation's "
+"website</p> <ul> <li>Enter the URL for your organisation’s web page where "
+"the person requesting access can apply for access to your organisation’s "
+"services.</li> <li>Access requests sent in this way will not appear in the "
+"API Catalogue.</li> </ul> <p>For more information on the administration of "
+"access rights, see the instructions in the <a target=\"_blank\" "
+"href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
 "<p style=\"font-weight: bold;\">Liityntäkatalogin valmis "
 "lupahakemus</p><ul><li>Käyttölupaa haetaan Liityntäkatalogin valmiilla "
 "sähköisellä lomakkeella.</li></ul><p style=\"font-weight: bold;\">Oma "
-"lupahakemus (PDF)</p><ul><li>Lataa Liityntäkatalogiin organisaatiosi oma "
-"PDF-lomake, jolla alijärjestelmään voi hakea käyttölupaa. Luvan pyytäjä "
-"lataa lomakkeen Liityntäkatalogista ja lähettää täytetyn lomakkeen "
-"määrittelemääsi sähköpostiosoitteeseen.</li><li>Kerro lomakkeessa, mihin "
+"lupahakemus</p><ul><li>Lataa Liityntäkatalogiin organisaatiosi oma PDF-"
+"lomake, jolla alijärjestelmään voi hakea käyttölupaa. Luvan pyytäjä lataa "
+"lomakkeen Liityntäkatalogista ja lähettää täytetyn lomakkeen määrittelemääsi"
+" sähköpostiosoitteeseen.</li><li>Kerro lomakkeessa, mihin "
 "sähköpostiosoitteeseen lomake pitää palauttaa.</li><li>Tällä tavalla "
 "lähetetyt lupapyynnöt eivät näy Liityntäkatalogissa.</li></ul><p "
 "style=\"font-weight: bold;\">Linkki lupahakemukseen organisaation "
@@ -345,30 +397,37 @@ msgstr ""
 "href=\"https://liityntakatalogi.suomi.fi/\">Liityntäkatalogin "
 "ohjeista.</a></p>"
 
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
+msgid "Additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
+msgid "Sending additional info"
+msgstr "Lisätietojen lähettäminen"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
+msgid ""
+"Requested subsystem is managed by a company that requires additional info"
+msgstr ""
+"Pyydettävää alijärjestelmää hallinnoiva organisaatio vaatii tämän lomakkeen "
+"tietojen lisäksi erillisen tiedoston täyttämistä."
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
+msgid "1. Download file and fill required information"
+msgstr "1. Lataa tiedosto ja täytä sen vaatimat tiedot"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
+msgid "Download"
+msgstr "Lataa"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
+msgid "2. Add completed file into the application"
+msgstr "2. Lisää täytetty tiedosto osaksi hakemusta"
+
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:5
 msgid "Permission management"
-msgstr ""
+msgstr "Lupapyyntöjen asetukset"
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
 msgstr "Hallinnoi lupapyyntöjä"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
-msgid ""
-"Applying organization acts as an intermediary on behalf of the organizations"
-" using the services"
-msgstr ""
-"Hakijaorganisaatio toimii välitoimijana palveluita käyttävän organisaatioin "
-"puolesta"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:62
-msgid "Information about the organization consuming the services"
-msgstr "Palveluita käyttävän organisaation tiedot"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
-msgid "Y-number"
-msgstr "Y-tunnus"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:64
-msgid "Organization using the services"
-msgstr "Palveluita käyttävä organisaatio"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/sv/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/sv/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -1,8 +1,8 @@
 # Translations template for ckanext-apply_permissions_for_service.
-# Copyright (C) 2021 ORGANIZATION
+# Copyright (C) 2022 ORGANIZATION
 # This file is distributed under the same license as the
 # ckanext-apply_permissions_for_service project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # 
 # Translators:
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2021
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-09 13:01+0000\n"
+"POT-Creation-Date: 2022-04-22 12:20+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
 "Last-Translator: Bert Viikmäe, 2021\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -25,31 +25,37 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/apply_permissions_for_service/views.py:27
-#: ckanext/apply_permissions_for_service/views.py:96
-#: ckanext/apply_permissions_for_service/views.py:107
-#: ckanext/apply_permissions_for_service/views.py:191
+#: ckanext/apply_permissions_for_service/views.py:26
+#: ckanext/apply_permissions_for_service/views.py:121
+#: ckanext/apply_permissions_for_service/views.py:132
+#: ckanext/apply_permissions_for_service/views.py:141
+#: ckanext/apply_permissions_for_service/views.py:252
 msgid "Not authorized to see this page"
 msgstr "Inga rättigheter att se denna sida"
 
-#: ckanext/apply_permissions_for_service/views.py:59
+#: ckanext/apply_permissions_for_service/views.py:80
 msgid "This API is not accepting access applications."
 msgstr "Detta subsystem tar inte emot ansökningar om användningstillstånd."
 
-#: ckanext/apply_permissions_for_service/views.py:179
+#: ckanext/apply_permissions_for_service/views.py:240
 msgid "Changes saved successfully"
 msgstr "Ändringarna har sparats"
 
-#: ckanext/apply_permissions_for_service/logic/action.py:26
-#: ckanext/apply_permissions_for_service/logic/action.py:29
-#: ckanext/apply_permissions_for_service/logic/action.py:32
-#: ckanext/apply_permissions_for_service/logic/action.py:35
-#: ckanext/apply_permissions_for_service/logic/action.py:38
-#: ckanext/apply_permissions_for_service/logic/action.py:41
-#: ckanext/apply_permissions_for_service/logic/action.py:44
-#: ckanext/apply_permissions_for_service/logic/action.py:47
+#: ckanext/apply_permissions_for_service/logic/action.py:27
+#: ckanext/apply_permissions_for_service/logic/action.py:30
+#: ckanext/apply_permissions_for_service/logic/action.py:33
+#: ckanext/apply_permissions_for_service/logic/action.py:36
+#: ckanext/apply_permissions_for_service/logic/action.py:39
+#: ckanext/apply_permissions_for_service/logic/action.py:42
+#: ckanext/apply_permissions_for_service/logic/action.py:45
+#: ckanext/apply_permissions_for_service/logic/action.py:48
+#: ckanext/apply_permissions_for_service/logic/action.py:51
 msgid "Missing value"
 msgstr "Värde som saknas"
+
+#: ckanext/apply_permissions_for_service/logic/auth.py:20
+msgid "User not authorized to view permission application."
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:4
@@ -97,12 +103,12 @@ msgstr "Be om användarlicens"
 msgid "Apply for permission to use API {}"
 msgstr "Be om tillstånd att använda subsystemet {}"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:28
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
 msgid "API access application"
 msgstr "Ansökan om användningstillstånd för subsystem"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:29
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
 "Use this form to apply for a permission to use a service that is available "
 "in the National Data Exchange Layer. Your application will be submitted to "
@@ -117,12 +123,12 @@ msgstr ""
 "Valtori informeras om det godkända användningstillståndet för nödvändiga "
 "öppningar i brandväggen."
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
 msgid "Applicant information"
 msgstr "Uppgifter om den sökande"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:32
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
 "Your contact infomation and organization details are prefilled based on "
 "information provided when your organization joined the National Data "
@@ -132,32 +138,50 @@ msgstr ""
 " i samband med att Informationsleden togs i bruk. Du kan redigera "
 "förhandsifyllda uppgifter vid behov."
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
 msgid "Organization"
 msgstr "Organisation"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:38
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
 msgid "Business code"
 msgstr "FO-nummer"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:40
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:20
 msgid "Contact name"
 msgstr "Kontaktpersonens namn"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:41
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:56
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:21
 msgid "Contact email"
 msgstr "Kontaktpersonens e-post"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:66
+msgid ""
+"Applying organization acts as an intermediary on behalf of the organizations"
+" using the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
+msgid "Information about the organization consuming the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+msgid "Organization using the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
+msgid "Y-number"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
 msgid "Details of your Security Server and Subsystem"
 msgstr "Uppgifter om din organisations anslutningsserver och subsystem"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:45
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:93
 msgid ""
 "Fill in the details of the Security Server and subsystem that you are "
 "applying permission for, and need the firewall opened to."
@@ -165,80 +189,99 @@ msgstr ""
 "Fyll i IP-adressen till anslutningsservern och uppgifterna i subsystemet för"
 " vilka du ansöker om användningstillstånd och brandväggsöppning. "
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
 msgid "IP address"
 msgstr "IP-adress"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Write the IP address"
 msgstr "Skriv in IP-adress"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid ""
 "Select one or several IP addresses of your organization's security servers"
 msgstr ""
 "Välj en eller flera IP-adresser för din organisations anslutningsserver"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:102
 msgid "Add an IP address"
 msgstr "Lägg till IP-adress"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:58
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
+msgid ""
+"Select the subsystem of your organization for which you want to apply "
+"permission"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
 msgstr "Subsystemets kod"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:63
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
 msgid "Details of the service and API you are applying to access"
 msgstr ""
 "Uppgifter om tjänsten och subsystemet, för vilket du begär "
 "användningstillstånd"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
 msgid "Organization name"
 msgstr "Organisationens namn"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:68
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
 msgid "Subsystem"
 msgstr "Subsystem"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Service code"
 msgstr "Tjänstens kod"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 msgid "Select one or several APIs you are applying to access"
 msgstr ""
 "Välj en eller flera subsystemets tjänster för vilka du ber om "
 "användningstillstånd"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
 msgid "Explain how the service will be used"
 msgstr "Berätta för vilket ändamål tillståndet begärs"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:82
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 msgid "Reason for requesting access"
 msgstr "Skriv en motivering till användningstillståndet"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:83
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
 msgid "Date when access is needed"
 msgstr "Från och med när behövs subsystemet"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:87
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:142
 msgid "Send access application"
 msgstr "Skicka ansökan om användningstillstånd"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:88
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Cancel"
 msgstr "Ångra"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
+msgid "Preview permission application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
+msgid "You are previewing permission from applicants point of view"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
+msgid "Exit from preview"
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:13
@@ -275,78 +318,92 @@ msgid "Disable access requests for this API"
 msgstr "Det går inte att begära tillstånd för detta subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
-msgid "Ticketing service API call"
-msgstr "Via gränssnittet till mitt eget ärendehanteringssystem"
+msgid "Application in API Catalogue"
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
-msgid "Upload your access request file"
+msgid "Organisation’s downloadable application (PDF)"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
-msgid "Access is requested on a web page managed by my organization"
-msgstr "Länk till tillståndsansökan på organisationens webbplats"
+msgid "Link to the access licence application on the organisation's website"
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
-msgid "Endpoint URL"
-msgstr "Gränssnittets URL"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:38
-msgid "Add your file"
+msgid "Email"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
+msgid "Request additional info with an attachment"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
+msgid "Add your file"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
 msgid "Webpage URL"
 msgstr "Webbplatsens URL"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:54
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
 msgid "Save"
 msgstr "Spara"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:59
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+msgid "Preview application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
 msgid "Permission request alternatives:"
 msgstr "Alternativ för tillståndsbegäran:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-msgid "Permission request alternatives instructions"
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
+msgid ""
+"<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
+"<li>Request permission to use a subsystem by using the predefined electronic"
+" form in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Organisation’s downloadable application (PDF)</p> <ul> <li>Upload "
+"your organisation's own PDF form to the API Catalogue that can be used to "
+"request permission to use the subsystem. The applicant must download the "
+"form from the API Catalogue and send the completed form to the email address"
+" you specified.</li> <li>In the form, explain to which email address the "
+"form should be returned to.</li> <li>Access requests sent in this way will "
+"not appear in the API Catalogue.</li> </ul> <p style=\"font-weight: "
+"bold;\">Link to the access licence application on the organisation's "
+"website</p> <ul> <li>Enter the URL for your organisation’s web page where "
+"the person requesting access can apply for access to your organisation’s "
+"services.</li> <li>Access requests sent in this way will not appear in the "
+"API Catalogue.</li> </ul> <p>For more information on the administration of "
+"access rights, see the instructions in the <a target=\"_blank\" "
+"href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-msgid ""
-"<p style=\"font-weight: bold;\">Application in API "
-"Catalogue</p><ul><li>Request permission to use a subsystem by using the "
-"predefined electronic form in the API Catalogue.</li></ul><p style=\"font-"
-"weight: bold;\">Organisation’s downloadable application "
-"(PDF)</p><ul><li>Upload your organisation's own PDF form to the API "
-"Catalogue that can be used to request permission to use the subsystem. The "
-"applicant must download the form from the API Catalogue and send the "
-"completed form to the email address you specified.</li><li>In the form, "
-"explain to which email address the form should be returned "
-"to.</li><li>Access requests sent in this way will not appear in the API "
-"Catalogue.</li></ul><p style=\"font-weight: bold;\">Link to the access "
-"licence application on the organisation's website</p><ul><li>Enter the URL "
-"for your organisation’s web page where the person requesting access can "
-"apply for access to your organisation’s services.</li><li>Access requests "
-"sent in this way will not appear in the API Catalogue.</li></ul><p>For more "
-"information on the administration of access rights, see the instructions in "
-"the<a target=\"_blank\" href=\"https://liityntakatalogi.suomi.fi/\">API "
-"Catalogue.</a></p>"
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
+msgid "Additional info"
 msgstr ""
-"<p style=\"font-weight: bold;\">Färdig tillståndsansökan för API-"
-"katalogen</p><ul><li>Användningstillstånd söks med en färdig elektronisk "
-"blankett i API-katalogen.</li></ul><p style=\"font-weight: bold;\">Egen "
-"tillståndsansökan (PDF)</p><ul><li>Ladda upp din organisations egen PDF-"
-"blankett i API-katalogen för ansökan om användningstillstånd för "
-"subsystemet. Den som begär tillstånd laddar ner blanketten från API-"
-"katalogen och skickar den ifyllda blanketten till den e-postadress du "
-"angett.</li><li>Ange på blanketten till vilken e-postadress blanketten ska "
-"returneras.</li><li>Begäran om tillstånd som skickats på detta sätt syns "
-"inte i API-katalogen.</li></ul><p style=\"font-weight: bold;\">Länk till "
-"tillståndsansökan på organisationens webbplats</p><ul><li>Ange URL-adressen "
-"till din organisations webbplats där den som begär tillstånd kan ansöka om "
-"användningstillstånd för subsystemet.</li><li>Begäran om tillstånd som "
-"skickats på detta sätt syns inte i API-katalogen.</li></ul><p>Läs mer om "
-"administrering av användningstillstånd i anvisningarna i<a target=\"_blank\""
-" href=\"https://liityntakatalogi.suomi.fi/\">API-katalogen.</a></p>"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
+msgid "Sending additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
+msgid ""
+"Requested subsystem is managed by a company that requires additional info"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
+msgid "1. Download file and fill required information"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
+msgid "Download"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
+msgid "2. Add completed file into the application"
+msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:5
 msgid "Permission management"
@@ -355,21 +412,3 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
 msgstr "Administrerar tillståndsbegäran"
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:41
-msgid ""
-"Applying organization acts as an intermediary on behalf of the organizations"
-" using the services"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:51
-msgid "Information about the organization consuming the services"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:64
-msgid "Y-number"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:55
-msgid "Organization using the services"
-msgstr ""

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -171,7 +171,8 @@ def service_permission_settings_update(context, data_dict):
         raise NotFound
 
     settings = {field: data_dict[field]
-                for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename', 'require_additional_application_file', 'additional_file_url', 'original_additional_filename')
+                for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename',
+                              'require_additional_application_file', 'additional_file_url', 'original_additional_filename')
                 if field in data_dict}
 
     tk.get_action('package_patch')(context, {

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -171,7 +171,7 @@ def service_permission_settings_update(context, data_dict):
         raise NotFound
 
     settings = {field: data_dict[field]
-                for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename')
+                for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename', 'require_additional_application_file', 'additional_file_url', 'original_additional_filename')
                 if field in data_dict}
 
     tk.get_action('package_patch')(context, {

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -103,7 +103,7 @@
   {% endcall %}
 
   <div class="select-wrapper">
-    {{ form.select('subsystemCode', label=_('Subsystem code'), options=subsystem_options, is_required=True, selected=values.subsystem_code) }}
+    {{ form.select_with_description('subsystemCode', description=_('Select the subsystem of your organization for which you want to apply permission'), label=_('Subsystem code'), options=subsystem_options, is_required=True, selected=values.subsystem_code) }}
   </div>
 
   <hr>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -133,8 +133,7 @@
   {{ form.input('requestDate', type='date', label=_('Date when access is needed'), value=values.request_date) }}
 
   <hr>
-
-  {% if pkg.get('service_permission_settings', {}).get('delivery_method') == 'file' %}
+  {% if pkg.get('service_permission_settings', {}).get('delivery_method') == 'email' and pkg.get('service_permission_settings', {}).get('require_additional_application_file') == True %}
     {% snippet "apply_permissions_for_service/snippets/additional_application_info.html", pkg=pkg, errors=errors %}
 
     <hr>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -139,7 +139,9 @@
 
     <hr>
   {% endif %}
-  <input class="btn btn-primary" type="submit" value="{{ _('Send access application') }}"></input>
-  <a class="btn btn-secondary">{{ _('Cancel') }}</a>
+  {% block application_form_actions %}
+    <input class="btn btn-primary" type="submit" value="{{ _('Send access application') }}"></input>
+    <a class="btn btn-secondary">{{ _('Cancel') }}</a>
+  {% endblock %}
 </form>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html
@@ -1,0 +1,14 @@
+{% extends 'apply_permissions_for_service/new.html' %}
+
+{% block prelude %}
+<h1>{{ _('Preview permission application') }}</h1>
+<div class="banner-status banner-status--info">
+    <span>{{ _('You are previewing permission from applicants point of view') }}</span>
+    <a class="btn btn-outline-white" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Exit from preview') }}</a>
+</div>
+
+{% endblock %}
+
+{% block application_form_actions %}
+    <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Exit from preview') }}</a>
+{% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html
@@ -4,11 +4,11 @@
 <h1>{{ _('Preview permission application') }}</h1>
 <div class="banner-status banner-status--info">
     <span>{{ _('You are previewing permission from applicants point of view') }}</span>
-    <a class="btn btn-outline-white" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Exit from preview') }}</a>
+    <button class="btn btn-outline-white" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}" onclick="window.close()">{{ _('Exit from preview') }}</button>
 </div>
 
 {% endblock %}
 
 {% block application_form_actions %}
-    <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Exit from preview') }}</a>
+    <button class="btn btn-primary" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}" onclick="window.close()">{{ _('Exit from preview') }}</button>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -54,7 +54,8 @@
         </div>
         <div class="module__actions">
           <button class="btn btn-primary" type="submit">{{ _('Save') }}</button>
-          <a class="btn btn-default">{{ _('Cancel') }}</a>
+          <a class="btn btn-default" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Cancel') }}</a>
+          <a class="btn btn-default btn--preview" href="{{ h.url_for('apply_permissions.preview_permission_application', subsystem_id=pkg.name) }}">{{ _('Preview application') }}</a>
         </div>
 
         <div class="module__settings-instructions">

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -27,7 +27,7 @@
           </div>
           <div data-mutex-field="deliveryMethod">
              <div data-mutex-value="email">
-                  {{ form.input('email', label=_('Application in API Catalogue'), value=settings.email) }}
+                  {{ form.input('email', label=_('Email'), value=settings.email) }}
                   <div class="additional_application_file_container">
                     <script>
                       function listenAdditionalFileCheckbox(event) {

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -49,6 +49,10 @@
                     {{ form.checkbox('require_additional_application_file', label=_('Request additional info with an attachment'), id='additional_application_file', value='True', checked=settings.require_additional_application_file) }}
 
                     <div id="additional_application_file_field">
+                      {% if settings.get('original_additional_filename', False) %}
+                        {{ form.hidden('original_additional_filename', value=settings.original_additional_filename) }}
+                      {% endif %}
+                      
                       {% set is_upload_additional_file = settings.additional_file_url and not settings.additional_file_url.startswith('http') %}
                       {% set is_url_additional_file = settings.additional_file_url and settings.additional_file_url.startswith('http') %}
                       {{ form.image_upload_dragndrop(
@@ -69,6 +73,10 @@
                   </div>
              </div>
             <div data-mutex-value="file">
+              {% if settings.get('original_filename', False) %}
+                {{ form.hidden('original_filename', value=settings.original_filename) }}
+              {% endif %}
+              
               {% set is_upload = settings.file_url and not settings.file_url.startswith('http') %}
               {% set is_url = settings.file_url and settings.file_url.startswith('http') %}
               {{ form.image_upload_dragndrop(

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -20,14 +20,53 @@
           <div class="select-wrapper">
             {{ form.select('deliveryMethod', label=_('Delivery method for access requests'), options=[
             {'value': 'none', 'text': _('Disable access requests for this API')},
-            {'value': 'email', 'text': _('E-mail')},
-            {'value': 'file', 'text': _('Upload your access request file')},
-            {'value': 'web', 'text': _('Access is requested on a web page managed by my organization')},
+            {'value': 'email', 'text': _('Application in API Catalogue')},
+            {'value': 'file', 'text': _('Organisation’s downloadable application (PDF)')},
+            {'value': 'web', 'text': _('Link to the access licence application on the organisation\'s website')},
             ], is_required=True, selected=(settings.delivery_method or 'none')) }}
           </div>
           <div data-mutex-field="deliveryMethod">
              <div data-mutex-value="email">
-                  {{ form.input('email', label=_('Email address'), value=settings.email) }}
+                  {{ form.input('email', label=_('Application in API Catalogue'), value=settings.email) }}
+                  <div class="additional_application_file_container">
+                    <script>
+                      function listenAdditionalFileCheckbox(event) {
+                        var fileField = document.querySelector('#additional_application_file_field');
+
+                        fileField.style.display = event.target.checked ? 'block' : 'none';
+                      }
+
+                      window.addEventListener('DOMContentLoaded', function(event) {
+                        var checkboxAdditionalFile = document.querySelector('#additional_application_file');
+                        checkboxAdditionalFile.addEventListener('change', listenAdditionalFileCheckbox);
+
+                        if (!checkboxAdditionalFile.checked) {
+                          var fileField = document.querySelector('#additional_application_file_field');
+                          fileField.style.display = 'none';
+                        }
+                      })
+                    </script>
+                    {{ form.checkbox('require_additional_application_file', label=_('Request additional info with an attachment'), id='additional_application_file', value='True', checked=settings.require_additional_application_file) }}
+
+                    <div id="additional_application_file_field">
+                      {% set is_upload_additional_file = settings.additional_file_url and not settings.additional_file_url.startswith('http') %}
+                      {% set is_url_additional_file = settings.additional_file_url and settings.additional_file_url.startswith('http') %}
+                      {{ form.image_upload_dragndrop(
+                          settings,
+                          errors,
+                          upload_label=_('Add your file'),
+                          is_upload_enabled=h.uploads_enabled(),
+                          is_url=is_url_additional_file,
+                          is_upload=is_upload_additional_file,
+                          field_url='additional_file_url',
+                          field_upload='file',
+                          field_clear='additional_file_clear_upload',
+                          max_filesize=h.max_resource_size(),
+                          max_total_size=h.max_resource_size()
+                          )
+                      }}
+                    </div>
+                  </div>
              </div>
             <div data-mutex-value="file">
               {% set is_upload = settings.file_url and not settings.file_url.startswith('http') %}
@@ -50,12 +89,12 @@
             <div data-mutex-value="web">
               {{ form.input('web', label=_('Webpage URL'), value=settings.web) }}
             </div>
+            <div class="module__actions">
+              <button class="btn btn-primary" type="submit">{{ _('Save') }}</button>
+              <a class="btn btn-default" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Cancel') }}</a>
+              <a data-mutex-value="email" class="btn btn-default btn--preview" href="{{ h.url_for('apply_permissions.preview_permission_application', subsystem_id=pkg.name) }}" target="_blank">{{ _('Preview application') }}</a>
+            </div>
           </div>
-        </div>
-        <div class="module__actions">
-          <button class="btn btn-primary" type="submit">{{ _('Save') }}</button>
-          <a class="btn btn-default" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Cancel') }}</a>
-          <a class="btn btn-default btn--preview" href="{{ h.url_for('apply_permissions.preview_permission_application', subsystem_id=pkg.name) }}">{{ _('Preview application') }}</a>
         </div>
 
         <div class="module__settings-instructions">

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
@@ -7,9 +7,9 @@
 <div class="additional_application_info--download">
     <div class="application-file">
         <i class="fal fa-file-alt"></i>
-        {{ pkg.get('service_permission_settings', {}).get('original_filename') }}
+        {{ pkg.get('service_permission_settings', {}).get('original_additional_filename') }}
     </div>
-    <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('file_url') }}">
+    <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('additional_file_url') }}">
         <i class="far fa-arrow-to-bottom"></i>
         {{ _('Download') }}
     </a>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
@@ -1,31 +1,36 @@
 {% import 'macros/form.html' as form %}
 
 
-<h3>{{ _('Sending additional info') }}</h3>
-<p>{{ _('Requested subsystem is managed by a company that requires additional info') }}</p>
-<h4>{{ _('1. Download file and fill required information') }}</h4>
-<div class="additional_application_info--download">
-    <div class="application-file">
-        <i class="fal fa-file-alt"></i>
-        {{ pkg.get('service_permission_settings', {}).get('original_additional_filename') }}
+<div class="additional_application_info_step">
+    <h3>{{ _('Sending additional info') }}</h3>
+    <p>{{ _('Requested subsystem is managed by a company that requires additional info') }}</p>
+    <h4>{{ _('1. Download file and fill required information') }}</h4>
+    <div class="additional_application_info--download">
+        <div class="application-file">
+            <i class="fal fa-file-alt"></i>
+            {{ pkg.get('service_permission_settings', {}).get('original_additional_filename') }}
+        </div>
+        <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('additional_file_url') }}">
+            <i class="far fa-arrow-to-bottom"></i>
+            {{ _('Download') }}
+        </a>
     </div>
-    <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('additional_file_url') }}">
-        <i class="far fa-arrow-to-bottom"></i>
-        {{ _('Download') }}
-    </a>
 </div>
-<h4>{{ _('2. Add completed file into the application') }}</h4>
-{{ form.image_upload_dragndrop(
-    {},
-    errors,
-    upload_label=_('Add your file'),
-    is_upload_enabled=h.uploads_enabled(),
-    is_url=is_url,
-    is_upload=is_upload,
-    field_url='file_url',
-    field_upload='file',
-    field_clear='clear_upload',
-    max_filesize=h.max_resource_size(),
-    max_total_size=h.max_resource_size()
-    )
-}}
+
+<div class="additional_application_info_step">
+    <h4>{{ _('2. Add completed file into the application') }}</h4>
+    {{ form.image_upload_dragndrop(
+        {},
+        errors,
+        upload_label=_('Add your file'),
+        is_upload_enabled=h.uploads_enabled(),
+        is_url=is_url,
+        is_upload=is_upload,
+        field_url='file_url',
+        field_upload='file',
+        field_clear='clear_upload',
+        max_filesize=h.max_resource_size(),
+        max_total_size=h.max_resource_size()
+        )
+    }}
+</div>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -187,12 +187,12 @@ def settings_post(context, subsystem_id):
         'api': form.get('api'),
         'file': files.get('file'),
         'file_url': form.get('file_url'),
-        'original_filename': form.get('file_url'),
+        'original_filename': form.get('original_filename'),
         'clear_upload': form.get('clear_upload'),
         'web': form.get('web'),
         'require_additional_application_file': toolkit.asbool(form.get('require_additional_application_file')),
         'additional_file_url': form.get('additional_file_url'),
-        'original_additional_filename': form.get('additional_file_url'),
+        'original_additional_filename': form.get('original_additional_filename'),
         'additional_file_clear_upload': form.get('additional_file_clear_upload'),
     }
 
@@ -208,6 +208,8 @@ def settings_post(context, subsystem_id):
 
         file_url = data_dict.get('file_url', '')
         if re.match('https?:', file_url) is None:
+            # File has been updated, so update filename too
+            data_dict['original_filename'] = file_url
             file_url = h.url_for_static(
                 'uploads/apply_permission/%s' % file_url,
                 qualified=True
@@ -221,6 +223,8 @@ def settings_post(context, subsystem_id):
 
         additional_file_url = data_dict.get('additional_file_url', '')
         if re.match('https?:', additional_file_url) is None:
+            # File has been updated, so update filename too
+            data_dict['original_additional_filename'] = additional_file_url
             additional_file_url = h.url_for_static(
                 'uploads/apply_permission/%s' % additional_file_url,
                 qualified=True

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -71,7 +71,7 @@ def new_post(context, subsystem_id):
     return toolkit.render('apply_permissions_for_service/sent.html')
 
 
-def new_get(context, subsystem_id, errors={}, values={}):
+def new_get(context, subsystem_id, errors={}, values={}, preview=False):
     service_id = toolkit.request.args.get('service_id')
     package = toolkit.get_action('package_show')(context, {'id': subsystem_id})
 
@@ -101,6 +101,10 @@ def new_get(context, subsystem_id, errors={}, values={}):
             'values': values,
             'errors': errors
             }
+
+    if preview:
+        return toolkit.render('apply_permissions_for_service/preview.html', extra_vars=extra_vars)
+
     return toolkit.render('apply_permissions_for_service/new.html', extra_vars=extra_vars)
 
 
@@ -124,6 +128,15 @@ def view(application_id):
         application = toolkit.get_action('service_permission_application_show')(context, data_dict)
         extra_vars = {'application': application}
         return toolkit.render('apply_permissions_for_service/view.html', extra_vars=extra_vars)
+    except toolkit.NotAuthorized:
+        toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
+
+
+def preview(subsystem_id):
+    try:
+        context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
+        toolkit.check_access('service_permission_application_create', context, {})
+        return new_get(context, subsystem_id, preview=True)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
@@ -220,6 +233,7 @@ def settings(subsystem_id):
 apply_permissions.add_url_rule('/', 'list_permission_applications', view_func=index)
 apply_permissions.add_url_rule('/new/<subsystem_id>', 'new_permission_application', view_func=new, methods=['GET', 'POST'])
 apply_permissions.add_url_rule('/view/<application_id>', 'view_permission_application', view_func=view)
+apply_permissions.add_url_rule('/preview/<subsystem_id>', 'preview_permission_application', view_func=preview)
 apply_permissions.add_url_rule('/manage/<subsystem_id>', 'manage_permission_applications', view_func=manage)
 apply_permissions.add_url_rule('/settings/<subsystem_id>', 'permission_application_settings',
                                view_func=settings, methods=['GET', 'POST'])


### PR DESCRIPTION
# Description
Implement a new view for permission application form preview.

## Jira ticket reference: [LIKA-433](https://jira.dvv.fi/browse/LIKA-433)

## What has changed:
- Added new route on apply_permission-plugin
- Added new template for preview

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.
![Screenshot from 2022-04-12 10-38-19](https://user-images.githubusercontent.com/13560443/162906784-4b611ec2-fbd4-44d3-965d-a8eb8a264013.png)
![Screenshot from 2022-04-12 10-38-06](https://user-images.githubusercontent.com/13560443/162906791-ca13fa7f-4f0f-4613-8870-befcf7d8749d.png)

