### PR TITLE
LIKA-231: Fix error about undefined group_dict in new group form

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/group/new.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/group/new.html
@@ -1,0 +1,2 @@
+{% extends "group/base_form_page.html" %}
+{% set group_dict = group_dict or {} %}


### PR DESCRIPTION
# Description
CKAN template for new group form gives an error about undefined group_dict so this defines that as an empty dict if it's not already defined

## Jira ticket reference: [LIKA-231](https://jira.dvv.fi/browse/LIKA-231)

## What has changed:
- Override group/new template with definition of group_dict if it's undefined

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

