### PR TITLE
Fix provision on vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
        ansible.inventory_path = "ansible/inventories/vagrant"
        ansible.config_file = "ansible/ansible.cfg"
        ansible.limit = "all"
-       ansible.pip_install_cmd = "sudo apt-get install -y python3-distutils && curl -s https://bootstrap.pypa.io/get-pip.py | sudo python3"
+       ansible.pip_install_cmd = "sudo apt-get install -y python3-distutils && curl -s https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo python3"
        ansible.install_mode = "pip"
     end
     server.vm.provider "virtualbox" do |vbox|

--- a/ansible/roles/ckan/tasks/database.yml
+++ b/ansible/roles/ckan/tasks/database.yml
@@ -38,10 +38,6 @@
 - name: Migrate Link Validation database
   shell: ./bin/ckan --config {{ ckan_ini }} links migrate chdir={{ virtualenv }}
 
-- name: Initialize service permission application database
-  shell: ./bin/ckan --config "{{ ckan_ini }}" apply-permissions init chdir={{ virtualenv }}
-  when: "'apply_permissions_for_service' in ckan_plugins"
-
 - name: Initialize users for organization database
   shell: ./bin/ckan --config "{{ ckan_ini }}" apicatalog-database init chdir={{ virtualenv }}
 
@@ -53,3 +49,4 @@
 
 - name: Migrate apply-permissions database
   shell: ./bin/ckan --config {{ ckan_ini }} db upgrade -p apply_permissions_for_service chdir={{ virtualenv }}
+  when: "'apply_permissions_for_service' in ckan_plugins"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/cli.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/cli.py
@@ -7,12 +7,5 @@ def apply_permissions():
     pass
 
 
-@apply_permissions.command()
-def init():
-    import ckan.model as model
-    from ckanext.apply_permissions_for_service.model import init_table
-    init_table(model.meta.engine)
-
-
 def get_commands():
     return [apply_permissions]

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/09e3ebeb1e37_create_apply_permissions_table.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/09e3ebeb1e37_create_apply_permissions_table.py
@@ -17,8 +17,10 @@ down_revision = None
 branch_labels = None
 depends_on = None
 
+
 def make_uuid():
     return str(uuid.uuid4())
+
 
 def upgrade():
     op.create_table('apply_permission',
@@ -38,7 +40,5 @@ def upgrade():
                     )
 
 
-
 def downgrade():
     op.drop_table('apply_permission')
-

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/09e3ebeb1e37_create_apply_permissions_table.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/09e3ebeb1e37_create_apply_permissions_table.py
@@ -1,0 +1,44 @@
+"""Create apply permissions table
+
+Revision ID: 09e3ebeb1e37
+Revises:
+Create Date: 2022-04-21 12:29:11.376163
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import uuid
+
+# revision identifiers, used by Alembic.
+
+
+revision = '09e3ebeb1e37'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def make_uuid():
+    return str(uuid.uuid4())
+
+def upgrade():
+    op.create_table('apply_permission',
+                    sa.Column('id', sa.types.UnicodeText, primary_key=True, default=make_uuid),
+                    sa.Column('organization_id', sa.types.UnicodeText, nullable=False),
+                    sa.Column('target_organization_id', sa.types.UnicodeText, nullable=False),
+                    sa.Column('business_code', sa.types.UnicodeText, nullable=False),
+                    sa.Column('contact_name', sa.types.UnicodeText, nullable=False),
+                    sa.Column('contact_email', sa.types.UnicodeText, nullable=False),
+                    sa.Column('ip_address_list', sa.types.JSON, nullable=False),
+                    sa.Column('subsystem_id', sa.types.UnicodeText, nullable=False),
+                    sa.Column('subsystem_code', sa.types.UnicodeText, nullable=False),
+                    sa.Column('service_code_list', sa.types.JSON, nullable=False),
+
+                    sa.Column('usage_description', sa.types.UnicodeText),
+                    sa.Column('request_date', sa.types.Date),
+                    )
+
+
+
+def downgrade():
+    op.drop_table('apply_permission')
+

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/13981b4847ac_add_intermediate_organization_columns.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/13981b4847ac_add_intermediate_organization_columns.py
@@ -1,8 +1,8 @@
-"""Add application file
+"""Add intermediate organization columns
 
-Revision ID: e2fdr852000b
-Revises:
-Create Date: 2022-04-08 11:45:38.997096
+Revision ID: 13981b4847ac
+Revises: e7cd24026024
+Create Date: 2022-04-21 13:08:26.718811
 
 """
 from alembic import op
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'e2fdr852000b'
-down_revision = 'e2fce751960a'
+revision = '13981b4847ac'
+down_revision = 'e7cd24026024'
 branch_labels = None
 depends_on = None
 
@@ -19,10 +19,10 @@ depends_on = None
 def upgrade():
     op.add_column('apply_permission', sa.Column('intermediate_organization_id', sa.String(255), nullable=True))
     op.add_column('apply_permission', sa.Column('intermediate_business_code', sa.String(255), nullable=True))
-    pass
+
 
 
 def downgrade():
     op.drop_column('apply_permission', 'intermediate_organization_id')
     op.drop_column('apply_permission', 'intermediate_business_code')
-    pass
+

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/13981b4847ac_add_intermediate_organization_columns.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/13981b4847ac_add_intermediate_organization_columns.py
@@ -21,8 +21,6 @@ def upgrade():
     op.add_column('apply_permission', sa.Column('intermediate_business_code', sa.String(255), nullable=True))
 
 
-
 def downgrade():
     op.drop_column('apply_permission', 'intermediate_organization_id')
     op.drop_column('apply_permission', 'intermediate_business_code')
-

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/e7cd24026024_add_application_file_column.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/e7cd24026024_add_application_file_column.py
@@ -20,6 +20,5 @@ def upgrade():
     op.add_column('apply_permission', sa.Column('application_filename', sa.String(255), nullable=True))
 
 
-
 def downgrade():
     op.drop_column('apply_permission', 'application_filename')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/e7cd24026024_add_application_file_column.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/e7cd24026024_add_application_file_column.py
@@ -1,8 +1,8 @@
-"""Add application file
+"""Add application file column
 
-Revision ID: e2fce751960a
-Revises:
-Create Date: 2022-03-30 09:36:38.997096
+Revision ID: e7cd24026024
+Revises: 09e3ebeb1e37
+Create Date: 2022-04-21 13:07:44.485191
 
 """
 from alembic import op
@@ -10,17 +10,16 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'e2fce751960a'
-down_revision = None
+revision = 'e7cd24026024'
+down_revision = '09e3ebeb1e37'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     op.add_column('apply_permission', sa.Column('application_filename', sa.String(255), nullable=True))
-    pass
+
 
 
 def downgrade():
     op.drop_column('apply_permission', 'application_filename')
-    pass

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -91,6 +91,4 @@ class ApplyPermission(Base):
         return application_dict
 
 
-def init_table(engine):
-    Base.metadata.create_all(engine)
-    log.info("Table for applying permissions is set-up")
+

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -89,6 +89,3 @@ class ApplyPermission(Base):
             {'ignore_auth': True}, {'id': application_dict['intermediate_organization_id']})
 
         return application_dict
-
-
-


### PR DESCRIPTION
# Description
Fixes various issues when building a new environment.

## What has changed:
Installs pip for python 3.6 to allow install of ansible.
Moves creation of apply_permission table to alembic and re-creates migrations. This is the current recommendation of ckan and running migrations to database which already had the columns failed. This requires dropping of existing tables in environments but this should not matter as the feature is not really released to end users yet.


## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

