### PR TITLE
LIKA-456: Store sessions into the database

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -107,6 +107,14 @@
     - { src: wsgi.py, dest: "{{ ckan_wsgi_script }}", mode: "0640", owner: root, group: "{{ www_group }}" }
     - { src: ckan-uwsgi.ini.j2, dest: "{{ ckan_uwsgi_conf }}", mode: "0640", owner: root, group: "{{ www_group }}" }
 
+- name: Setup beaker session cleanup script
+  template:
+    src: "beaker_session_cleanup.sh.j2"
+    dest: "/usr/local/sbin/beaker_session_cleanup.sh"
+    mode: "0500"
+    owner: root
+    group: "root"
+
 - name: Install CKAN frontend requirements
   shell: npm install --only=prod chdir={{ virtualenv }}/src/ckan
 
@@ -166,6 +174,13 @@
     minute: "0"
     hour: "0"
     job: "find /tmp/default/sessions -type f -mtime +3 -print -exec rm {} ';'"
+
+- name: Remove old beaker sessions from beaker_cache table
+  cron:
+    name: "Remove old beaker sessions"
+    minute: "0"
+    hour: "3"
+    job: "/usr/local/sbin/beaker_session_cleanup.sh > /dev/null 2>&1"
 
 - name: Modify allowed robots
   template:

--- a/ansible/roles/ckan/templates/beaker_session_cleanup.sh.j2
+++ b/ansible/roles/ckan/templates/beaker_session_cleanup.sh.j2
@@ -1,0 +1,12 @@
+#!/bin/bash
+psql --quiet postgres://{{ database_ckan.username }}:{{ database_ckan.password }}@{{ database_ckan.host }}/{{ database_ckan.name }} << EOF
+DO \$\$
+    BEGIN
+        IF EXISTS
+            (select 1 from pg_tables where tablename = 'beaker_cache')
+        THEN
+            delete from beaker_cache where accessed < NOW()-'7  day'::interval;
+        END IF;
+    END
+\$\$ ;
+EOF

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -19,6 +19,8 @@ beaker.session.secret = {{ secret.ckan_config.beaker_session_secret }}
 beaker.session.secure = True
 beaker.session.httponly = True
 beaker.session.samesite = Strict
+beaker.session.type = ext:database
+beaker.session.url = postgres://{{ database_ckan.username }}:{{ database_ckan.password }}@{{ database_ckan.host }}/{{ database_ckan.name }}
 
 app_instance_uuid = {{ secret.ckan_config.app_instance_uuid }}
 


### PR DESCRIPTION
# Description
Change configs to use database based sessions and add cleanup script for beaker sessions. Also configure cron job for cleanup script


## Jira ticket reference: [LIKA-456](https://jira.dvv.fi/browse/LIKA-456)

## What has changed:
- Ckan configurations session type
- New script to clean deprecated sessions from database
- Added new cron job in ansible configuration

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

