### PR TITLE
LIKA-357: Fix attachments-list in resource view

### DIFF
--- a/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/snippets/resources.html
+++ b/ckanext/ckanext-apicatalog_ui/ckanext/apicatalog_ui/templates/package/snippets/resources.html
@@ -5,7 +5,7 @@
     {% for resource in resources %}
       <li class="nav-item{{ ' active' if active == resource.id }}">
         {% set service_type = ' (' + resource.xroad_service_type|upper + ')' if resource.xroad_service_type and resource.xroad_service_type else '' %}
-        {% link_for h.resource_display_name(resource)|truncate(25) + service_type, 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
+        {% link_for h.resource_display_name(resource) + service_type, 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
       </li>
     {% endfor %}
   </ul>

--- a/ckanext/ckanext-apicatalog_ui/less/dataset.less
+++ b/ckanext/ckanext-apicatalog_ui/less/dataset.less
@@ -320,6 +320,7 @@
         a {
           overflow: hidden;
           text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
     }


### PR DESCRIPTION
Prevent line-breaks on attachments name so that overflow attribute works as expected

# Description
Add description of PR here.

## Jira ticket reference: [LIKA-357](https://jira.dvv.fi/browse/LIKA-357)

## What has changed:
- Added css to prevent line breaks on attachments name in resource view
- Removed python based truncate from attachments-list as it's done by css now

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

