### PR TITLE
LIKA-413: allow intermediate organization to be empty if not empty add relevant information to permission view and notification email

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -50,8 +50,8 @@ def service_permission_application_create(context, data_dict):
     if service_code_list is None or service_code_list == "":
         errors['service_code_list'] = _('Missing value')
 
-    intermediate_organization_id = data_dict.get('intermediate_organization_id')
-    intermediate_business_code = data_dict.get('intermediate_business_code')
+    intermediate_organization_id = data_dict.get('intermediate_organization_id') or None
+    intermediate_business_code = data_dict.get('intermediate_business_code') or None
 
     if errors:
         raise tk.ValidationError(errors)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -50,8 +50,8 @@ def service_permission_application_create(context, data_dict):
     if service_code_list is None or service_code_list == "":
         errors['service_code_list'] = _('Missing value')
 
-    intermediate_organization_id = data_dict.get('intermediate_organization_id') or None
-    intermediate_business_code = data_dict.get('intermediate_business_code') or None
+    intermediate_organization_id = data_dict.get('intermediate_organization_id')
+    intermediate_business_code = data_dict.get('intermediate_business_code')
 
     if errors:
         raise tk.ValidationError(errors)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -86,8 +86,7 @@ class ApplyPermission(Base):
         application_dict['target_organization'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['target_organization_id']})
 
-        if "intermediate_organization_id" in application_dict \
-                and application_dict['intermediate_organization_id'] is not None:
+        if application_dict.get('intermediate_organization_id'):
             try:
                 application_dict['intermediate_organization'] = toolkit.get_action('organization_show')(
                     {'ignore_auth': True}, {'id': application_dict['intermediate_organization_id']})

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -86,8 +86,8 @@ class ApplyPermission(Base):
         application_dict['target_organization'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['target_organization_id']})
 
-        if "intermediate_organization_id" in application_dict and \
-            application_dict['intermediate_organization_id'] is not None:
+        if "intermediate_organization_id" in application_dict \
+                and application_dict['intermediate_organization_id'] is not None:
             try:
                 application_dict['intermediate_organization'] = toolkit.get_action('organization_show')(
                     {'ignore_auth': True}, {'id': application_dict['intermediate_organization_id']})

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -3,6 +3,7 @@ import uuid
 
 from ckan import model
 from ckan.lib import dictization
+from ckan.logic import NotFound
 from ckan.plugins import toolkit
 from sqlalchemy import Column, types
 from sqlalchemy.ext.declarative import declarative_base
@@ -85,7 +86,12 @@ class ApplyPermission(Base):
         application_dict['target_organization'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['target_organization_id']})
 
-        application_dict['intermediate_organization'] = toolkit.get_action('organization_show')(
-            {'ignore_auth': True}, {'id': application_dict['intermediate_organization_id']})
+        if "intermediate_organization_id" in application_dict and \
+            application_dict['intermediate_organization_id'] is not None:
+            try:
+                application_dict['intermediate_organization'] = toolkit.get_action('organization_show')(
+                    {'ignore_auth': True}, {'id': application_dict['intermediate_organization_id']})
+            except NotFound:
+                pass
 
         return application_dict

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -28,6 +28,14 @@
       <li>Yhteyshenkilön sähköposti: {{ application.contact_email }}</li>
     </ul>
   </p>
+    {% if "intermediate_organization" in application %}
+    <p><strong>Palveluita käyttävän organisaatioin tiedot:</strong>
+        <ul>
+        <li>Organisaatio: {{ application.intermediate_organization['title'] }}</li>
+        <li>Yritystunnus: {{ application.intermediate_business_code }}</li>
+        </ul>
+    </p>
+  {% endif %}
   <p><strong>Luvan pyytäjän alijärjestelmän tiedot:</strong>
     <ul>
       <li>Alijärjestelmän tunnus: {{ h.xroad_subsystem_path(application.requester_subsystem) or h.get_translated(application.requester_subsystem, 'title') }}</li>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -22,6 +22,22 @@
     </tbody>
   </table>
 
+  {% if "intermediate_organization" in application %}
+    <hr>
+    <h3>{{ _('Information about the organization consuming the services') }}</h3>
+    <table class="table">
+      <tbody>
+        <tr>
+            <th>{{ _('Organization') }}</th>
+            <td>{{ h.get_translated(application.intermediate_organization, 'title') }}</td>
+        </tr>
+        <tr>
+            <th>{{ _('Business code') }}</th>
+            <td>{{ application.intermediate_business_code }}</td>
+        </tr>
+    </tbody>
+    </table>
+  {% endif %}
   <hr>
 
   <h3>{{ _('Details of your Security Server and Subsystem') }}</h3>


### PR DESCRIPTION
Allow intermediate organization to be empty if not empty add relevant information to permission view and notification email

# Description
Allow intermediate organization to be empty if not empty add relevant information to permission view and notification email.

## Jira ticket reference: [LIKA-413](https://jira.dvv.fi/browse/LIKA-413)

## What has changed:
Allow intermediate organization to be empty if not empty add relevant information to permission view and notification email

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.

