### PR TITLE
LIKA-415: Support additional permission application file in email

### DIFF
--- a/ansible/roles/ckan/files/patches/email_attachment.patch
+++ b/ansible/roles/ckan/files/patches/email_attachment.patch
@@ -1,0 +1,188 @@
+diff --git a/ckan/lib/mailer.py b/ckan/lib/mailer.py
+index 780dffd72..8a7e3053f 100644
+--- a/ckan/lib/mailer.py
++++ b/ckan/lib/mailer.py
+@@ -5,10 +5,10 @@ import os
+ import smtplib
+ import socket
+ import logging
++import mimetypes
+ from time import time
+-from email.mime.multipart import MIMEMultipart
+-from email.mime.text import MIMEText
+-from email.header import Header
++
++from email.message import EmailMessage
+ from email import utils
+ 
+ from ckan.common import config
+@@ -31,29 +31,31 @@ class MailerException(Exception):
+ 
+ def _mail_recipient(recipient_name, recipient_email,
+                     sender_name, sender_url, subject,
+-                    body, body_html=None, headers=None):
++                    body, body_html=None, headers=None,
++                    attachments=None):
+ 
+     if not headers:
+         headers = {}
+ 
+-    mail_from = config.get('smtp.mail_from')
+-    reply_to = config.get('smtp.reply_to')
++    if not attachments:
++        attachments = []
++
++    mail_from = config.get('smtp.mail_from')
++    reply_to = config.get('smtp.reply_to')
++
++    msg = EmailMessage()
++
++    msg.set_content(body, cte='base64')
++
+     if body_html:
+-        # multipart
+-        msg = MIMEMultipart('alternative')
+-        part1 = MIMEText(body.encode('utf-8'), 'plain', 'utf-8')
+-        part2 = MIMEText(body_html.encode('utf-8'), 'html', 'utf-8')
+-        msg.attach(part1)
+-        msg.attach(part2)
+-    else:
+-        # just plain text
+-        msg = MIMEText(body.encode('utf-8'), 'plain', 'utf-8')
++        msg.add_alternative(body_html, subtype='html', cte='base64')
++
+     for k, v in headers.items():
+         if k in msg.keys():
+             msg.replace_header(k, v)
+         else:
+             msg.add_header(k, v)
+-    subject = Header(subject.encode('utf-8'), 'utf-8')
++
+     msg['Subject'] = subject
+     msg['From'] = _("%s <%s>") % (sender_name, mail_from)
+     msg['To'] = u"%s <%s>" % (recipient_name, recipient_email)
+@@ -62,6 +64,23 @@ def _mail_recipient(recipient_name, recipient_email,
+     if reply_to and reply_to != '':
+         msg['Reply-to'] = reply_to
+ 
++    for attachment in attachments:
++        if len(attachment) == 3:
++            name, _file, media_type = attachment
++        else:
++            name, _file = attachment
++            media_type = None
++
++        if not media_type:
++            media_type, encoding = mimetypes.guess_type(name)
++        if media_type:
++            main_type, sub_type = media_type.split('/')
++        else:
++            main_type = sub_type = None
++
++        msg.add_attachment(
++            _file.read(), filename=name, maintype=main_type, subtype=sub_type)
++
+     # Send the email using Python's smtplib.
+     if 'smtp.test_server' in config:
+         # If 'smtp.test_server' is configured we assume we're running tests,
+@@ -115,22 +134,72 @@ def _mail_recipient(recipient_name, recipient_email,
+         smtp_connection.quit()
+ 
+ 
+-def mail_recipient(recipient_name, recipient_email, subject,
+-                   body, body_html=None, headers={}):
+-    '''Sends an email'''
+-    site_title = config.get('ckan.site_title')
+-    site_url = config.get('ckan.site_url')
+-    return _mail_recipient(recipient_name, recipient_email,
+-                           site_title, site_url, subject, body,
+-                           body_html=body_html, headers=headers)
+-
++def mail_recipient(
++        recipient_name, recipient_email, subject, body,
++        body_html=None, headers=None, attachments=None):
++    '''Sends an email to a an email address.
++
++    .. note:: You need to set up the :ref:`email-settings` to able to send
++        emails.
++
++    :param recipient_name: the name of the recipient
++    :type recipient: string
++    :param recipient_email: the email address of the recipient
++    :type recipient: string
++
++    :param subject: the email subject
++    :type subject: string
++    :param body: the email body, in plain text
++    :type body: string
++    :param body_html: the email body, in html format (optional)
++    :type body_html: string
++    :headers: extra headers to add to email, in the form
++        {'Header name': 'Header value'}
++    :type: dict
++    :attachments: a list of tuples containing file attachments to add to the
++        email. Tuples should contain the file name and a file-like object
++        pointing to the file contents::
++
++            [
++                ('some_report.csv', file_object),
++            ]
++
++        Optionally, you can add a third element to the tuple containing the
++        media type. If not provided, it will be guessed using
++        the ``mimetypes`` module::
++
++            [
++                ('some_report.csv', file_object, 'text/csv'),
++            ]
++    :type: list
++    '''
++    site_title = config.get('ckan.site_title')
++    site_url = config.get('ckan.site_url')
++    return _mail_recipient(
++        recipient_name, recipient_email,
++        site_title, site_url, subject, body,
++        body_html=body_html, headers=headers, attachments=attachments)
++
++
++def mail_user(
++        recipient, subject, body,
++        body_html=None, headers=None, attachments=None):
++    '''Sends an email to a CKAN user.
++
++    You need to set up the :ref:`email-settings` to able to send emails.
++
++    :param recipient: a CKAN user object
++    :type recipient: a model.User object
++
++    For further parameters see
++    :py:func:`~ckan.lib.mailer.mail_recipient`.
++    '''
+ 
+-def mail_user(recipient, subject, body, body_html=None, headers={}):
+-    '''Sends an email to a CKAN user'''
+     if (recipient.email is None) or not len(recipient.email):
+         raise MailerException(_("No recipient email address available!"))
+-    mail_recipient(recipient.display_name, recipient.email, subject,
+-                   body, body_html=body_html, headers=headers)
++    mail_recipient(
++        recipient.display_name, recipient.email, subject,
++        body, body_html=body_html, headers=headers, attachments=attachments)
+ 
+ 
+ def get_reset_link_body(user):
+@@ -202,12 +271,12 @@ def send_invite(user, group_dict=None, role=None):
+ 
+ 
+ def create_reset_key(user):
+-    user.reset_key = text_type(make_key())
++    user.reset_key = make_key()
+     model.repo.commit_and_remove()
+ 
+ 
+ def make_key():
+-    return codecs.encode(os.urandom(16), 'hex')
++    return codecs.encode(os.urandom(16), 'hex').decode()
+ 
+ 
+ def verify_reset_link(user, key):

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -30,6 +30,7 @@ ckan_patches:
   - { file: "remove_gravatar" }
   - { file: "set_attachment_content_disposition" }
   - { file: "remove_old_fontawesome" }
+  - { file: "email_attachment" }
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/helpers.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/helpers.py
@@ -13,5 +13,6 @@ def service_permission_applications_enabled(subsystem_id):
                                                                       {'subsystem_id': subsystem_id})
     return True if settings and settings.get('delivery_method', 'none') != 'none' else False
 
+
 def get_application_attachment(filename):
-    return open('{}/storage/uploads/apply_permission/{}'.format(uploader.get_storage_path(), filename), 'rb') 
+    return open('{}/storage/uploads/apply_permission/{}'.format(uploader.get_storage_path(), filename), 'rb')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/helpers.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/helpers.py
@@ -1,4 +1,5 @@
 from ckan.plugins import toolkit
+import ckan.lib.uploader as uploader
 
 
 def service_permission_application_url(subsystem_id):
@@ -11,3 +12,6 @@ def service_permission_applications_enabled(subsystem_id):
     settings = toolkit.get_action('service_permission_settings_show')({'ignore_auth': True},
                                                                       {'subsystem_id': subsystem_id})
     return True if settings and settings.get('delivery_method', 'none') != 'none' else False
+
+def get_application_attachment(filename):
+    return open('{}/storage/uploads/apply_permission/{}'.format(uploader.get_storage_path(), filename), 'rb') 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -112,10 +112,10 @@ def service_permission_application_create(context, data_dict):
                 if application_filename:
                     with get_application_attachment(application_filename) as file:
                         mail_recipient(owner_org['title'], email_address, email_subject, email_content,
-                                    headers={'Content-Type': 'text/html'}, attachments=[(application_filename, file)])
+                                       headers={'Content-Type': 'text/html'}, attachments=[(application_filename, file)])
                 else:
                     mail_recipient(owner_org['title'], email_address, email_subject, email_content,
-                                    headers={'Content-Type': 'text/html'})
+                                   headers={'Content-Type': 'text/html'})
             except Exception as e:
                 # Email exceptions are not user relevant nor action critical, but should be logged
                 log.warning(e)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -9,6 +9,7 @@ from ckan.lib.mailer import mail_recipient
 import ckan.lib.helpers as h
 from .. import model
 import logging
+from ckanext.apply_permissions_for_service.helpers import get_application_attachment
 
 _ = tk._
 
@@ -80,7 +81,6 @@ def service_permission_application_create(context, data_dict):
                                                   request_date=request_date,
                                                   application_filename=application_filename)
 
-    log.info(package.get('service_permission_settings', '{}'))
     service_permission_settings = package.get('service_permission_settings', {})
     delivery_method = service_permission_settings.get('delivery_method', 'email')
 
@@ -109,8 +109,13 @@ def service_permission_application_create(context, data_dict):
             email_content = tk.render('apply_permissions_for_service/notification_email.html',
                                       extra_vars={'application': application})
             try:
-                mail_recipient(owner_org['title'], email_address, email_subject, email_content,
-                               headers={'content-type': 'text/html'})
+                if application_filename:
+                    with get_application_attachment(application_filename) as file:
+                        mail_recipient(owner_org['title'], email_address, email_subject, email_content,
+                                    headers={'Content-Type': 'text/html'}, attachments=[(application_filename, file)])
+                else:
+                    mail_recipient(owner_org['title'], email_address, email_subject, email_content,
+                                    headers={'Content-Type': 'text/html'})
             except Exception as e:
                 # Email exceptions are not user relevant nor action critical, but should be logged
                 log.warning(e)


### PR DESCRIPTION
Add support for additional info as an attachment in email

# Description
Add support for additional info file as an attachment in email confirmation about permission application

## Jira ticket reference: [LIKA-415](https://jira.dvv.fi/browse/LIKA-415)

## What has changed:
- Add 6535 patch about email attachments. 
- Include additional file in email that is sent when permission application is created


## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

