### PR TITLE
LIKA-368: refacto view for user permission applications

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/ckanext-apply_permissions_for_service.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-27 07:00+0000\n"
+"POT-Creation-Date: 2022-05-05 08:50+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.7.0\n"
 
-#: ckanext/apply_permissions_for_service/views.py:26
-#: ckanext/apply_permissions_for_service/views.py:121
-#: ckanext/apply_permissions_for_service/views.py:132
-#: ckanext/apply_permissions_for_service/views.py:141
-#: ckanext/apply_permissions_for_service/views.py:253
+#: ckanext/apply_permissions_for_service/views.py:23
+#: ckanext/apply_permissions_for_service/views.py:118
+#: ckanext/apply_permissions_for_service/views.py:129
+#: ckanext/apply_permissions_for_service/views.py:138
+#: ckanext/apply_permissions_for_service/views.py:250
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:80
+#: ckanext/apply_permissions_for_service/views.py:77
 msgid "This API is not accepting access applications."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/views.py:241
+#: ckanext/apply_permissions_for_service/views.py:238
 msgid "Changes saved successfully"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/logic/action.py:27
-#: ckanext/apply_permissions_for_service/logic/action.py:30
-#: ckanext/apply_permissions_for_service/logic/action.py:33
-#: ckanext/apply_permissions_for_service/logic/action.py:36
-#: ckanext/apply_permissions_for_service/logic/action.py:39
-#: ckanext/apply_permissions_for_service/logic/action.py:42
-#: ckanext/apply_permissions_for_service/logic/action.py:45
-#: ckanext/apply_permissions_for_service/logic/action.py:48
-#: ckanext/apply_permissions_for_service/logic/action.py:51
+#: ckanext/apply_permissions_for_service/logic/action.py:28
+#: ckanext/apply_permissions_for_service/logic/action.py:31
+#: ckanext/apply_permissions_for_service/logic/action.py:34
+#: ckanext/apply_permissions_for_service/logic/action.py:37
+#: ckanext/apply_permissions_for_service/logic/action.py:40
+#: ckanext/apply_permissions_for_service/logic/action.py:43
+#: ckanext/apply_permissions_for_service/logic/action.py:46
+#: ckanext/apply_permissions_for_service/logic/action.py:49
+#: ckanext/apply_permissions_for_service/logic/action.py:52
 msgid "Missing value"
 msgstr ""
 
@@ -55,22 +55,72 @@ msgstr ""
 msgid "Service access applications"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:9
-msgid "Sent applications"
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:13
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
+msgid "Applicant information"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:19
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:14
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
+msgid "Information about the organization consuming the services"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:15
+msgid "Service and API you are applying to access"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:16
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
+msgid "API access application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:25
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:30
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
+msgid "Organization"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:26
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:38
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:57
+msgid "Subsystem"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:35
+msgid "Business code"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:39
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
+msgid "Service code"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:41
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:104
+msgid "Preview application"
+msgstr ""
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:48
 msgid ""
 "You have not sent any service access applications. You can apply for access "
 "to services by clicking the \"Request access\" button on the service page."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:22
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html:4
 msgid "Received applications"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:32
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html:12
 msgid "You have not received any service access applications."
 msgstr ""
@@ -93,11 +143,6 @@ msgstr ""
 msgid "Apply for permission to use API {}"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
-msgid "API access application"
-msgstr ""
-
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
 "Use this form to apply for a permission to use a service that is available in"
@@ -106,26 +151,11 @@ msgid ""
 "Valtori is automatically notified of the needed firewall configurations."
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
-msgid "Applicant information"
-msgstr ""
-
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
 "Your contact infomation and organization details are prefilled based on "
 "information provided when your organization joined the National Data Exchange"
 " layer. Modify the prefilled information if necessary."
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
-msgid "Organization"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
-msgid "Business code"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
@@ -144,10 +174,6 @@ msgid ""
 "using the services"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
-msgid "Information about the organization consuming the services"
-msgstr ""
-
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
 msgid "Organization using the services"
 msgstr ""
@@ -157,7 +183,7 @@ msgid "Y-number"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Details of your Security Server and Subsystem"
 msgstr ""
 
@@ -168,7 +194,7 @@ msgid ""
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:46
 msgid "IP address"
 msgstr ""
 
@@ -191,28 +217,18 @@ msgid ""
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:47
 msgid "Subsystem code"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:53
 msgid "Details of the service and API you are applying to access"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:56
 msgid "Organization name"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
-msgid "Subsystem"
-msgstr ""
-
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
-msgid "Service code"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
@@ -220,7 +236,7 @@ msgid "Select one or several APIs you are applying to access"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:67
 msgid "Explain how the service will be used"
 msgstr ""
 
@@ -229,7 +245,7 @@ msgid "Reason for requesting access"
 msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:68
 msgid "Date when access is needed"
 msgstr ""
 
@@ -321,10 +337,6 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:104
-msgid "Preview application"
-msgstr ""
-
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:110
 msgid "Permission request alternatives:"
 msgstr ""
@@ -350,7 +362,7 @@ msgid ""
 "href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:75
 msgid "Additional info"
 msgstr ""
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/en_GB/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/en_GB/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-22 12:20+0000\n"
+"POT-Creation-Date: 2022-04-27 07:00+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
 "Last-Translator: Bert Viikmäe, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -29,17 +29,17 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/views.py:121
 #: ckanext/apply_permissions_for_service/views.py:132
 #: ckanext/apply_permissions_for_service/views.py:141
-#: ckanext/apply_permissions_for_service/views.py:252
+#: ckanext/apply_permissions_for_service/views.py:253
 msgid "Not authorized to see this page"
-msgstr ""
+msgstr "Not authorized to see this page"
 
 #: ckanext/apply_permissions_for_service/views.py:80
 msgid "This API is not accepting access applications."
 msgstr "This subsystem is not accepting access applications."
 
-#: ckanext/apply_permissions_for_service/views.py:240
+#: ckanext/apply_permissions_for_service/views.py:241
 msgid "Changes saved successfully"
-msgstr ""
+msgstr "Changes saved successfully"
 
 #: ckanext/apply_permissions_for_service/logic/action.py:27
 #: ckanext/apply_permissions_for_service/logic/action.py:30
@@ -51,40 +51,42 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/logic/action.py:48
 #: ckanext/apply_permissions_for_service/logic/action.py:51
 msgid "Missing value"
-msgstr ""
+msgstr "Missing value"
 
 #: ckanext/apply_permissions_for_service/logic/auth.py:20
 msgid "User not authorized to view permission application."
-msgstr ""
+msgstr "User not authorized to view permission application."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:4
 msgid "Service access applications"
-msgstr ""
+msgstr "Service access applications"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:9
 msgid "Sent applications"
-msgstr ""
+msgstr "Sent applications"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:19
 msgid ""
 "You have not sent any service access applications. You can apply for access "
 "to services by clicking the \"Request access\" button on the service page."
 msgstr ""
+"You have not sent any service access applications. You can apply for access "
+"to services by clicking the \"Request access\" button on the service page."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:22
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html:4
 msgid "Received applications"
-msgstr ""
+msgstr "Received applications"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:32
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html:12
 msgid "You have not received any service access applications."
-msgstr ""
+msgstr "You have not received any service access applications."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:8
 msgid "Organizations"
-msgstr ""
+msgstr "Organizations"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:11
 msgid "Datasets"
@@ -94,16 +96,16 @@ msgstr "Subsystems"
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/request_access_button.html:3
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/request_access_button.html:5
 msgid "Request access"
-msgstr ""
+msgstr "Request access"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:21
 msgid "Apply for permission to use API {}"
-msgstr ""
+msgstr "Apply for permission to use API {}"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:43
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:9
 msgid "API access application"
-msgstr ""
+msgstr "API access application"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:44
 msgid ""
@@ -122,7 +124,7 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:46
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:15
 msgid "Applicant information"
-msgstr ""
+msgstr "Applicant information"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:47
 msgid ""
@@ -130,26 +132,29 @@ msgid ""
 "information provided when your organization joined the National Data "
 "Exchange layer. Modify the prefilled information if necessary."
 msgstr ""
+"Your contact infomation and organization details are prefilled based on "
+"information provided when your organization joined the National Data "
+"Exchange layer. Modify the prefilled information if necessary."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:52
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:18
 msgid "Organization"
-msgstr ""
+msgstr "Organization"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:53
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:19
 msgid "Business code"
-msgstr ""
+msgstr "Business code"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:55
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:20
 msgid "Contact name"
-msgstr ""
+msgstr "Contact name"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:56
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:21
 msgid "Contact email"
-msgstr ""
+msgstr "Contact email"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:66
 msgid ""
@@ -174,119 +179,124 @@ msgstr "Y-number"
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
 msgid "Details of your Security Server and Subsystem"
-msgstr ""
+msgstr "Details of your Security Server and Subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:93
 msgid ""
 "Fill in the details of the Security Server and subsystem that you are "
 "applying permission for, and need the firewall opened to."
 msgstr ""
+"Fill in the details of the Security Server and subsystem that you are "
+"applying permission for, and need the firewall opened to."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:30
 msgid "IP address"
-msgstr ""
+msgstr "IP address"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid "Write the IP address"
-msgstr ""
+msgstr "Write the IP address"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:101
 msgid ""
 "Select one or several IP addresses of your organization's security servers"
 msgstr ""
+"Select one or several IP addresses of your organization's security servers"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:102
 msgid "Add an IP address"
-msgstr ""
+msgstr "Add an IP address"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 msgid ""
 "Select the subsystem of your organization for which you want to apply "
 "permission"
 msgstr ""
+"Select the subsystem of your organization for which you want to apply "
+"permission"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
 msgid "Subsystem code"
-msgstr ""
+msgstr "Subsystem code"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:111
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:37
 msgid "Details of the service and API you are applying to access"
-msgstr ""
+msgstr "Details of the service and API you are applying to access"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:40
 msgid "Organization name"
-msgstr ""
+msgstr "Organization name"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:116
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:41
 msgid "Subsystem"
-msgstr ""
+msgstr "Subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:43
 msgid "Service code"
-msgstr ""
+msgstr "Service code"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:131
 msgid "Select one or several APIs you are applying to access"
-msgstr ""
+msgstr "Select one or several APIs you are applying to access"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:51
 msgid "Explain how the service will be used"
-msgstr ""
+msgstr "Explain how the service will be used"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:132
 msgid "Reason for requesting access"
-msgstr ""
+msgstr "Reason for requesting access"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:133
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:52
 msgid "Date when access is needed"
-msgstr ""
+msgstr "Date when access is needed"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:142
 msgid "Send access application"
-msgstr ""
+msgstr "Send access application"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
 msgid "Preview permission application"
-msgstr ""
+msgstr "Preview permission application"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
 msgid "You are previewing permission from applicants point of view"
-msgstr ""
+msgstr "You are previewing permission from applicants point of view"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
 msgid "Exit from preview"
-msgstr ""
+msgstr "Exit from preview"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:13
 msgid "All access applications"
-msgstr ""
+msgstr "All access applications"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:6
 msgid "Application sent successfully"
-msgstr ""
+msgstr "Application sent successfully"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:6
 msgid "Exit the settings"
-msgstr ""
+msgstr "Exit the settings"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:13
 msgid "Subsystem permission"
-msgstr ""
+msgstr "Subsystem permission"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:14
 msgid ""
@@ -307,47 +317,48 @@ msgstr "Disable access requests for this subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
 msgid "Application in API Catalogue"
-msgstr ""
+msgstr "Application in API Catalogue"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
 msgid "Organisation’s downloadable application (PDF)"
-msgstr ""
+msgstr "Organisation’s downloadable application (PDF)"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
 msgid "Link to the access licence application on the organisation's website"
-msgstr ""
+msgstr "Link to the access licence application on the organisation's website"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:80
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
 msgid "Request additional info with an attachment"
-msgstr ""
+msgstr "Request additional info with an attachment"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:86
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
 msgid "Add your file"
-msgstr ""
+msgstr "Add your file"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:99
 msgid "Webpage URL"
-msgstr ""
+msgstr "Webpage URL"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Save"
-msgstr ""
+msgstr "Save"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:104
 msgid "Preview application"
-msgstr ""
+msgstr "Preview application"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:110
 msgid "Permission request alternatives:"
 msgstr "Access request options:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:112
 msgid ""
 "<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
 "<li>Request permission to use a subsystem by using the predefined electronic"
@@ -367,36 +378,59 @@ msgid ""
 "access rights, see the instructions in the <a target=\"_blank\" "
 "href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
+"<p style=\"font-weight: bold;\">Application in API "
+"Catalogue</p><ul><li>Request permission to use a subsystem by using the "
+"predefined electronic form in the API Catalogue.</li></ul><p style=\"font-"
+"weight: bold;\">Organisation’s downloadable application "
+"(PDF)</p><ul><li>Upload your organisation's own PDF form to the API "
+"Catalogue that can be used to request permission to use the subsystem. The "
+"applicant must download the form from the API Catalogue and send the "
+"completed form to the email address you specified.</li><li>In the form, "
+"explain to which email address the form should be returned "
+"to.</li><li>Access requests sent in this way will not appear in the API "
+"Catalogue.</li></ul><p style=\"font-weight: bold;\">Link to the access "
+"licence application on the organisation's website</p><ul><li>Enter the URL "
+"for your organisation’s web page where the person requesting access can "
+"apply for access to your organisation’s services.</li><li>Access requests "
+"sent in this way will not appear in the API Catalogue.</li></ul><p>For more "
+"information on the administration of access rights, see the instructions in "
+"the<a target=\"_blank\" href=\"https://liityntakatalogi.suomi.fi/\">API "
+"Catalogue.</a></p>"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
 msgid "Additional info"
-msgstr ""
+msgstr "Additional info"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
 msgid "Sending additional info"
-msgstr ""
+msgstr "Sending additional info"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
 msgid ""
 "Requested subsystem is managed by a company that requires additional info"
 msgstr ""
+"Requested subsystem is managed by a company that requires additional info"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
 msgid "1. Download file and fill required information"
-msgstr ""
+msgstr "1. Download file and fill required information"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
 msgid "2. Add completed file into the application"
-msgstr ""
+msgstr "2. Add completed file into the application"
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:5
 msgid "Permission management"
-msgstr ""
+msgstr "Permission management"
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
-msgstr ""
+msgstr "Manage access requests"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:15
+msgid "Service and API you are applying to access"
+msgstr "Service and API you are applying to access"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/fi/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/fi/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -9,17 +9,17 @@
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2021
-# Bert Viikmäe, 2022
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
+# Bert Viikmäe, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-22 12:20+0000\n"
+"POT-Creation-Date: 2022-04-27 07:00+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
-"Last-Translator: Pasi Laakso <pasi.laakso@gofore.com>, 2022\n"
+"Last-Translator: Bert Viikmäe, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,7 +32,7 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/views.py:121
 #: ckanext/apply_permissions_for_service/views.py:132
 #: ckanext/apply_permissions_for_service/views.py:141
-#: ckanext/apply_permissions_for_service/views.py:252
+#: ckanext/apply_permissions_for_service/views.py:253
 msgid "Not authorized to see this page"
 msgstr "Tämän sivun näyttäminen ei ole sallittu"
 
@@ -40,7 +40,7 @@ msgstr "Tämän sivun näyttäminen ei ole sallittu"
 msgid "This API is not accepting access applications."
 msgstr "Tämä alijärjestelmä ei ota vastaan käyttölupahakemuksia."
 
-#: ckanext/apply_permissions_for_service/views.py:240
+#: ckanext/apply_permissions_for_service/views.py:241
 msgid "Changes saved successfully"
 msgstr "Muutokset tallennettu onnistuneesti"
 
@@ -58,7 +58,7 @@ msgstr "Puuttuva arvo"
 
 #: ckanext/apply_permissions_for_service/logic/auth.py:20
 msgid "User not authorized to view permission application."
-msgstr ""
+msgstr "Käyttäjällä ei ole oikeutta tarkastella lupahakemusta."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:4
@@ -267,7 +267,7 @@ msgid "Send access application"
 msgstr "Lähetä käyttölupahakemus"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
 msgid "Cancel"
 msgstr "Peruuta"
 
@@ -331,36 +331,37 @@ msgid "Link to the access licence application on the organisation's website"
 msgstr "Linkki lupahakemukseen organisaation sivulla"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:80
 msgid "Email"
-msgstr ""
+msgstr "Sähköposti"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
 msgid "Request additional info with an attachment"
 msgstr "Pyydä lisätietoja liitetiedostona"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:86
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
 msgid "Add your file"
 msgstr "Lisää tiedosto"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:99
 msgid "Webpage URL"
 msgstr "Verkkosivuston URL"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Save"
 msgstr "Tallenna"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:104
 msgid "Preview application"
 msgstr "Esikatsele hakemusta"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:110
 msgid "Permission request alternatives:"
 msgstr "Lupapyyntövaihtoehdot:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:112
 msgid ""
 "<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
 "<li>Request permission to use a subsystem by using the predefined electronic"
@@ -399,7 +400,7 @@ msgstr ""
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
 msgid "Additional info"
-msgstr ""
+msgstr "Lisätiedot"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
 msgid "Sending additional info"
@@ -431,3 +432,7 @@ msgstr "Lupapyyntöjen asetukset"
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
 msgstr "Hallinnoi lupapyyntöjä"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:15
+msgid "Service and API you are applying to access"
+msgstr "Palvelu ja API, jolle haet käyttöoikeutta"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/sv/LC_MESSAGES/ckanext-apply_permissions_for_service.po
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/i18n/sv/LC_MESSAGES/ckanext-apply_permissions_for_service.po
@@ -7,16 +7,16 @@
 # Translators:
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2021
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2021
-# Bert Viikmäe, 2021
+# Bert Viikmäe, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apply_permissions_for_service 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-22 12:20+0000\n"
+"POT-Creation-Date: 2022-04-27 07:00+0000\n"
 "PO-Revision-Date: 2020-05-08 07:33+0000\n"
-"Last-Translator: Bert Viikmäe, 2021\n"
+"Last-Translator: Bert Viikmäe, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +29,7 @@ msgstr ""
 #: ckanext/apply_permissions_for_service/views.py:121
 #: ckanext/apply_permissions_for_service/views.py:132
 #: ckanext/apply_permissions_for_service/views.py:141
-#: ckanext/apply_permissions_for_service/views.py:252
+#: ckanext/apply_permissions_for_service/views.py:253
 msgid "Not authorized to see this page"
 msgstr "Inga rättigheter att se denna sida"
 
@@ -37,7 +37,7 @@ msgstr "Inga rättigheter att se denna sida"
 msgid "This API is not accepting access applications."
 msgstr "Detta subsystem tar inte emot ansökningar om användningstillstånd."
 
-#: ckanext/apply_permissions_for_service/views.py:240
+#: ckanext/apply_permissions_for_service/views.py:241
 msgid "Changes saved successfully"
 msgstr "Ändringarna har sparats"
 
@@ -55,7 +55,7 @@ msgstr "Värde som saknas"
 
 #: ckanext/apply_permissions_for_service/logic/auth.py:20
 msgid "User not authorized to view permission application."
-msgstr ""
+msgstr "Användaren har inte behörighet att se tillståndsansökan."
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:4
@@ -163,18 +163,20 @@ msgid ""
 "Applying organization acts as an intermediary on behalf of the organizations"
 " using the services"
 msgstr ""
+"Den ansökande organisationen agerar som mellanhand på uppdrag av de "
+"organisationer som använder tjänsterna"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:79
 msgid "Information about the organization consuming the services"
-msgstr ""
+msgstr "Information om organisationen som konsumerar tjänsterna"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:81
 msgid "Organization using the services"
-msgstr ""
+msgstr "Organisation som använder tjänsterna"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:85
 msgid "Y-number"
-msgstr ""
+msgstr "Y-nummer"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:92
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:27
@@ -213,6 +215,7 @@ msgid ""
 "Select the subsystem of your organization for which you want to apply "
 "permission"
 msgstr ""
+"Välj det subsystem i din organisation som du vill ansöka om behörighet för"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:106
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:31
@@ -266,22 +269,22 @@ msgid "Send access application"
 msgstr "Skicka ansökan om användningstillstånd"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html:143
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
 msgid "Cancel"
 msgstr "Ångra"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:4
 msgid "Preview permission application"
-msgstr ""
+msgstr "Förhandsgranska tillståndsansökan"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:6
 msgid "You are previewing permission from applicants point of view"
-msgstr ""
+msgstr "Du förhandsgranskar tillstånd från sökandes synvinkel"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:7
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/preview.html:13
 msgid "Exit from preview"
-msgstr ""
+msgstr "Avsluta förhandsgranskningen"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html:4
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:13
@@ -294,11 +297,11 @@ msgstr "Ansökan har skickats"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:6
 msgid "Exit the settings"
-msgstr ""
+msgstr "Avsluta inställningarna"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:13
 msgid "Subsystem permission"
-msgstr ""
+msgstr "Subsystemtillstånd"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:14
 msgid ""
@@ -319,47 +322,48 @@ msgstr "Det går inte att begära tillstånd för detta subsystem"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:23
 msgid "Application in API Catalogue"
-msgstr ""
+msgstr "Applikation i API-katalogen"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:24
 msgid "Organisation’s downloadable application (PDF)"
-msgstr ""
+msgstr "Organisationens nedladdningsbara applikation (PDF)"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:25
 msgid "Link to the access licence application on the organisation's website"
-msgstr ""
+msgstr "Länk till ansökan om tillträdeslicens på organisationens hemsida"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:30
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:80
 msgid "Email"
-msgstr ""
+msgstr "E-post"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:49
 msgid "Request additional info with an attachment"
-msgstr ""
+msgstr "Begär ytterligare information med en bilaga"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:61
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:85
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:86
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:25
 msgid "Add your file"
-msgstr ""
+msgstr "Lägg till din fil"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:98
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:99
 msgid "Webpage URL"
 msgstr "Webbplatsens URL"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:101
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:102
 msgid "Save"
 msgstr "Spara"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:103
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:104
 msgid "Preview application"
-msgstr ""
+msgstr "Förhandsgranska ansökan"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:109
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:110
 msgid "Permission request alternatives:"
 msgstr "Alternativ för tillståndsbegäran:"
 
-#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:111
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html:112
 msgid ""
 "<p style=\"font-weight: bold;\">Application in API Catalogue</p> <ul> "
 "<li>Request permission to use a subsystem by using the predefined electronic"
@@ -379,36 +383,60 @@ msgid ""
 "access rights, see the instructions in the <a target=\"_blank\" "
 "href=\"https://liityntakatalogi.suomi.fi/\"> API Catalogue. </a> </p>"
 msgstr ""
+"<p style=\"font-weight: bold;\">Applikation i API-katalogen</p><ul><li>Begär"
+" tillstånd att använda ett delsystem genom att använda det fördefinierade "
+"elektroniska formuläret i API-katalogen.</li></ul><p style=\"font-weight: "
+"bold;\">Organisationens nedladdningsbara applikation (PDF)</p><ul><li>Ladda "
+"upp din organisations eget PDF-formulär till API-katalogen som kan användas "
+"för att begära tillstånd att använda undersystemet. Den sökande måste ladda "
+"ner formuläret från API-katalogen och skicka det ifyllda formuläret till den"
+" e-postadress du angett.</li><li>Förklara i formuläret till vilken "
+"e-postadress formuläret ska skickas tillbaka "
+"till.</li><li>Åtkomstförfrågningar som skickas på detta sätt kommer inte att"
+" visas i API-katalogen.</li></ul><p style=\"font-weight: bold;\">Länk till "
+"ansökan om tillträdeslicens på organisationens hemsida</p><ul><li>Ange "
+"webbadressen till din organisations webbsida där den person som begär "
+"åtkomst kan ansöka om åtkomst till din organisations "
+"tjänster.</li><li>Åtkomstförfrågningar som skickas på detta sätt kommer inte"
+" att visas i API-katalogen.</li></ul><p>För mer information om "
+"administrering av åtkomsträttigheter, se instruktionerna i<a "
+"target=\"_blank\" href=\"https://liityntakatalogi.suomi.fi/\">API-"
+"katalog.</a></p>"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html:59
 msgid "Additional info"
-msgstr ""
+msgstr "Ytterligare info"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:5
 msgid "Sending additional info"
-msgstr ""
+msgstr "Skickar ytterligare information"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:6
 msgid ""
 "Requested subsystem is managed by a company that requires additional info"
 msgstr ""
+"Begärt delsystem hanteras av ett företag som kräver ytterligare information"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:7
 msgid "1. Download file and fill required information"
-msgstr ""
+msgstr "1. Ladda ner filen och fyll i nödvändig information"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:15
 msgid "Download"
-msgstr ""
+msgstr "Ladda ner"
 
 #: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html:21
 msgid "2. Add completed file into the application"
-msgstr ""
+msgstr "2. Lägg till färdig fil i applikationen"
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:5
 msgid "Permission management"
-msgstr ""
+msgstr "Tillståndshantering"
 
 #: ckanext/apply_permissions_for_service/templates/package/edit_base.html:6
 msgid "Manage access requests"
 msgstr "Administrerar tillståndsbegäran"
+
+#: ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html:15
+msgid "Service and API you are applying to access"
+msgstr "Tjänst och API som du ansöker om att få tillgång till"

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html
@@ -6,30 +6,46 @@
 
 {% block primary_content_inner %}
 
-<h2>{{ _('Sent applications') }}</h2>
-{% if sent_applications %}
-  <ul>
-  {% for application in sent_applications %}
-      {% for service in application.services %}
-        <li>{% link_for ((h.xroad_subsystem_path(application.subsystem) or application.subsystem.name) + ' → ' + (h.xroad_subsystem_path(service) or service.name)), named_route='apply_permissions.view_permission_application', application_id=application.id %}</li>
-    {% endfor %}
-  {% endfor %}
-  </ul>
+{% if applications %}
+    <table class="table table-bordered" style="table-layout:fixed;">
+        <thead>
+            <tr>
+                <th style="width: 28%">{{ _('Applicant information') }}</th>
+                <th style="width: 20%">{{ _('Information about the organization consuming the services') }}</th>
+                <th style="width: 36%">{{ _('Service and API you are applying to access') }}</th>
+                <th style="width: 16%">{{ _('API access application') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for application in applications %}
+            {% set subsystem_code = application.subsystem_code.split('.') %}
+            {% for service in application.services %}
+            <tr>
+                <td>
+                    {{ _('Organization') }} : <b>{{ application.organization["title"] }}</b><br>
+                    {{ _('Subsystem') }} : <b>{{ application.requester_subsystem.name }}</b><br>
+                </td>
+                {% if "intermediate_organization" in application %}
+                <td>
+                    {{ _('Organization') }} : <b>{{ h.get_translated(application.intermediate_organization, 'title') }}</b><br>
+                    {{ _('Business code') }} : <b>{{ application.intermediate_business_code }}</b><br>
+                </td>
+                {% else %}
+                <td></td>
+                {% endif %}
+                <td>
+                    {{ _('Organization') }} : <b>{{ h.get_translated(application.target_organization, 'title') }}</b><br>
+                    {{ _('Subsystem') }} : <b>{{ subsystem_code[3] }}</b><br>
+                    {{ _('Service code') }} : <b>{{ service.name }}</b><br>
+                </td>
+                <td>{% link_for _('Preview application'), named_route='apply_permissions.view_permission_application', application_id=application.id %}</td>
+            </tr>
+            {% endfor %}
+        {% endfor %}
+        </tbody>
+    </table>
 {% else %}
 <p>{{ _('You have not sent any service access applications. You can apply for access to services by clicking the "Request access" button on the service page.') }}</p>
-{% endif %}
-
-<h2>{{ _('Received applications') }}</h2>
-{% if received_applications %}
-  <ul>
-  {% for application in received_applications %}
-      {% for service in application.services %}
-        <li>{% link_for ((h.xroad_subsystem_path(application.subsystem) or application.subsystem.name) + ' → ' + (h.xroad_subsystem_path(service) or service.name)), named_route='apply_permissions.view_permission_application', application_id=application.id %}</li>
-    {% endfor %}
-  {% endfor %}
-  </ul>
-{% else %}
-<p>{{ _('You have not received any service access applications.') }}</p>
 {% endif %}
 
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -17,10 +17,7 @@ def index():
         context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
         data_dict = {'subsystem_id': subsystem_id}
         applications = toolkit.get_action('service_permission_application_list')(context, data_dict)
-        extra_vars = {
-                'sent_applications': applications,
-                'received_applications': applications
-                }
+        extra_vars = {'applications': applications}
         return toolkit.render('apply_permissions_for_service/index.html', extra_vars=extra_vars)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))


### PR DESCRIPTION
# Description
Refacto view for user permission applications.

## Jira ticket reference: [LIKA-368](https://jira.dvv.fi/browse/LIKA-368)

## What has changed:
Refactored view for user permission applications.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.
![screenshot](https://user-images.githubusercontent.com/59827771/166870908-0f07c2c4-d7cf-45db-98f1-75ae604bd39e.png)

