### PR TITLE
Make apply permission optional in menu generation

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html
@@ -41,12 +41,14 @@
   </a>
 </li>
 
-<li class="{{ class }}">
-  <a href="{{ h.url_for('apply_permissions.list_permission_applications') }}" title="{{ _('Blog') }}">
-    <i class="fa fa-file-text-o"></i>
-    <span class="text">{{ _('Service access applications') }}</span>
-  </a>
-</li>
+{% if h.is_extension_loaded('apply_permissions_for_service') %}
+    <li class="{{ class }}">
+        <a href="{{ h.url_for('apply_permissions.list_permission_applications') }}" title="{{ _('Blog') }}">
+            <i class="fa fa-file-text-o"></i>
+            <span class="text">{{ _('Service access applications') }}</span>
+        </a>
+    </li>
+{% endif %}
 <!-- /ckanext_pages -->
 
 {% block header_account_logged %}


### PR DESCRIPTION
# Description
Apply permission extension is not enabled in production so url generation produced server error. 

## What has changed:
Added checks if apply permissions plugin is enabled.


