### PR TITLE
Fix javascript error on form page

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/javascript/collapsible.js
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/javascript/collapsible.js
@@ -1,5 +1,3 @@
-'use strict';
-
 this.ckan.module('collapsible', function($) {
   return {
 


### PR DESCRIPTION
# Description
Javascript was failing on "Unexpected string", which was caused by "use strict" during bundling. 

## What has changed:
Removed "use strict" from one of the js files.
Updated ckanext-sentry.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

