### PR TITLE
LIKA-488: add cron job for fetching xroad distinct services daily

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -144,6 +144,9 @@
 - name: Ensure fetch xroad stats cronjob
   cron: name="Fetch X-Road Stats" special_time=daily job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" xroad fetch-stats"
 
+- name: Ensure fetch xroad distinct service stats cronjob
+  cron: name="Fetch X-Road Distinct Service Stats" special_time=daily job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" xroad fetch-distinct-service-stats"
+
 - name: Ensure fetch xroad services cronjob
   cron: name="Fetch X-Road Services" special_time=daily job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" xroad fetch-service-list"
 


### PR DESCRIPTION
# Description
Add cron job for fetching xroad distinct services daily.

## Jira ticket reference: [LIKA-488](https://jira.dvv.fi/browse/LIKA-488)

## What has changed:
Add cron job for fetching xroad distinct services daily.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

