### PR TITLE
LIKA-491: url should not be downloadable file when service is unknown

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
@@ -36,7 +36,11 @@
                     <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
                     <i class="fa fa-key"></i> {{ _('API Endpoint') }}
                   {% else %}
-                    <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" download>
+                      {% if 'unknown-service' in res.url %}
+                          <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+                      {% else %}
+                          <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" download>
+                      {% endif %}
                     <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
                   {% endif %}
                 </a>


### PR DESCRIPTION
# Description
Url should not be downloadable file when service is unknown.

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
When pressing "download" button in the resource read view and there is an unknown service(the url contains "unknown-service"), the link opens as page instead of as downloadable file.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

