### PR TITLE
Fix dataset edit when apply permission is not enabled

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit.html
@@ -8,8 +8,11 @@
       <div class="module-content">
           {# The first option will always be the selected one for now until the new UI is also implemented for the other linked views #}
           <a class="dataset-sidebar dataset-sidebar-selected" href="{{ h.url_for(pkg.type + '_read', controller='dataset', action='read', id=pkg.name) }}">{{ _("Subsystem's information") }}</a>
-          <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Access request settings') }}</a>
-          <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.manage_permission_applications', subsystem_id=pkg.name) }}">{{ _('Received access requests') }}</a>
+
+          {% if h.is_extension_loaded('apply_permissions_for_service') %}
+            <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Access request settings') }}</a>
+            <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.manage_permission_applications', subsystem_id=pkg.name) }}">{{ _('Received access requests') }}</a>
+          {% endif %}
       </div>
     </div>
   </section>


### PR DESCRIPTION
# Description
Generating urls to apply permissions failed when apply permission is not enabled.


## What has changed:
Added add check if apply permission is enabled

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

