### PR TITLE
LIKA-492: fix layout problems

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
@@ -14,3 +14,5 @@
         {{ _('Cancel editing') }}
     </a>
 {% endblock %}
+
+{% block wrapper_class %}dataset-edit{% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/page.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/page.html
@@ -103,7 +103,7 @@
             {% endblock %}
             {% block secondary %}
                 {%  if not no_nav %}
-                <section class="secondary dataset-secondary border-right {% block secondary_col %}col-sm-4{% endblock %} navbar-offcanvas navbar-offcanvas-touch {% block secondary_class %}{% endblock %}" id="js-bootstrap-offcanvas">
+                <section class="secondary border-right {% block secondary_col %}col-sm-4{% endblock %} navbar-offcanvas navbar-offcanvas-touch {% block secondary_class %}{% endblock %}" id="js-bootstrap-offcanvas">
               {% snippet 'snippets/apicatalog_offcanvas-close-button.html' %}
               {#
               The secondary_content block can be used to add content to the

--- a/ckanext/ckanext-apicatalog/less/dataset.less
+++ b/ckanext/ckanext-apicatalog/less/dataset.less
@@ -436,4 +436,8 @@
       padding-top: 0;
     }
   }
+
+  .secondary {
+    border: none;
+  }
 }

--- a/ckanext/ckanext-apicatalog/less/dataset.less
+++ b/ckanext/ckanext-apicatalog/less/dataset.less
@@ -422,3 +422,18 @@
     margin: 0;
   }
 }
+
+.wrapper.dataset-edit {
+  .box();
+  background-color: @white;
+
+  .module {
+    margin-left: 0;
+    margin-right: 0;
+    padding-right: 10px;
+
+    .dataset-form {
+      padding-top: 0;
+    }
+  }
+}

--- a/ckanext/ckanext-apicatalog/less/layout.less
+++ b/ckanext/ckanext-apicatalog/less/layout.less
@@ -1,9 +1,9 @@
 .wrapper {
   .clearfix();
-  .box();
   position: relative;
   margin-bottom: 20px;
-  background: @white;
+  background: initial;
+  border: none;
   box-shadow: initial;
   border-radius: 0;
 
@@ -261,7 +261,8 @@
   }
 
   .prelude-dataset {
-    background-color: initial;
+    .box();
+    background-color: @white;
     padding: @spacing-y @spacing-x 0;
   }
 

--- a/ckanext/ckanext-apicatalog/less/module.less
+++ b/ckanext/ckanext-apicatalog/less/module.less
@@ -103,7 +103,7 @@
 
 .module-content > :first-child:not(.fill-module) {
   margin-top: 0;
-  padding-top: 0;
+  padding-top: @gutterY;
 }
 
 .module-content > :first-child:is(.dataset-sidebar) {
@@ -112,7 +112,7 @@
 
 .module-content > :last-child:not(.fill-module) {
   margin-bottom: 0;
-  padding-bottom: 0;
+  padding-bottom: @gutterY;
 }
 
 .module-content > :last-child {
@@ -163,7 +163,8 @@
   background-color: @moduleBackgroundColor;
 
   .module {
-    padding-right: 10px;
+    margin-left: 20px;
+    margin-right: 20px;
   }
 }
 

--- a/ckanext/ckanext-apicatalog/less/module.less
+++ b/ckanext/ckanext-apicatalog/less/module.less
@@ -168,10 +168,6 @@
   }
 }
 
-.dataset-secondary {
-  border: none;
-}
-
 .module-image {
   width: 50px;
   line-height: @line-height-computed;


### PR DESCRIPTION
# Description
Dataset form layout modification were too extensive which broke other pages, this narrows it somewhat.

## Jira ticket reference: [LIKA-492](https://jira.dvv.fi/browse/LIKA-492)

## What has changed:
Adds a new css class to dataset form and styles it.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Fixed dataset list:
![image](https://user-images.githubusercontent.com/830663/173521016-55611f48-4585-4524-927c-904485bbadee.png)

Fixed organization list:
![image](https://user-images.githubusercontent.com/830663/173521085-abe4cbbc-20f6-4959-bb91-c1df672dee5f.png)

Dataset form is still working design:
![image](https://user-images.githubusercontent.com/830663/173521187-1bfaac9d-0264-41fc-a6b2-824ecb394164.png)


