### PR TITLE
LIKA-493: Upgrade Vagrant environment to Ubuntu 20.04 (focal)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "catalog" do |server|
-    server.vm.box = "bento/ubuntu-18.04"
+    server.vm.box = "bento/ubuntu-20.04"
     server.vm.network :private_network, ip: "10.100.10.10"
     server.vm.network :private_network, ip: "10.100.10.11"
     server.vm.hostname = "api-catalog"

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -30,6 +30,12 @@
     owner: root
     group: root
 
+- name: "Workaround: remove `typing` before installing CKAN to fix reprovisioning"
+  pip:
+    name: typing
+    state: absent
+    virtualenv: "{{ virtualenv }}"
+
 - name: Install project requirements
   pip:
    requirements: "{{ cache_path }}/requirements.txt"

--- a/ansible/roles/os-base/templates/sources.list.j2
+++ b/ansible/roles/os-base/templates/sources.list.j2
@@ -1,32 +1,32 @@
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} main restricted
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} main restricted
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates main restricted
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates main restricted
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} main restricted
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} main restricted
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates main restricted
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates main restricted
 
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} universe
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} universe
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates universe
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates universe
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} universe
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} universe
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates universe
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates universe
 
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} multiverse
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }} multiverse
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates multiverse
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-updates multiverse
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} multiverse
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }} multiverse
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates multiverse
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-updates multiverse
 
-deb {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-backports main restricted universe multiverse
-deb-src {{ apt_source_url }}/ubuntu/ {{ ubuntu_codename }}-backports main restricted universe multiverse
+deb {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-backports main restricted universe multiverse
+deb-src {{ apt_source_url }}/ubuntu/ {{ system.ubuntu_codename }}-backports main restricted universe multiverse
 
-deb http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security main restricted
-deb-src http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security main restricted
-deb http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security universe
-deb-src http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security universe
-deb http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security multiverse
-deb-src http://security.ubuntu.com/ubuntu {{ ubuntu_codename }}-security multiverse
+deb http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security main restricted
+deb-src http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security main restricted
+deb http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security universe
+deb-src http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security universe
+deb http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security multiverse
+deb-src http://security.ubuntu.com/ubuntu {{ system.ubuntu_codename }}-security multiverse
 
 # Canonical's 'partner' repository
-# deb http://archive.canonical.com/ubuntu {{ ubuntu_codename }} partner
-# deb-src http://archive.canonical.com/ubuntu {{ ubuntu_codename }} partner
+# deb http://archive.canonical.com/ubuntu {{ system.ubuntu_codename }} partner
+# deb-src http://archive.canonical.com/ubuntu {{ system.ubuntu_codename }} partner
 
 # Ubuntu's 'extras' repository
-# deb http://extras.ubuntu.com/ubuntu {{ ubuntu_codename }} main
-# deb-src http://extras.ubuntu.com/ubuntu {{ ubuntu_codename }} main
+# deb http://extras.ubuntu.com/ubuntu {{ system.ubuntu_codename }} main
+# deb-src http://extras.ubuntu.com/ubuntu {{ system.ubuntu_codename }} main

--- a/ansible/roles/os-base/vars/main.yml
+++ b/ansible/roles/os-base/vars/main.yml
@@ -6,5 +6,4 @@ timezone: UTC
 
 # Apt repository configuration
 apt_source_url: http://archive.ubuntu.com
-ubuntu_codename: bionic
 

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -8,14 +8,14 @@
 - name: Copy postgres configurations
   template: src={{ item.file }} dest={{ item.dest }} owner=postgres group=postgres mode="0640"
   with_items:
-  - { file: pg_hba.conf.j2, dest: /etc/postgresql/10/main/pg_hba.conf }
-  - { file: postgresql.conf.j2, dest: /etc/postgresql/10/main/postgresql.conf }
+  - { file: pg_hba.conf.j2, dest: "/etc/postgresql/{{ system.postgresql.version }}/main/pg_hba.conf" }
+  - { file: postgresql.conf.j2, dest: "/etc/postgresql/{{ system.postgresql.version }}/main/postgresql.conf" }
 
 - name: Generate self-signed SSL certificate
-  command: openssl req -new -nodes -x509 -subj "/C=FI/ST=Helsinki/L=Helsinki/O=IT/CN={{ public_facing_hostname }}" -days 3650 -keyout "/var/lib/postgresql/10/main/server.key" -out "/var/lib/postgresql/10/main/server.crt" -extensions v3_ca creates="/var/lib/postgresql/10/main/server.crt"
+  command: openssl req -new -nodes -x509 -subj "/C=FI/ST=Helsinki/L=Helsinki/O=IT/CN={{ public_facing_hostname }}" -days 3650 -keyout "/var/lib/postgresql/{{ system.postgresql.version }}/main/server.key" -out "/var/lib/postgresql/{{ system.postgresql.version }}/main/server.crt" -extensions v3_ca creates="/var/lib/postgresql/{{ system.postgresql.version }}/main/server.crt"
 
 - name: Set certificate file ownership and mode
-  shell: chmod 600 /var/lib/postgresql/10/main/server.* && chown "postgres:postgres" /var/lib/postgresql/10/main/server.*
+  shell: chmod 600 /var/lib/postgresql/{{ system.postgresql.version }}/main/server.* && chown "postgres:postgres" /var/lib/postgresql/{{ system.postgresql.version }}/main/server.*
 
 - name: Ensure CKAN is not running before making changes to the database
   supervisorctl: name="{{ ckan_supervisor_name }}:" state=stopped

--- a/ansible/roles/postgres/templates/postgresql.conf.j2
+++ b/ansible/roles/postgres/templates/postgresql.conf.j2
@@ -1,8 +1,8 @@
 
-data_directory = '/var/lib/postgresql/10/main'
-hba_file = '/etc/postgresql/10/main/pg_hba.conf'
-ident_file = '/etc/postgresql/10/main/pg_ident.conf'
-external_pid_file = '/var/run/postgresql/10-main.pid'
+data_directory = '/var/lib/postgresql/{{ system.postgresql.version }}/main'
+hba_file = '/etc/postgresql/{{ system.postgresql.version }}/main/pg_hba.conf'
+ident_file = '/etc/postgresql/{{ system.postgresql.version }}/main/pg_ident.conf'
+external_pid_file = '/var/run/postgresql/{{ system.postgresql.version }}-main.pid'
 
 listen_addresses = '*'
 port = 5432

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -17,3 +17,8 @@ ssl_certificate_path: /etc/ssl/apicatalog
 ssl_cert_filename: server.crt
 ssl_key_filename: server.key
 ssl_dh_parameters_path: "{{ ssl_certificate_path }}/dhparams.pem"
+
+system:
+  ubuntu_codename: bionic
+  postgresql:
+    version: 10

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -20,6 +20,10 @@ matomo:
 sentry:
   dsn: ""
 
+system:
+  ubuntu_codename: focal
+  postgresql:
+    version: 12
 
 database_ckan:
   host: 127.0.0.1


### PR DESCRIPTION
# Description
Upgrade vagrant environment to Ubuntu 20.04 (focal)

## Jira ticket reference: [LIKA-493](https://jira.dvv.fi/browse/LIKA-493)

## What has changed:
- Change base image in Vagrantfile
- Parametrize postgres version in ansible
- Make `ubuntu_codename` and postgres version environment-specific variables
- Add workaround for `typing` python package causing errors when installing CKAN

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

