### PR TITLE
LIKA-491: Add checks for external urls

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
@@ -1259,7 +1259,7 @@ msgstr "Näytä vain palveluntarjoajat"
 
 #: ckanext/apicatalog/templates/package/edit.html:10
 msgid "Subsystem's information"
-msgstr "Alijärjelmän tiedot"
+msgstr "Alijärjestelmän tiedot"
 
 #: ckanext/apicatalog/templates/package/edit.html:11
 msgid "Access request settings"
@@ -1323,7 +1323,7 @@ msgstr "Hae käyttölupaa organisaation sivuilla"
 #: ckanext/apicatalog/templates/package/read.html:38
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:20
 msgid "Subsystem information"
-msgstr "Alijärjelmän tiedot"
+msgstr "Alijärjestelmän tiedot"
 
 #: ckanext/apicatalog/templates/package/read.html:39
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:59

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -340,6 +340,11 @@
       "preset": "datetime",
       "form_snippet": false,
       "display_snippet": null
+    },
+    {
+      "field_name": "url_type",
+      "form_snippet": "hidden.html",
+      "validators": "ignore_missing"
     }
   ]
 }

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit.html
@@ -8,7 +8,7 @@
       <div class="module-content">
           {# The first option will always be the selected one for now until the new UI is also implemented for the other linked views #}
           <a class="dataset-sidebar dataset-sidebar-selected" href="{{ h.url_for(pkg.type + '_read', controller='dataset', action='read', id=pkg.name) }}">{{ _("Subsystem's information") }}</a>
-
+          <a class="dataset-sidebar" href="{{ h.url_for(pkg.type ~ '.resources', _('Resources'), id=pkg.name) }}">{{ _('Attachments') }}</a>
           {% if h.is_extension_loaded('apply_permissions_for_service') %}
             <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Access request settings') }}</a>
             <a class="dataset-sidebar" href="{{ h.url_for('apply_permissions.manage_permission_applications', subsystem_id=pkg.name) }}">{{ _('Received access requests') }}</a>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
@@ -31,14 +31,21 @@
       <div class="col-xs-3 hidden-xs">
       <div class="container-fluid resource-download">
         {% block resource_item_explore %}
-        {% if not url_is_edit %}
-            {% if res.url and h.is_url(res.url) %}
-              <a href="{{ res.url }}" class="resource-url-analytics" target="_blank" aria-label="{{ _('Download') + ' ' + h.resource_display_name(res) + ' ' + res.format  }}">
-                  <i class="fal fa-download" aria-hidden="true"></i>
-                  <span aria-hidden="true">{{ _('Download') }}</span>
-              </a>
+            {% if not url_is_edit %}
+                {% if res.url and h.is_url(res.url) %}
+                    {% if res.has_views or res.url_type == 'upload' %}
+                        <a href="{{ res.url }}" class="resource-url-analytics" target="_blank" aria-label="{{ _('Download') + ' ' + h.resource_display_name(res) + ' ' + res.format  }}">
+                            <i class="fal fa-download" aria-hidden="true"></i>
+                            <span aria-hidden="true">{{ _('Download') }}</span>
+                        </a>
+                    {% else %}
+                        <a href="{{ res.url }}" class="resource-url-analytics" target="_blank" aria-label="{{ _('Go to resource') + ' ' + h.resource_display_name(res) + ' ' + res.format  }}">
+                            <i class="fa fa-external-link" aria-hidden="true"></i>
+                            <span aria-hidden="true">{{ _('Go to resource') }}</span>
+                        </a>
+                    {% endif %}
+                {% endif %}
             {% endif %}
-        {% endif %}
         {% endblock %}
       </div>
       </div>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
@@ -35,6 +35,9 @@
                   {% elif res.resource_type == 'api' %}
                     <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
                     <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+                  {% elif not res.has_views and not res.url_type == 'upload' %}
+                      <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+                      <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
                   {% else %}
                     <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}" download>
                     <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}


### PR DESCRIPTION
# Description
Our templates did not have "Go to resource" checks, this adds them from core templates.

## Jira ticket reference: [LIKA-491](https://jira.dvv.fi/browse/LIKA-491)

## What has changed:
Adds checks for non uploaded urls to have "go to resource" functionality on them.
Adds resources tab to dataset edit as there was no route to it until rest of the UIs are implemented.
Adds url_type to resource schema to keep the value when resource with uploaded file is edited.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No


