### PR TITLE
LIKA-421: Fix swedish dashboard by fixing translate string format

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
@@ -6,6 +6,7 @@
 # 
 # Translators:
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
+# Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
 # 
 #, fuzzy
 msgid ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2022-05-05 07:11+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2022\n"
+"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -944,7 +945,7 @@ msgstr "Visa profil"
 msgid "Dashboard (%(num)d new item)"
 msgid_plural "Dashboard (%(num)d new items)"
 msgstr[0] "På skrivbordet (%(num)d nytt objekt)"
-msgstr[1] "På skrivbordet (% (num)d nya objekt)"
+msgstr[1] "På skrivbordet (%(num)d nya objekt)"
 
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html:38
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html:40


### PR DESCRIPTION
# Description
Swedish translation for a format string had a type, which caused rendering errors

## Jira ticket reference: [LIKA-421](https://jira.dvv.fi/browse/LIKA-421)

## What has changed:
Fixed the format string

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

