### PR TITLE
LIKA-421: Remove unnecessary asset directive

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
@@ -1,7 +1,5 @@
 {% import 'macros/form.html' as form %}
 
-{% asset 'apicatalog/javascript/api-catalog-select2' %}
-
 {% set languages = h.fluent_form_languages(field, entity_type, object_type, schema) %}
 
 {% set attrs = field.form_attrs if 'form_attrs' in field else {} %}


### PR DESCRIPTION
# Description
Remove unnecessary asset directive that causes errors.
https://sentry.io/organizations/gofore-b3/issues/3276655324

## Jira ticket reference: [LIKA-421](https://jira.dvv.fi/browse/LIKA-421)

## What has changed:
Removed reference to api-catalog-select2 asset since it is already included in `main_js` bundle

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

