### PR TITLE
LIKA-342: Add option to create developer accounts for environments

### DIFF
--- a/ansible/roles/os-base/tasks/developer-users.yml
+++ b/ansible/roles/os-base/tasks/developer-users.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Ensure developer user accounts
+  loop: "{{ secret.developers }}"
+  when: not item.remove|default(false)
+  user:
+    name: "{{ item.user }}"
+    state: "present"
+    groups: "sudo"
+    password: "*" # disable password
+
+- name: Remove old developer user accounts
+  loop: "{{ secret.developers }}"
+  when: item.remove|default(false)
+  user:
+    name: "{{ item.user }}"
+    state: "absent"
+
+- name: Ensure developer .ssh directories
+  loop: "{{ secret.developers }}"
+  when: not item.remove|default(false)
+  file: path=/home/{{ item.user }}/.ssh state=directory mode="0700" owner={{ item.user }} group={{ item.user }}
+
+- name: Deploy developer SSH keys
+  loop: "{{ secret.developers }}"
+  when: not item.remove|default(false)
+  uri:
+    url: "https://github.com/{{ item.user }}.keys"
+    dest: "/home/{{ item.user }}/.ssh/authorized_keys"
+    mode: "0600"
+    owner: "{{ item.user }}"
+    force: true

--- a/ansible/roles/os-base/tasks/main.yml
+++ b/ansible/roles/os-base/tasks/main.yml
@@ -65,3 +65,5 @@
   locale_gen:
     name: fi_FI.UTF-8
     state: present
+
+- include: developer-users.yml

--- a/ansible/vars/secrets-defaults.yml
+++ b/ansible/vars/secrets-defaults.yml
@@ -19,3 +19,4 @@ secret:
     - "vagrant@localhost"
   ckan_harvester_instruction_url: "http://example.com"
   analytics_auth_token: ""
+  developers: [] # [{user: github user name, remove: bool (optional)}]

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -836,7 +836,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
     def get_blueprint(self):
         from .views.useradd import useradd
         from .views import xroad_statistics
-        from.views import get_blueprints
+        from .views import get_blueprints
         return xroad_statistics.get_blueprints() + get_blueprints() + [useradd]
 
     # IFacets


### PR DESCRIPTION
# Description
Create developer accounts during deploy

## Jira ticket reference: [LIKA-342](https://jira.dvv.fi/browse/LIKA-342)

## What has changed:
- Added new secret value: developers
- Added ansible tasks for creating/removing developer accounts

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

