### PR TITLE
LIKA-342: Move developers from secrets to environment-specific variables

### DIFF
--- a/ansible/roles/os-base/tasks/developer-users.yml
+++ b/ansible/roles/os-base/tasks/developer-users.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure developer user accounts
-  loop: "{{ secret.developers }}"
+  loop: "{{ developers }}"
   when: not item.remove|default(false)
   user:
     name: "{{ item.user }}"
@@ -10,19 +10,19 @@
     password: "*" # disable password
 
 - name: Remove old developer user accounts
-  loop: "{{ secret.developers }}"
+  loop: "{{ developers }}"
   when: item.remove|default(false)
   user:
     name: "{{ item.user }}"
     state: "absent"
 
 - name: Ensure developer .ssh directories
-  loop: "{{ secret.developers }}"
+  loop: "{{ developers }}"
   when: not item.remove|default(false)
   file: path=/home/{{ item.user }}/.ssh state=directory mode="0700" owner={{ item.user }} group={{ item.user }}
 
 - name: Deploy developer SSH keys
-  loop: "{{ secret.developers }}"
+  loop: "{{ developers }}"
   when: not item.remove|default(false)
   uri:
     url: "https://github.com/{{ item.user }}.keys"

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -22,3 +22,5 @@ system:
   ubuntu_codename: bionic
   postgresql:
     version: 10
+
+developers: [] # [{user: github user name, remove: bool (optional)}]

--- a/ansible/vars/environment-specific/prod.yml
+++ b/ansible/vars/environment-specific/prod.yml
@@ -125,3 +125,8 @@ allowed_user_editors:
 
 allowed_member_editors:
   - csc_admin
+
+developers:
+  - user: bzar
+  - user: zharktas
+  - user: eetumans

--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -126,3 +126,8 @@ allowed_user_editors:
 
 allowed_member_editors:
   - csc_admin
+
+developers:
+  - user: bzar
+  - user: zharktas
+  - user: eetumans

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -122,3 +122,8 @@ allowed_user_editors:
 
 allowed_member_editors:
   - csc_admin
+
+developers:
+  - user: bzar
+  - user: zharktas
+  - user: eetumans

--- a/ansible/vars/secrets-defaults.yml
+++ b/ansible/vars/secrets-defaults.yml
@@ -19,4 +19,3 @@ secret:
     - "vagrant@localhost"
   ckan_harvester_instruction_url: "http://example.com"
   analytics_auth_token: ""
-  developers: [] # [{user: github user name, remove: bool (optional)}]


### PR DESCRIPTION
# Description
Remove developers from secrets and add them to environment configurations

## Jira ticket reference: [LIKA-342](https://jira.dvv.fi/browse/LIKA-342)

## What has changed:
- Remove developers from secrets
- Add developers to environment configurations
- Modify ansible tasks accordingly

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

