### PR TITLE
LIKA-498: Clean up unnecessary fields from subsystem/resource additional info table

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -34,7 +34,8 @@
       "form_languages": ["fi", "sv", "en"],
       "group_title": "Subsystem description",
       "group_description": "General, compact and easy to understand description of the subsystem. You can use markdown formatting in the description.<br><br><div class=\"collapsible-container\"><button type=\"button\" class=\"collapsible dataset-collapsible\" data-module=\"collapsible\">Instructions for writing the description <i class=\"collapsible-icon fa fa-chevron-down\"></i></button><div class=\"collapsible-content dataset-collapsible-content\"><p>The description should contain at least the following things:</p><ul><li>What services does the subsystem provide?<ul><li>What interfaces does the subsystem have?</li><li>What kind of information can other organizations get through the services?</li></ul><li>What kind of conditions and limitations have to be considered in the use of the subsystem's services?<ul><li>Is the use of the services, for example, limited to certain kinds of organizations?</li><li>What's the cost of using the services?</li></ul></li><li>How can you get access to the service?<ul><li>What is the process like for the introduction of the service to use?</li><li>Does the use of the service require, for example, acquiring an information permission?</li></ul></li></ul><p>More detailed instructions for writing the description of the service can be found in <a href=\"https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5ef313c79a155e0139629cb5\">API catalog instructions</a>.</div></div>",
-      "end_of_section": true
+      "end_of_section": true,
+      "display_snippet": null
     },
     {
       "field_name": "keywords",
@@ -51,7 +52,8 @@
       "description": "",
       "group_title": "Keywords",
       "group_description": "Using keywords the user can easily find this application or similar applications through the search function. Choose at least one Finnish keyword.",
-      "end_of_section": true
+      "end_of_section": true,
+      "display_snippet": null
     },
     {
       "field_name": "maintainer",
@@ -96,7 +98,8 @@
           "label": "Limited"
         }
       ],
-      "default_value": "true"
+      "default_value": "true",
+      "display_snippet": null
     },
     {
       "field_name": "allowed_organizations",
@@ -105,7 +108,8 @@
       "preset": "apicatalog_organization_string_autocomplete",
       "validators": "ignore_missing",
       "form_placeholder": "Allowed organizations",
-      "end_of_section": true
+      "end_of_section": true,
+      "display_snippet": null
     },
     {
       "field_name": "validSince",


### PR DESCRIPTION
# Description
This removes duplicated information, internal information (doesn't interest the user) and empty rows from subsystem and resource additional info tables

## Jira ticket reference: [LIKA-498](https://jira.dvv.fi/browse/LIKA-498)

## What has changed:
* Hide (null display_snippets) for description and keywords that are already separately listed above
* Hide (null display snippets) for privateness(?) and allowed organizations
* Hide empty rows (rows without values). Template change at [vrk-kpa/ckanext-scheming](https://github.com/vrk-kpa/ckanext-scheming) level so it affects both LIKA and AV

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.

Technically yes but as it only hides some rows the impact is minimal
