### PR TITLE
LIKA-342: Create a new user group for developers

### DIFF
--- a/ansible/roles/os-base/tasks/developer-users.yml
+++ b/ansible/roles/os-base/tasks/developer-users.yml
@@ -37,9 +37,9 @@
     force: true
 
 - name: Developer sudo configuration
-  template:
-    src: sudoers.d.developers.j2
-    dest: /etc/sudoers.d/developers
-    mode: "0440"
-    owner: root
-    group: root
+  community.general.sudoers:
+    name: developers
+    state: present
+    group: developers
+    commands: ALL
+    nopassword: true

--- a/ansible/roles/os-base/tasks/developer-users.yml
+++ b/ansible/roles/os-base/tasks/developer-users.yml
@@ -1,12 +1,17 @@
 ---
 
+- name: Ensure developer user group
+  group:
+    name: developers
+    state: present
+
 - name: Ensure developer user accounts
   loop: "{{ developers }}"
   when: not item.remove|default(false)
   user:
     name: "{{ item.user }}"
     state: "present"
-    groups: "sudo"
+    groups: "developers"
     password: "*" # disable password
 
 - name: Remove old developer user accounts
@@ -30,3 +35,11 @@
     mode: "0600"
     owner: "{{ item.user }}"
     force: true
+
+- name: Developer sudo configuration
+  template:
+    src: sudoers.d.developers.j2
+    dest: /etc/sudoers.d/developers
+    mode: "0440"
+    owner: root
+    group: root

--- a/ansible/roles/os-base/templates/sudoers.d.developers.j2
+++ b/ansible/roles/os-base/templates/sudoers.d.developers.j2
@@ -1,2 +1,0 @@
-# Developers don't have passwords set and only log in using SSH keys
-%developers ALL=(ALL) NOPASSWD: ALL

--- a/ansible/roles/os-base/templates/sudoers.d.developers.j2
+++ b/ansible/roles/os-base/templates/sudoers.d.developers.j2
@@ -1,0 +1,2 @@
+# Developers don't have passwords set and only log in using SSH keys
+%developers ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
# Description
Create a new user group `developers` for developer user accounts to handle sudo configuration

## Jira ticket reference: [LIKA-342](https://jira.dvv.fi/browse/LIKA-342)

## What has changed:
- Create `developers` user group
- Add developer users to this group instead of `sudo`
- Create specific sudo configuration for the group

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No
