### PR TITLE
LIKA-484: Remove old permission application links

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/read.html
@@ -15,11 +15,6 @@
 {% endblock %}
 
 {% block content_action %}
-  {% if h.is_extension_loaded('apply_permissions_for_service')
-     and h.check_access('service_permission_application_create', {})
-     and not h.check_access('package_update', {'id':pkg.id }) %}
-    {% snippet 'apply_permissions_for_service/snippets/request_access_button.html', subsystem_id=pkg.name %}
-  {% endif %}
   {{ super() }}
 {% endblock %}
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
@@ -48,9 +48,6 @@
             {% if 'datastore' in g.plugins %}
               <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
             {% endif %}
-                {% if h.organizations_available() and h.is_extension_loaded('apply_permissions_for_service') and not h.check_access('package_update', {'id':pkg.id }) %}
-                    {% snippet 'apply_permissions_for_service/snippets/request_access_button.html', subsystem_id=pkg.name %}
-                {% endif %}
             {% endblock %}
           </ul>
           {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/request_access_button.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/request_access_button.html
@@ -1,6 +1,0 @@
-{% set access_request_url = h.service_permission_application_url(subsystem_id) %}
-{% if access_request_url %}
-<a href="{{ access_request_url }}" class="btn">{{ _('Request access') }}</a>
-{% elif h.service_permission_applications_enabled(subsystem_id) %}
-  {% link_for _('Request access'), named_route='apply_permissions.new_permission_application', subsystem_id=subsystem_id, class_='btn', icon='' %}
-{% endif %}


### PR DESCRIPTION
# Description
Removes the old permission application links from both subsystem page and resource page

## Jira ticket reference: [LIKA-484](https://jira.dvv.fi/browse/LIKA-484)

## What has changed:
Removed the old permission application links from both subsystem page and resource page

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Technically yes, although I'd say it very much depends on your definition of impact... 

There was a link
![image](https://user-images.githubusercontent.com/3969176/187660756-4ae2febd-5f2c-4eca-b878-ce2c16b5f072.png)
Now there's not
![image](https://user-images.githubusercontent.com/3969176/187660809-3cdebd16-b440-41e4-8f69-23cc91e323b9.png)

There used to be a link
![image](https://user-images.githubusercontent.com/3969176/187660857-3d0a8bdb-bb75-44aa-8681-b5c503bef5be.png)
Now there's not
![image](https://user-images.githubusercontent.com/3969176/187660879-0acef2b9-1e13-44b2-925b-5e54ced1a9f9.png)


