### PR TITLE
LIKA-495: Fix stats to use correct prop names and format dates

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/admin/statistics.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/admin/statistics.html
@@ -13,16 +13,15 @@
     <table class="table table-condensed table-hover">
         <tr class="active">
             <td class="col-sm-3">
-                <b>{% trans %}X-ROAD Graphs{% endtrans %}</b>&nbsp;&nbsp;{{xroad_stats.get('date', '')}}
+                <b>{% trans %}X-ROAD Graphs{% endtrans %}</b>&nbsp;&nbsp;<i>{{h.render_datetime(h.date_str_to_datetime(xroad_stats.get('date', '')), "%d.%m.%Y")}}</i>
             </td>
-            <td>
-            </td>
+            <td></td>
         </tr>
         <tr>
-            <td>
+            <td class="col-sm-3">
                 <b>{% trans %}X-Road Environment:{% endtrans %}</b>
             </td>
-            <td>
+            <td class="col-sm-9">
                 {{xroad_stats.get('instanceIdentifier', '')}}
             </td>
         </tr>
@@ -51,10 +50,8 @@
             </td>
         </tr>
         <tr class="active">
-            <td class="col-sm-3">
-                <b>{% trans %}X-ROAD Catalog - Services{% endtrans %}</b>&nbsp;&nbsp;{{xroad_services.get('date', '')}}
-            </td>
-            <td>
+            <td colspan="2">
+                <b>{% trans %}X-ROAD Catalog - Services{% endtrans %}</b>&nbsp;&nbsp;<i>{{h.render_datetime(h.date_str_to_datetime(xroad_services.get('date', '')), "%d.%m.%Y")}}</i>
             </td>
         </tr>
         <tr>
@@ -62,7 +59,7 @@
                 <b>{% trans %}SOAP services: {% endtrans %}</b>
             </td>
             <td>
-                {{xroad_services.get('soapServiceCount', '')}}
+                {{xroad_services.get('soap_service_count', '')}}
             </td>
         </tr>
         <tr>
@@ -70,7 +67,7 @@
                 <b>{% trans %}REST services: {% endtrans %}</b>
             </td>
             <td>
-                {{xroad_services.get('restServiceCount', '')}}
+                {{xroad_services.get('rest_service_count', '')}}
             </td>
         </tr>
         <tr>
@@ -78,14 +75,12 @@
                 <b>{% trans %}OpenAPI services: {% endtrans %}</b>
             </td>
             <td>
-                {{xroad_services.get('openapiServiceCount', '')}}
+                {{xroad_services.get('openapi_service_count', '')}}
             </td>
         </tr>
         <tr class="active">
-            <td class="col-sm-3">
-                <b>{% trans %}X-ROAD Catalog - Distinct Services{% endtrans %}</b>&nbsp;&nbsp;{{xroad_distinct_services.get('date', '')}}
-            </td>
-            <td>
+            <td colspan="2">
+                <b>{% trans %}X-ROAD Catalog - Distinct Services{% endtrans %}</b>&nbsp;&nbsp;<i>{{h.render_datetime(h.date_str_to_datetime(xroad_distinct_services.get('date', '')), "%d.%m.%Y")}}</i>
             </td>
         </tr>
         <tr>
@@ -93,14 +88,12 @@
                 <b>{% trans %}Distinct services: {% endtrans %}</b>
             </td>
             <td>
-                {{xroad_distinct_services.get('distinctServiceCount', '')}}
+                {{xroad_distinct_services.get('distinct_service_count', '')}}
             </td>
         </tr>
         <tr class="active">
-            <td>
-                <b>{% trans %}CKAN{% endtrans %}</b>&nbsp;&nbsp;Current
-            </td>
-            <td>
+            <td colspan="2">
+                <b>{% trans %}CKAN{% endtrans %}</b>&nbsp;&nbsp;<i>Current</i>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
# Description
Fixed stats page to use correct prop names and formatted dates

## Jira ticket reference: [LIKA-495](https://jira.dvv.fi/browse/LIKA-495)

## What has changed:
* Switched to use correct prop names (underscore_case vs camelCase)
* Formatted dates
* Actually tested the changes (inserted data into DB so I could verify I didn't do a dummy again) 

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/3969176/189320541-dd6f0ca7-3d90-42a7-9e61-b2e29604f2b2.png)


