### PR TITLE
LIKA-453: Fix harvest errors

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -878,9 +878,13 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
             # OR
             # 3) Visibility/private is limited (True) AND the logged in user's list of organizations contains
             #    the organization of the package
-            user_orgs = toolkit.get_action('organization_list_for_user')(
-                {'ignore_auth': True},
-                {'id': toolkit.g.user, 'permission': 'read'})
+            if 'user' in toolkit.g:
+                user_orgs = toolkit.get_action('organization_list_for_user')(
+                    {'ignore_auth': True},
+                    {'id': toolkit.g.user, 'permission': 'read'})
+            else:
+                user_orgs = []
+
             allowed_resources = [resource for resource in result.get('resources', [])
                                  if resource.get('access_restriction_level', '') in ('', 'public') or
                                  ((resource.get('access_restriction_level', '') == 'private')


### PR DESCRIPTION
# Description
Fix some errors during harvesting

## Jira ticket reference: [LIKA-453](https://jira.dvv.fi/browse/LIKA-453)

## What has changed:
- Fix crash in ckanext-apicatalog `after_search` if no user object in global context
- Remove request context from harvester jobs to fix after_search authorization during harvesting

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

