### PR TITLE
LIKA-467: Choose resource edit form labels based on resource type

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/helpers.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/helpers.py
@@ -1,4 +1,5 @@
 import itertools
+import copy
 from datetime import datetime
 
 from ckan.plugins.toolkit import get_action, request
@@ -112,3 +113,23 @@ def parse_datetime(t):
         except Exception as e:
             log.warn(e)
             return None
+
+
+def with_field_string_replacements(fields, replaced, replacement, affected_values):
+    fields = copy.deepcopy(fields)
+
+    def process(value):
+        if isinstance(value, list):
+            return [process(v) for v in value]
+        else:
+            return (value
+                    .replace(replaced, replacement)
+                    .replace(replaced.capitalize(), replacement.capitalize()))
+
+    for field in fields:
+        for value_name in affected_values:
+            value = field.get(value_name)
+            if value is not None:
+                field[value_name] = process(value)
+
+    return fields

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-27 10:25+0000\n"
+"POT-Creation-Date: 2022-09-20 11:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,27 +22,27 @@ msgstr ""
 msgid "User {user} not authorized to create users via the API"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:678
+#: ckanext/apicatalog/plugin.py:632
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:875
+#: ckanext/apicatalog/plugin.py:829
 #: ckanext/apicatalog/templates/package/read.html:61
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:876
+#: ckanext/apicatalog/plugin.py:830
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:877
+#: ckanext/apicatalog/plugin.py:831
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:878
+#: ckanext/apicatalog/plugin.py:832
 msgid "Formats"
 msgstr ""
 
@@ -116,7 +116,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:71
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
 #: ckanext/apicatalog/translations.py:27
 msgid "Discard changes"
 msgstr ""
@@ -267,62 +267,83 @@ msgid ""
 " catalog instructions</a>.</div></div>"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:60
+#: ckanext/apicatalog/translations.py:77
 msgid "Write the subsystem's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:61
+#: ckanext/apicatalog/translations.py:78
+msgid "Write the service's description"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:79
+msgid "Write the attachment's description"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
+#: ckanext/apicatalog/translations.py:80
+msgid "Update Service"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:81
+msgid "Edit service"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:82
+msgid "Edit attachment"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:83
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
 "keyword."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:62
+#: ckanext/apicatalog/translations.py:85
 msgid "Write a keyword"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:63
+#: ckanext/apicatalog/translations.py:86
 msgid "Maintainer's information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:64
+#: ckanext/apicatalog/translations.py:87
 msgid "Use the maintainer's common contact information."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:65
+#: ckanext/apicatalog/translations.py:88
 msgid "The name of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:66
+#: ckanext/apicatalog/translations.py:89
 msgid "The email of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:67
+#: ckanext/apicatalog/translations.py:90
 msgid "Limited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:68
+#: ckanext/apicatalog/translations.py:91
 msgid "Allowed organizations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:69
+#: ckanext/apicatalog/translations.py:92
 msgid "Other information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:70
+#: ckanext/apicatalog/translations.py:93
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:71
+#: ckanext/apicatalog/translations.py:94
 msgid "fi"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:72
+#: ckanext/apicatalog/translations.py:95
 msgid "en"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:73
+#: ckanext/apicatalog/translations.py:96
 msgid "sv"
 msgstr ""
 
@@ -665,6 +686,66 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ckanext/apicatalog/templates/admin/statistics.html:16
+msgid "X-ROAD Graphs"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:23
+msgid "X-Road Environment:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:31
+msgid "Subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:39
+msgid "Members:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:47
+msgid "SecurityServers:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:55
+msgid "X-ROAD Catalog - Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:62
+msgid "SOAP services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:70
+msgid "REST services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:78
+msgid "OpenAPI services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:86
+msgid "X-ROAD Catalog - Distinct Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:93
+msgid "Distinct services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:101
+msgid "CKAN"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:108
+msgid "Public subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:116
+msgid "Total organizations:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:124
+msgid "Provider organizations:"
+msgstr ""
+
 #: ckanext/apicatalog/templates/admin/useradd.html:9
 #, python-format
 msgid ""
@@ -695,18 +776,6 @@ msgstr ""
 #: ckanext/apicatalog/templates/admin/useradd.html:18
 #: ckanext/apicatalog/templates/contact/snippets/form_simple.html:24
 msgid "Submit"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:13
-msgid "X-Road Graphs"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:19
-msgid "FI"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:20
-msgid "FI-TEST"
 msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:4
@@ -1239,7 +1308,7 @@ msgstr ""
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr ""
@@ -1357,7 +1426,7 @@ msgid "Subsystem information"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:39
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:62
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr ""
 
@@ -1369,15 +1438,11 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:7
+#: ckanext/apicatalog/templates/package/resource_edit.html:13
 msgid "Cancel edit"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:16
-msgid "Edit resource"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/resource_edit.html:25
+#: ckanext/apicatalog/templates/package/resource_edit.html:31
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
@@ -1453,6 +1518,10 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:7
+msgid "Update Resource"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/resource_item.html:26
 msgid "Invalid content"
 msgstr ""
@@ -1474,7 +1543,7 @@ msgid "This resource view is not available at the moment."
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_view.html:20
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:122
 msgid "Click here for more information."
 msgstr ""
 
@@ -1533,81 +1602,81 @@ msgstr ""
 msgid "API Endpoint"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:77
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:74
 msgid "From the dataset abstract"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:79
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:76
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:119
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:116
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:123
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:130
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:127
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:131
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:132
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:129
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, or"
 " the data may not have been pushed to the DataStore, or the DataStore hasn't "
 "finished processing the data yet"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:151
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:148
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:155
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
 msgid "Field"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:156
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:153
 msgid "Value"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:162
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:159
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:163
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:169
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:175
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:160
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:166
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:172
 msgid "unknown"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:168
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:165
 msgid "Created"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:174
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
 msgid "Format"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:180
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:177
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 msgid "Are you sure you want to delete this resource?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
 msgid "Finish"
 msgstr ""
 
@@ -1777,8 +1846,7 @@ msgid ""
 "href=\"mailto:palveluvayla@palveluvayla.fi\">palveluvayla@palveluvayla.fi</a>."
 msgstr ""
 
-#: ckanext/apicatalog/views/useradd.py:41
-#: ckanext/apicatalog/views/xroad_statistics.py:19
+#: ckanext/apicatalog/views/statistics.py:19 ckanext/apicatalog/views/useradd.py:41
 msgid "Not authorized to see this page"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/en_GB/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/en_GB/LC_MESSAGES/ckanext-apicatalog.po
@@ -8,15 +8,16 @@
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022
 # Suvi Nuttunen, 2022
+# Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-27 10:25+0000\n"
+"POT-Creation-Date: 2022-09-20 09:59+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Suvi Nuttunen, 2022\n"
+"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,27 +30,27 @@ msgstr ""
 msgid "User {user} not authorized to create users via the API"
 msgstr "User {user} not authorised to create users via the API"
 
-#: ckanext/apicatalog/plugin.py:678
+#: ckanext/apicatalog/plugin.py:632
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:875
+#: ckanext/apicatalog/plugin.py:829
 #: ckanext/apicatalog/templates/package/read.html:61
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:876
+#: ckanext/apicatalog/plugin.py:830
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr "Organisation"
 
-#: ckanext/apicatalog/plugin.py:877
+#: ckanext/apicatalog/plugin.py:831
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:878
+#: ckanext/apicatalog/plugin.py:832
 msgid "Formats"
 msgstr ""
 
@@ -129,7 +130,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:71
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
 #: ckanext/apicatalog/translations.py:27
 msgid "Discard changes"
 msgstr ""
@@ -300,11 +301,20 @@ msgstr ""
 "href=\"https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5ef313c79a155e0139629cb5\">API"
 " catalog instructions</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:60
+#: ckanext/apicatalog/translations.py:77
 msgid "Write the subsystem's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:61
+#: ckanext/apicatalog/translations.py:78
+msgid "Write the service's description"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
+#: ckanext/apicatalog/translations.py:79
+msgid "Update Service"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:80
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -313,51 +323,51 @@ msgstr ""
 "Using keywords the user can easily find this subsystem or similar subsystems"
 " through the search function. Choose at least one Finnish keyword."
 
-#: ckanext/apicatalog/translations.py:62
+#: ckanext/apicatalog/translations.py:82
 msgid "Write a keyword"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:63
+#: ckanext/apicatalog/translations.py:83
 msgid "Maintainer's information"
 msgstr "Administrator's contact information"
 
-#: ckanext/apicatalog/translations.py:64
+#: ckanext/apicatalog/translations.py:84
 msgid "Use the maintainer's common contact information."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:65
+#: ckanext/apicatalog/translations.py:85
 msgid "The name of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:66
+#: ckanext/apicatalog/translations.py:86
 msgid "The email of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:67
+#: ckanext/apicatalog/translations.py:87
 msgid "Limited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:68
+#: ckanext/apicatalog/translations.py:88
 msgid "Allowed organizations"
 msgstr "Allowed organisations"
 
-#: ckanext/apicatalog/translations.py:69
+#: ckanext/apicatalog/translations.py:89
 msgid "Other information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:70
+#: ckanext/apicatalog/translations.py:90
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:71
+#: ckanext/apicatalog/translations.py:91
 msgid "fi"
 msgstr "in Finnish"
 
-#: ckanext/apicatalog/translations.py:72
+#: ckanext/apicatalog/translations.py:92
 msgid "en"
 msgstr "in English"
 
-#: ckanext/apicatalog/translations.py:73
+#: ckanext/apicatalog/translations.py:93
 msgid "sv"
 msgstr "in Swedish"
 
@@ -700,6 +710,66 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ckanext/apicatalog/templates/admin/statistics.html:16
+msgid "X-ROAD Graphs"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:23
+msgid "X-Road Environment:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:31
+msgid "Subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:39
+msgid "Members:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:47
+msgid "SecurityServers:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:55
+msgid "X-ROAD Catalog - Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:62
+msgid "SOAP services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:70
+msgid "REST services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:78
+msgid "OpenAPI services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:86
+msgid "X-ROAD Catalog - Distinct Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:93
+msgid "Distinct services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:101
+msgid "CKAN"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:108
+msgid "Public subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:116
+msgid "Total organizations:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:124
+msgid "Provider organizations:"
+msgstr ""
+
 #: ckanext/apicatalog/templates/admin/useradd.html:9
 #, python-format
 msgid ""
@@ -730,18 +800,6 @@ msgstr ""
 #: ckanext/apicatalog/templates/admin/useradd.html:18
 #: ckanext/apicatalog/templates/contact/snippets/form_simple.html:24
 msgid "Submit"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:13
-msgid "X-Road Graphs"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:19
-msgid "FI"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:20
-msgid "FI-TEST"
 msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:4
@@ -1287,7 +1345,7 @@ msgstr ""
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr ""
@@ -1317,7 +1375,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/organization/snippets/organization_item.html:25
 msgid "View {organization_name}"
-msgstr "View {organisation_name}"
+msgstr "View {organization_name}"
 
 #: ckanext/apicatalog/templates/organization/snippets/organization_item.html:40
 msgid "Consumes data available via the Suomi.fi-Data Exchange Layer."
@@ -1414,7 +1472,7 @@ msgid "Subsystem information"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:39
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:62
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr ""
 
@@ -1426,15 +1484,11 @@ msgstr ""
 msgid "Groups"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:7
+#: ckanext/apicatalog/templates/package/resource_edit.html:13
 msgid "Cancel edit"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:16
-msgid "Edit resource"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/resource_edit.html:25
+#: ckanext/apicatalog/templates/package/resource_edit.html:31
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
@@ -1510,6 +1564,10 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:7
+msgid "Update Resource"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/resource_item.html:26
 msgid "Invalid content"
 msgstr ""
@@ -1531,7 +1589,7 @@ msgid "This resource view is not available at the moment."
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_view.html:20
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:122
 msgid "Click here for more information."
 msgstr ""
 
@@ -1594,81 +1652,81 @@ msgstr ""
 msgid "API Endpoint"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:77
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:74
 msgid "From the dataset abstract"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:79
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:76
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:119
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:116
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:123
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:130
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:127
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:131
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:132
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:129
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:151
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:148
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:155
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
 msgid "Field"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:156
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:153
 msgid "Value"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:162
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:159
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:163
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:169
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:175
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:160
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:166
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:172
 msgid "unknown"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:168
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:165
 msgid "Created"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:174
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
 msgid "Format"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:180
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:177
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 msgid "Are you sure you want to delete this resource?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
 msgid "Finish"
 msgstr ""
 
@@ -1838,8 +1896,8 @@ msgid ""
 "href=\"mailto:palveluvayla@palveluvayla.fi\">palveluvayla@palveluvayla.fi</a>."
 msgstr ""
 
+#: ckanext/apicatalog/views/statistics.py:19
 #: ckanext/apicatalog/views/useradd.py:41
-#: ckanext/apicatalog/views/xroad_statistics.py:19
 msgid "Not authorized to see this page"
 msgstr "Not authorised to see this page"
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
@@ -8,15 +8,16 @@
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
 # Suvi Nuttunen, 2022
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022
+# Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-27 10:25+0000\n"
+"POT-Creation-Date: 2022-09-20 11:06+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022\n"
+"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -30,27 +31,27 @@ msgid "User {user} not authorized to create users via the API"
 msgstr ""
 "Käyttäjällä {user} ei ole oikeutta luoda käyttäjiä API-rajapinnan kautta."
 
-#: ckanext/apicatalog/plugin.py:678
+#: ckanext/apicatalog/plugin.py:632
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:875
+#: ckanext/apicatalog/plugin.py:829
 #: ckanext/apicatalog/templates/package/read.html:61
 msgid "Services"
 msgstr "Palvelut"
 
-#: ckanext/apicatalog/plugin.py:876
+#: ckanext/apicatalog/plugin.py:830
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr "Organisaatio"
 
-#: ckanext/apicatalog/plugin.py:877
+#: ckanext/apicatalog/plugin.py:831
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr "Asiasanat"
 
-#: ckanext/apicatalog/plugin.py:878
+#: ckanext/apicatalog/plugin.py:832
 msgid "Formats"
 msgstr "Tiedostomuodot"
 
@@ -129,7 +130,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:71
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
 #: ckanext/apicatalog/translations.py:27
 msgid "Discard changes"
 msgstr "Hylkää muutokset"
@@ -308,11 +309,32 @@ msgstr ""
 "href=\"https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/5ef313c79a155e0139629cb5\">Liityntäkatalogin"
 " ohjeista</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:60
+#: ckanext/apicatalog/translations.py:77
 msgid "Write the subsystem's description"
 msgstr "Kirjoita alijärjestelmän kuvaus"
 
-#: ckanext/apicatalog/translations.py:61
+#: ckanext/apicatalog/translations.py:78
+msgid "Write the service's description"
+msgstr "Kirjoita palvelun kuvaus"
+
+#: ckanext/apicatalog/translations.py:79
+msgid "Write the attachment's description"
+msgstr "Kirjoita liitetiedoston kuvaus"
+
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
+#: ckanext/apicatalog/translations.py:80
+msgid "Update Service"
+msgstr "Päivitä palvelu"
+
+#: ckanext/apicatalog/translations.py:81
+msgid "Edit service"
+msgstr "Muokkaa palvelua"
+
+#: ckanext/apicatalog/translations.py:82
+msgid "Edit attachment"
+msgstr "Muokkaa liitetiedostoa"
+
+#: ckanext/apicatalog/translations.py:83
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -322,51 +344,51 @@ msgstr ""
 "alijärjestelmiä helposti hakusivun kautta. Valitse vähintään yksi "
 "suomenkielinen avainsana."
 
-#: ckanext/apicatalog/translations.py:62
+#: ckanext/apicatalog/translations.py:85
 msgid "Write a keyword"
 msgstr "Kirjoita avainsana"
 
-#: ckanext/apicatalog/translations.py:63
+#: ckanext/apicatalog/translations.py:86
 msgid "Maintainer's information"
 msgstr "Ylläpitäjän yhteystiedot"
 
-#: ckanext/apicatalog/translations.py:64
+#: ckanext/apicatalog/translations.py:87
 msgid "Use the maintainer's common contact information."
 msgstr "Käytä organisaation yleisiä yhteystietoja."
 
-#: ckanext/apicatalog/translations.py:65
+#: ckanext/apicatalog/translations.py:88
 msgid "The name of the maintainer"
 msgstr "Ylläpitäjän nimi"
 
-#: ckanext/apicatalog/translations.py:66
+#: ckanext/apicatalog/translations.py:89
 msgid "The email of the maintainer"
 msgstr "Ylläpitäjän sähköposti"
 
-#: ckanext/apicatalog/translations.py:67
+#: ckanext/apicatalog/translations.py:90
 msgid "Limited"
 msgstr "Rajoitettu"
 
-#: ckanext/apicatalog/translations.py:68
+#: ckanext/apicatalog/translations.py:91
 msgid "Allowed organizations"
 msgstr "Sallitut organisaatiot"
 
-#: ckanext/apicatalog/translations.py:69
+#: ckanext/apicatalog/translations.py:92
 msgid "Other information"
 msgstr "Voimassaoloaika"
 
-#: ckanext/apicatalog/translations.py:70
+#: ckanext/apicatalog/translations.py:93
 msgid "dd/mm/yyyy"
 msgstr "pp.kk.vvvv"
 
-#: ckanext/apicatalog/translations.py:71
+#: ckanext/apicatalog/translations.py:94
 msgid "fi"
 msgstr "suomeksi"
 
-#: ckanext/apicatalog/translations.py:72
+#: ckanext/apicatalog/translations.py:95
 msgid "en"
 msgstr "englanniksi"
 
-#: ckanext/apicatalog/translations.py:73
+#: ckanext/apicatalog/translations.py:96
 msgid "sv"
 msgstr "ruotsiksi"
 
@@ -715,6 +737,66 @@ msgstr "Kyllä"
 msgid "No"
 msgstr "Ei"
 
+#: ckanext/apicatalog/templates/admin/statistics.html:16
+msgid "X-ROAD Graphs"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:23
+msgid "X-Road Environment:"
+msgstr "X-Road-ympäristö:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:31
+msgid "Subsystems:"
+msgstr "Alijärjestelmiä:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:39
+msgid "Members:"
+msgstr "Jäseniä:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:47
+msgid "SecurityServers:"
+msgstr "Turvallisuuspalvelimia:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:55
+msgid "X-ROAD Catalog - Services"
+msgstr "X-ROAD Catalog - Palvelut"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:62
+msgid "SOAP services:"
+msgstr "SOAP-palvelut:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:70
+msgid "REST services:"
+msgstr "REST-palvelut:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:78
+msgid "OpenAPI services:"
+msgstr "OpenAPI-palvelut:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:86
+msgid "X-ROAD Catalog - Distinct Services"
+msgstr "X-ROAD Catalog: Erilliset palvelut"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:93
+msgid "Distinct services:"
+msgstr "Erilliset palvelut:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:101
+msgid "CKAN"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:108
+msgid "Public subsystems:"
+msgstr "Julkisia alijärjestelmiä:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:116
+msgid "Total organizations:"
+msgstr "Organisaatioita yhteensä:"
+
+#: ckanext/apicatalog/templates/admin/statistics.html:124
+msgid "Provider organizations:"
+msgstr "Tuottajaorganisaatioita"
+
 #: ckanext/apicatalog/templates/admin/useradd.html:9
 #, python-format
 msgid ""
@@ -748,18 +830,6 @@ msgstr "joe@example.com"
 #: ckanext/apicatalog/templates/contact/snippets/form_simple.html:24
 msgid "Submit"
 msgstr "Lähetä"
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:13
-msgid "X-Road Graphs"
-msgstr "X-Roadin kaaviot"
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:19
-msgid "FI"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:20
-msgid "FI-TEST"
-msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:4
 #: ckanext/apicatalog/templates/home/layout1.html:75
@@ -1340,7 +1410,7 @@ msgstr "Haluatko varmasti poistaa tämän jäsenen?"
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr "Poista"
@@ -1466,7 +1536,7 @@ msgid "Subsystem information"
 msgstr "Alijärjestelmän tiedot"
 
 #: ckanext/apicatalog/templates/package/read.html:39
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:62
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr "Tunniste Palveluväylässä"
 
@@ -1478,15 +1548,11 @@ msgstr "Kuvaus"
 msgid "Groups"
 msgstr "Ryhmät"
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:7
+#: ckanext/apicatalog/templates/package/resource_edit.html:13
 msgid "Cancel edit"
 msgstr "Peruuta muokkaus"
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:16
-msgid "Edit resource"
-msgstr "Muokkaa liitetiedostoa"
-
-#: ckanext/apicatalog/templates/package/resource_edit.html:25
+#: ckanext/apicatalog/templates/package/resource_edit.html:31
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
@@ -1577,6 +1643,10 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr "Haluatko varmasti poistaa alijärjestelmän?"
 
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:7
+msgid "Update Resource"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/resource_item.html:26
 msgid "Invalid content"
 msgstr "Virheellistä sisältöä"
@@ -1598,7 +1668,7 @@ msgid "This resource view is not available at the moment."
 msgstr "Tämä liitetiedostonäyttö ei ole saatavissa tällä hetkellä."
 
 #: ckanext/apicatalog/templates/package/snippets/resource_view.html:20
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:122
 msgid "Click here for more information."
 msgstr "Klikkaa tästä saadaksesi lisätietoa..."
 
@@ -1663,38 +1733,38 @@ msgstr "Hallinnoi"
 msgid "API Endpoint"
 msgstr "API-osoite"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:77
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:74
 msgid "From the dataset abstract"
 msgstr "Alijärjestelmän yhteenvedosta"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:79
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:76
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr "Lähde: <a href=\"%(url)s\">%(dataset)s</a>"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:119
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:116
 msgid "There are no views created for this resource yet."
 msgstr "Tälle liitetiedostolle ei ole luotu vielä yhtään näkymää."
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:123
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
 msgid "Not seeing the views you were expecting?"
 msgstr "Et näe odottamiasi näkymiä?"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr "Tässä joitakin syitä, jos et näe odottamiasi näkymiä:"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:130
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:127
 msgid "No view has been created that is suitable for this resource"
 msgstr "Tälle liitetiedostolle ei ole luotu yhtään sopivaa näkymää"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:131
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 "Voi olla, ettei järjestelmänhoitaja ole ottanut käyttöön asiaan liittyviä "
 "liitännäisiä"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:132
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:129
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
@@ -1704,45 +1774,45 @@ msgstr ""
 "otettu käyttöön, tai ettei tietoja ole tallennettu DataStoreen, tai ettei "
 "DataStore ole vielä saanut prosessointia valmiiksi"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:151
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:148
 msgid "Additional Information"
 msgstr "Lisätietoa"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:155
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
 msgid "Field"
 msgstr "Kenttä"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:156
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:153
 msgid "Value"
 msgstr "Arvo"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:162
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:159
 msgid "Last updated"
 msgstr "Viimeksi päivitetty"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:163
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:169
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:175
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:160
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:166
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:172
 msgid "unknown"
 msgstr "tuntematon"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:168
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:165
 msgid "Created"
 msgstr "Luotu"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:174
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
 msgid "Format"
 msgstr "Tiedostomuoto"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:180
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:177
 msgid "License"
 msgstr "Lisenssi"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 msgid "Are you sure you want to delete this resource?"
 msgstr "Haluatko varmasti poistaa tämän liitetiedoston?"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
 msgid "Finish"
 msgstr "Valmis"
 
@@ -1923,8 +1993,8 @@ msgstr ""
 "<a "
 "href=\"mailto:palveluvayla@palveluvayla.fi\">palveluvayla@palveluvayla.fi</a>."
 
+#: ckanext/apicatalog/views/statistics.py:19
 #: ckanext/apicatalog/views/useradd.py:41
-#: ckanext/apicatalog/views/xroad_statistics.py:19
 msgid "Not authorized to see this page"
 msgstr "Tämän sivun näyttäminen ei ole sallittu"
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-27 10:25+0000\n"
+"POT-Creation-Date: 2022-09-20 09:59+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
 "Last-Translator: Suvi Nuttunen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -31,27 +31,27 @@ msgid "User {user} not authorized to create users via the API"
 msgstr ""
 "Användare {user} har inte behörighet att skapa användare via subsystemet."
 
-#: ckanext/apicatalog/plugin.py:678
+#: ckanext/apicatalog/plugin.py:632
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:875
+#: ckanext/apicatalog/plugin.py:829
 #: ckanext/apicatalog/templates/package/read.html:61
 msgid "Services"
 msgstr "Tjänster"
 
-#: ckanext/apicatalog/plugin.py:876
+#: ckanext/apicatalog/plugin.py:830
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr "Organisation"
 
-#: ckanext/apicatalog/plugin.py:877
+#: ckanext/apicatalog/plugin.py:831
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr "Ämnesord"
 
-#: ckanext/apicatalog/plugin.py:878
+#: ckanext/apicatalog/plugin.py:832
 msgid "Formats"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:71
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
 #: ckanext/apicatalog/translations.py:27
 msgid "Discard changes"
 msgstr "Ignorera ändringar"
@@ -306,11 +306,20 @@ msgstr ""
 "href=\"https://palveluhallinta.suomi.fi/sv/tuki/artikkelit/5ef313c79a155e0139629cb5\">Beskrivning"
 " av tjänster i API-katalogen</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:60
+#: ckanext/apicatalog/translations.py:77
 msgid "Write the subsystem's description"
 msgstr "Skriv subsystemets beskrivning"
 
-#: ckanext/apicatalog/translations.py:61
+#: ckanext/apicatalog/translations.py:78
+msgid "Write the service's description"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
+#: ckanext/apicatalog/translations.py:79
+msgid "Update Service"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:80
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -319,51 +328,51 @@ msgstr ""
 "Med hjälp av nyckelord kan användaren enkelt hitta detta subsystem eller "
 "liknande subsystem genom sök funktionen. Välj minst ett finskt nyckelord."
 
-#: ckanext/apicatalog/translations.py:62
+#: ckanext/apicatalog/translations.py:82
 msgid "Write a keyword"
 msgstr "Skriv ett nyckelord"
 
-#: ckanext/apicatalog/translations.py:63
+#: ckanext/apicatalog/translations.py:83
 msgid "Maintainer's information"
 msgstr "Administratörens kontaktuppgifter"
 
-#: ckanext/apicatalog/translations.py:64
+#: ckanext/apicatalog/translations.py:84
 msgid "Use the maintainer's common contact information."
 msgstr "Använda administratörens allmänna kontaktuppgifter."
 
-#: ckanext/apicatalog/translations.py:65
+#: ckanext/apicatalog/translations.py:85
 msgid "The name of the maintainer"
 msgstr "Namnet av administratören"
 
-#: ckanext/apicatalog/translations.py:66
+#: ckanext/apicatalog/translations.py:86
 msgid "The email of the maintainer"
 msgstr "E-post av administratören"
 
-#: ckanext/apicatalog/translations.py:67
+#: ckanext/apicatalog/translations.py:87
 msgid "Limited"
 msgstr "Begränsad"
 
-#: ckanext/apicatalog/translations.py:68
+#: ckanext/apicatalog/translations.py:88
 msgid "Allowed organizations"
 msgstr "Tillåtna organisationer"
 
-#: ckanext/apicatalog/translations.py:69
+#: ckanext/apicatalog/translations.py:89
 msgid "Other information"
 msgstr "Giltighetstid"
 
-#: ckanext/apicatalog/translations.py:70
+#: ckanext/apicatalog/translations.py:90
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:71
+#: ckanext/apicatalog/translations.py:91
 msgid "fi"
 msgstr "på finska"
 
-#: ckanext/apicatalog/translations.py:72
+#: ckanext/apicatalog/translations.py:92
 msgid "en"
 msgstr "på engelska"
 
-#: ckanext/apicatalog/translations.py:73
+#: ckanext/apicatalog/translations.py:93
 msgid "sv"
 msgstr "på svenska"
 
@@ -710,6 +719,66 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nej"
 
+#: ckanext/apicatalog/templates/admin/statistics.html:16
+msgid "X-ROAD Graphs"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:23
+msgid "X-Road Environment:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:31
+msgid "Subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:39
+msgid "Members:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:47
+msgid "SecurityServers:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:55
+msgid "X-ROAD Catalog - Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:62
+msgid "SOAP services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:70
+msgid "REST services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:78
+msgid "OpenAPI services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:86
+msgid "X-ROAD Catalog - Distinct Services"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:93
+msgid "Distinct services:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:101
+msgid "CKAN"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:108
+msgid "Public subsystems:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:116
+msgid "Total organizations:"
+msgstr ""
+
+#: ckanext/apicatalog/templates/admin/statistics.html:124
+msgid "Provider organizations:"
+msgstr ""
+
 #: ckanext/apicatalog/templates/admin/useradd.html:9
 #, python-format
 msgid ""
@@ -743,18 +812,6 @@ msgstr "joe@example.com"
 #: ckanext/apicatalog/templates/contact/snippets/form_simple.html:24
 msgid "Submit"
 msgstr "Sänd"
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:13
-msgid "X-Road Graphs"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:19
-msgid "FI"
-msgstr ""
-
-#: ckanext/apicatalog/templates/admin/xroad_statistics.html:20
-msgid "FI-TEST"
-msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:4
 #: ckanext/apicatalog/templates/home/layout1.html:75
@@ -1320,7 +1377,7 @@ msgstr "Är du säker på att du vill ta bort medlemmen?"
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr "Radera"
@@ -1384,7 +1441,7 @@ msgstr "Bilagor"
 
 #: ckanext/apicatalog/templates/package/edit.html:13
 msgid "Access request settings"
-msgstr ""
+msgstr "Administrering av begäran om tillstånd"
 
 #: ckanext/apicatalog/templates/package/edit.html:14
 msgid "Received access requests"
@@ -1448,7 +1505,7 @@ msgid "Subsystem information"
 msgstr "Subsystemets information"
 
 #: ckanext/apicatalog/templates/package/read.html:39
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:62
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr "Kod i Informationsleden"
 
@@ -1460,15 +1517,11 @@ msgstr "Beskrivning"
 msgid "Groups"
 msgstr "Grupper"
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:7
+#: ckanext/apicatalog/templates/package/resource_edit.html:13
 msgid "Cancel edit"
 msgstr "Avbryt redigering"
 
-#: ckanext/apicatalog/templates/package/resource_edit.html:16
-msgid "Edit resource"
-msgstr "Redigera resurs"
-
-#: ckanext/apicatalog/templates/package/resource_edit.html:25
+#: ckanext/apicatalog/templates/package/resource_edit.html:31
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
@@ -1556,6 +1609,10 @@ msgstr ""
 msgid "Are you sure you want to delete this dataset?"
 msgstr "Vill du verkligen radera detta subsystem?"
 
+#: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:7
+msgid "Update Resource"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/resource_item.html:26
 msgid "Invalid content"
 msgstr "Felaktigt innehåll"
@@ -1577,7 +1634,7 @@ msgid "This resource view is not available at the moment."
 msgstr "Denna filbilaga är för närvarande inte tillgänglig."
 
 #: ckanext/apicatalog/templates/package/snippets/resource_view.html:20
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:122
 msgid "Click here for more information."
 msgstr "Klicka här för mer information..."
 
@@ -1640,81 +1697,81 @@ msgstr "Hantera"
 msgid "API Endpoint"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:77
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:74
 msgid "From the dataset abstract"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:79
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:76
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:119
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:116
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:123
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:130
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:127
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:131
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:132
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:129
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:151
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:148
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:155
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
 msgid "Field"
 msgstr "Fält"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:156
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:153
 msgid "Value"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:162
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:159
 msgid "Last updated"
 msgstr "Senast uppdaterad"
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:163
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:169
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:175
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:160
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:166
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:172
 msgid "unknown"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:168
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:165
 msgid "Created"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:174
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
 msgid "Format"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:180
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:177
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:65
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
 msgid "Are you sure you want to delete this resource?"
 msgstr "Vill du verkligen radera denna resurs?"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
 msgid "Finish"
 msgstr ""
 
@@ -1894,8 +1951,8 @@ msgstr ""
 "Om du har glömt ditt användarnamn och din e-postadress, kontakta <a "
 "href=\"mailto:palveluvayla@palveluvayla.fi\">palveluvayla@palveluvayla.fi</a>."
 
+#: ckanext/apicatalog/views/statistics.py:19
 #: ckanext/apicatalog/views/useradd.py:41
-#: ckanext/apicatalog/views/xroad_statistics.py:19
 msgid "Not authorized to see this page"
 msgstr "Det är inte tillåtet att visa denna sida"
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -33,7 +33,7 @@ from ckanext.apicatalog.schema import create_user_to_organization_schema
 from . import validators
 from ckanext.apicatalog import cli
 from ckanext.apicatalog import auth, db
-from ckanext.apicatalog.helpers import lang as apicatalog_lang, parse_datetime
+from ckanext.apicatalog.helpers import with_field_string_replacements, lang as apicatalog_lang, parse_datetime
 
 from collections import OrderedDict
 
@@ -773,6 +773,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
                 'add_locale_to_source': add_locale_to_source,
                 'get_field_from_schema': get_field_from_schema,
                 'max_resource_size': get_max_resource_size,
+                'with_field_string_replacements': with_field_string_replacements,
                 "lang": apicatalog_lang
                 }
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -202,7 +202,7 @@
       "preset": "fluent_markdown_editor",
       "required": false,
       "only_default_lang_required": true,
-      "form_placeholder": "Write attachment description",
+      "form_placeholder": "Write the attachment's description",
       "form_languages": ["fi", "sv", "en"],
       "display_snippet": null,
       "form_attrs": {}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resource_edit.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resource_edit.html
@@ -1,6 +1,12 @@
 {% ckan_extends %}
 
 <div class="row">
+    {% if resource.get('harvested_from_xroad') %}
+      {% set title = 'Edit service' %}
+    {% else %}
+      {% set title = 'Edit attachment' %}
+    {% endif %}
+
     <div class="col-xs-12 prelude">
         <div class="pull-right page-actions">
             {% block content_action %}
@@ -13,7 +19,7 @@
             {% endif %}
         </div>
         {% block prelude %}
-            <h1>{{ _('Edit resource') }}</h1>
+            <h1>{{ _(title) }}</h1>
         {% endblock %}
     </div>
 </div>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_edit_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_edit_form.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block save_button_text %}
+{%- if data.get('harvested_from_xroad') -%}
+  {{ _('Update Service') }}
+{%- else -%}
+  {{ _('Update Resource') }}
+{%- endif -%}
+{% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html
@@ -25,7 +25,21 @@
   {%- endif -%}
 
   {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
-  {%- for field in schema.resource_fields -%}
+
+  {% if data.get('harvested_from_xroad') %}
+  {#{% set resource_fields = h.with_service_field_labels(schema.resource_fields) %}#}
+    {% set resource_fields = h.with_field_string_replacements(schema.resource_fields, 'attachment', 'service',
+                                                              ['label',
+                                                               'extra_label',
+                                                               'additional_description',
+                                                               'input_title',
+                                                               'form_placeholder',
+                                                               ]) %}
+  {% else %}
+    {% set resource_fields = schema.resource_fields %}
+  {% endif %}
+
+  {%- for field in resource_fields -%}
     {%- if field.field_name not in exclude_fields -%}
     {%- if field.form_snippet is not none -%}
       {%- if field.field_name not in data %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
@@ -75,6 +75,11 @@ def schema_translatable_strings():
               '<a href=\"https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5ef313c79a155e0139629cb5\">'
               'API catalog instructions</a>.</div></div>'),
             _('Write the subsystem\'s description'),
+            _('Write the service\'s description'),
+            _('Write the attachment\'s description'),
+            _('Update Service'),
+            _('Edit service'),
+            _('Edit attachment'),
             _('Using keywords the user can easily find this application or similar applications through the search function. '
               'Choose at least one Finnish keyword.'),
             _('Write a keyword'),


### PR DESCRIPTION
# Description
Resource edit page now refers to a "service" or "attachment" depending on the property `harvested_from_xroad`

## Jira ticket reference: [LIKA-467](https://jira.dvv.fi/browse/LIKA-467)

## What has changed:
- Added a helper `with_field_string_replacements` to create modified versions of scheming field lists
- Utilized the helper to change "attachment" substrings to "service" in specific labels
- Updated translations
- Fixed a typo bug in translations where a change in a variable name caused issues rendering organization pages

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [ ] Changes are covered by tests.

Rendering pages with several languages should be a part of testing, but not in scope for this PR.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/191243586-2fe83e9d-4187-443d-b16c-f26f05a7ccbf.png)
![image](https://user-images.githubusercontent.com/726461/191243738-f7135df8-adb5-4829-adf7-2db1f536ca63.png)
