### PR TITLE
LIKA-453: CKAN core patch to fix resource file size updating

### DIFF
--- a/ansible/roles/ckan/files/patches/fix_updating_resource_filesize.patch
+++ b/ansible/roles/ckan/files/patches/fix_updating_resource_filesize.patch
@@ -1,0 +1,13 @@
+diff --git a/ckan/logic/action/update.py b/ckan/logic/action/update.py
+index 0fbb183a2..74b50d888 100644
+--- a/ckan/logic/action/update.py
++++ b/ckan/logic/action/update.py
+@@ -292,7 +292,7 @@ def package_update(context, data_dict):
+             if hasattr(upload, 'mimetype'):
+                 resource['mimetype'] = upload.mimetype
+ 
+-        if 'size' not in resource and 'url_type' in resource:
++        if 'url_type' in resource:
+             if hasattr(upload, 'filesize'):
+                 resource['size'] = upload.filesize
+ 

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -31,6 +31,7 @@ ckan_patches:
   - { file: "remove_old_fontawesome" }
   - { file: "fix_autocomplete_server_error" }
   - { file: "email_attachment" }
+  - { file: "fix_updating_resource_filesize" } # https://github.com/ckan/ckan/pull/7103
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}


### PR DESCRIPTION
# Description
Added a CKAN core patch to fix resource file size not updating on reupload.

## Jira ticket reference: [LIKA-453](https://jira.dvv.fi/browse/LIKA-453)

## What has changed:
- Added a patch file
- Enabled patch

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No


