### PR TITLE
Hotfix: check if apply_permissions_for_service plugin is loaded

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
@@ -23,8 +23,10 @@
         <div class="module-content dataset-sidebar">
             {{ h.build_nav_icon(pkg.type + '.edit', _("Subsystem's information"), id=pkg.name) }}
             {{ h.build_nav_icon(pkg.type ~ '.resources', _('Attachments'), id=pkg.name) }}
-            {{ h.build_nav_icon('apply_permissions.permission_application_settings', _('Access request settings'), subsystem_id=pkg.name) }}
-            {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), subsystem_id=pkg.name) }}
+            {% if h.is_extension_loaded('apply_permissions_for_service') %}
+              {{ h.build_nav_icon('apply_permissions.permission_application_settings', _('Access request settings'), subsystem_id=pkg.name) }}
+              {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), subsystem_id=pkg.name) }}
+            {% endif %}
         </div>
     </div>
     </section>


### PR DESCRIPTION
apply_permissions_for_service is not enabled in production, check if it is before use

# Description
-

## Jira ticket reference:None

## What has changed:
Add check for plugin

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No
