### PR TITLE
LIKA-514: Validate service access application values

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-20 11:06+0000\n"
+"POT-Creation-Date: 2022-09-27 11:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,136 +114,140 @@ msgid ""
 " not the email address of the individual."
 msgstr ""
 
+#: ckanext/apicatalog/translations.py:27
+msgid "Email {email} is not a valid format"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
-#: ckanext/apicatalog/translations.py:27
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:76
+#: ckanext/apicatalog/translations.py:28
 msgid "Discard changes"
 msgstr ""
 
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:36
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_edit_form.html:3
-#: ckanext/apicatalog/translations.py:28
+#: ckanext/apicatalog/translations.py:29
 msgid "Save changes"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:29
+#: ckanext/apicatalog/translations.py:30
 msgid "Write subsystem description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:30
+#: ckanext/apicatalog/translations.py:31
 msgid "Write attachment description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:31
+#: ckanext/apicatalog/translations.py:32
 msgid "Service name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:32
+#: ckanext/apicatalog/translations.py:33
 msgid "Attachment name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:33
+#: ckanext/apicatalog/translations.py:34
 msgid "Service visibility"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:34
+#: ckanext/apicatalog/translations.py:35
 msgid "Service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:35
+#: ckanext/apicatalog/translations.py:36
 msgid "Service name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:36
+#: ckanext/apicatalog/translations.py:37
 msgid "Attachment visibility"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:37
+#: ckanext/apicatalog/translations.py:38
 msgid "Attachment description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:38
+#: ckanext/apicatalog/translations.py:39
 msgid "Attachment name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:39
+#: ckanext/apicatalog/translations.py:40
 msgid ""
 "When service visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:41
+#: ckanext/apicatalog/translations.py:42
 msgid ""
 "When attachment visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:43
+#: ckanext/apicatalog/translations.py:44
 msgid "Chargeable"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:44
+#: ckanext/apicatalog/translations.py:45
 msgid "Free of charge"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:45
+#: ckanext/apicatalog/translations.py:46
 msgid "Mentioned in service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:46
+#: ckanext/apicatalog/translations.py:47
 msgid "No license specified"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:47
+#: ckanext/apicatalog/translations.py:48
 msgid "Open Database license"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:48
+#: ckanext/apicatalog/translations.py:49
 msgid "Web address"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:49
+#: ckanext/apicatalog/translations.py:50
 msgid ""
 "URL will be formed automatically from the name of the application and should "
 "in general not be edited."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:51
+#: ckanext/apicatalog/translations.py:52
 msgid "E-mail address in Finnish"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:52
+#: ckanext/apicatalog/translations.py:53
 msgid "E-mail address in Swedish"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:53
+#: ckanext/apicatalog/translations.py:54
 msgid "E-mail address in English"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:54
+#: ckanext/apicatalog/translations.py:55
 msgid "Subsystem's title"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:55
+#: ckanext/apicatalog/translations.py:56
 msgid ""
 "We recommend that the subsystem is given a clear name that describes its real"
 " name or purpose."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:56
+#: ckanext/apicatalog/translations.py:57
 msgid "The subsystem's name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:57
+#: ckanext/apicatalog/translations.py:58
 msgid "Title in Data Exchange Layer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:58
+#: ckanext/apicatalog/translations.py:59
 msgid "Subsystem description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:59
+#: ckanext/apicatalog/translations.py:60
 msgid ""
 "General, compact and easy to understand description of the subsystem. You can"
 " use markdown formatting in the description.<br><br><div class=\"collapsible-"
@@ -267,83 +271,83 @@ msgid ""
 " catalog instructions</a>.</div></div>"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:77
+#: ckanext/apicatalog/translations.py:78
 msgid "Write the subsystem's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:78
+#: ckanext/apicatalog/translations.py:79
 msgid "Write the service's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:79
+#: ckanext/apicatalog/translations.py:80
 msgid "Write the attachment's description"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
-#: ckanext/apicatalog/translations.py:80
+#: ckanext/apicatalog/translations.py:81
 msgid "Update Service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:81
+#: ckanext/apicatalog/translations.py:82
 msgid "Edit service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:82
+#: ckanext/apicatalog/translations.py:83
 msgid "Edit attachment"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:83
+#: ckanext/apicatalog/translations.py:84
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
 "keyword."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:85
+#: ckanext/apicatalog/translations.py:86
 msgid "Write a keyword"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:86
+#: ckanext/apicatalog/translations.py:87
 msgid "Maintainer's information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:87
+#: ckanext/apicatalog/translations.py:88
 msgid "Use the maintainer's common contact information."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:88
+#: ckanext/apicatalog/translations.py:89
 msgid "The name of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:89
+#: ckanext/apicatalog/translations.py:90
 msgid "The email of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:90
+#: ckanext/apicatalog/translations.py:91
 msgid "Limited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:91
+#: ckanext/apicatalog/translations.py:92
 msgid "Allowed organizations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:92
+#: ckanext/apicatalog/translations.py:93
 msgid "Other information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:93
+#: ckanext/apicatalog/translations.py:94
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:94
+#: ckanext/apicatalog/translations.py:95
 msgid "fi"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:95
+#: ckanext/apicatalog/translations.py:96
 msgid "en"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:96
+#: ckanext/apicatalog/translations.py:97
 msgid "sv"
 msgstr ""
 
@@ -690,59 +694,59 @@ msgstr ""
 msgid "X-ROAD Graphs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:23
+#: ckanext/apicatalog/templates/admin/statistics.html:22
 msgid "X-Road Environment:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:31
+#: ckanext/apicatalog/templates/admin/statistics.html:30
 msgid "Subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:39
+#: ckanext/apicatalog/templates/admin/statistics.html:38
 msgid "Members:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:47
+#: ckanext/apicatalog/templates/admin/statistics.html:46
 msgid "SecurityServers:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:55
+#: ckanext/apicatalog/templates/admin/statistics.html:54
 msgid "X-ROAD Catalog - Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:62
+#: ckanext/apicatalog/templates/admin/statistics.html:59
 msgid "SOAP services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:70
+#: ckanext/apicatalog/templates/admin/statistics.html:67
 msgid "REST services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:78
+#: ckanext/apicatalog/templates/admin/statistics.html:75
 msgid "OpenAPI services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:86
+#: ckanext/apicatalog/templates/admin/statistics.html:83
 msgid "X-ROAD Catalog - Distinct Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:93
+#: ckanext/apicatalog/templates/admin/statistics.html:88
 msgid "Distinct services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:101
+#: ckanext/apicatalog/templates/admin/statistics.html:96
 msgid "CKAN"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:108
+#: ckanext/apicatalog/templates/admin/statistics.html:101
 msgid "Public subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:116
+#: ckanext/apicatalog/templates/admin/statistics.html:109
 msgid "Total organizations:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:124
+#: ckanext/apicatalog/templates/admin/statistics.html:117
 msgid "Provider organizations:"
 msgstr ""
 
@@ -1308,7 +1312,7 @@ msgstr ""
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr ""
@@ -1356,33 +1360,29 @@ msgstr ""
 msgid "Show only service providers"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/edit.html:10
-msgid "Subsystem's information"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-msgid "Resources"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-#: ckanext/apicatalog/templates/package/read.html:64
-msgid "Attachments"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:13
-msgid "Access request settings"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:14
-msgid "Received access requests"
-msgstr ""
-
 #: ckanext/apicatalog/templates/package/edit_base.html:7
 msgid "Edit subsystem"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 msgid "Cancel editing"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:24
+msgid "Subsystem's information"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:25
+#: ckanext/apicatalog/templates/package/read.html:64
+msgid "Attachments"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:27
+msgid "Access request settings"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:28
+msgid "Received access requests"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:18
@@ -1672,11 +1672,11 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 msgid "Are you sure you want to delete this resource?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:75
 msgid "Finish"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/en_GB/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/en_GB/LC_MESSAGES/ckanext-apicatalog.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-20 11:06+0000\n"
+"POT-Creation-Date: 2022-09-27 11:17+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
 "Last-Translator: Suvi Nuttunen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -128,136 +128,140 @@ msgstr ""
 "If possible, enter the email address of the organisation or customer "
 "service, not the email address of the individual."
 
+#: ckanext/apicatalog/translations.py:27
+msgid "Email {email} is not a valid format"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
-#: ckanext/apicatalog/translations.py:27
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:76
+#: ckanext/apicatalog/translations.py:28
 msgid "Discard changes"
 msgstr ""
 
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:36
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_edit_form.html:3
-#: ckanext/apicatalog/translations.py:28
+#: ckanext/apicatalog/translations.py:29
 msgid "Save changes"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:29
+#: ckanext/apicatalog/translations.py:30
 msgid "Write subsystem description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:30
+#: ckanext/apicatalog/translations.py:31
 msgid "Write attachment description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:31
+#: ckanext/apicatalog/translations.py:32
 msgid "Service name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:32
+#: ckanext/apicatalog/translations.py:33
 msgid "Attachment name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:33
+#: ckanext/apicatalog/translations.py:34
 msgid "Service visibility"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:34
+#: ckanext/apicatalog/translations.py:35
 msgid "Service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:35
+#: ckanext/apicatalog/translations.py:36
 msgid "Service name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:36
+#: ckanext/apicatalog/translations.py:37
 msgid "Attachment visibility"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:37
+#: ckanext/apicatalog/translations.py:38
 msgid "Attachment description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:38
+#: ckanext/apicatalog/translations.py:39
 msgid "Attachment name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:39
+#: ckanext/apicatalog/translations.py:40
 msgid ""
 "When service visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:41
+#: ckanext/apicatalog/translations.py:42
 msgid ""
 "When attachment visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:43
+#: ckanext/apicatalog/translations.py:44
 msgid "Chargeable"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:44
+#: ckanext/apicatalog/translations.py:45
 msgid "Free of charge"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:45
+#: ckanext/apicatalog/translations.py:46
 msgid "Mentioned in service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:46
+#: ckanext/apicatalog/translations.py:47
 msgid "No license specified"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:47
+#: ckanext/apicatalog/translations.py:48
 msgid "Open Database license"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:48
+#: ckanext/apicatalog/translations.py:49
 msgid "Web address"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:49
+#: ckanext/apicatalog/translations.py:50
 msgid ""
 "URL will be formed automatically from the name of the application and should"
 " in general not be edited."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:51
+#: ckanext/apicatalog/translations.py:52
 msgid "E-mail address in Finnish"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:52
+#: ckanext/apicatalog/translations.py:53
 msgid "E-mail address in Swedish"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:53
+#: ckanext/apicatalog/translations.py:54
 msgid "E-mail address in English"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:54
+#: ckanext/apicatalog/translations.py:55
 msgid "Subsystem's title"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:55
+#: ckanext/apicatalog/translations.py:56
 msgid ""
 "We recommend that the subsystem is given a clear name that describes its "
 "real name or purpose."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:56
+#: ckanext/apicatalog/translations.py:57
 msgid "The subsystem's name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:57
+#: ckanext/apicatalog/translations.py:58
 msgid "Title in Data Exchange Layer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:58
+#: ckanext/apicatalog/translations.py:59
 msgid "Subsystem description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:59
+#: ckanext/apicatalog/translations.py:60
 msgid ""
 "General, compact and easy to understand description of the subsystem. You "
 "can use markdown formatting in the description.<br><br><div "
@@ -299,34 +303,34 @@ msgstr ""
 " information permission?</li></ul></li></ul> <p>More detailed instructions "
 "for writing the description of the service can be found in <a "
 "href=\"https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5ef313c79a155e0139629cb5\">API"
-" catalog instructions</a>.</div></div>"
+" Catalogue instructions</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:77
+#: ckanext/apicatalog/translations.py:78
 msgid "Write the subsystem's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:78
+#: ckanext/apicatalog/translations.py:79
 msgid "Write the service's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:79
+#: ckanext/apicatalog/translations.py:80
 msgid "Write the attachment's description"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
-#: ckanext/apicatalog/translations.py:80
+#: ckanext/apicatalog/translations.py:81
 msgid "Update Service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:81
+#: ckanext/apicatalog/translations.py:82
 msgid "Edit service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:82
+#: ckanext/apicatalog/translations.py:83
 msgid "Edit attachment"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:83
+#: ckanext/apicatalog/translations.py:84
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -335,51 +339,51 @@ msgstr ""
 "Using keywords the user can easily find this subsystem or similar subsystems"
 " through the search function. Choose at least one Finnish keyword."
 
-#: ckanext/apicatalog/translations.py:85
+#: ckanext/apicatalog/translations.py:86
 msgid "Write a keyword"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:86
+#: ckanext/apicatalog/translations.py:87
 msgid "Maintainer's information"
 msgstr "Administrator's contact information"
 
-#: ckanext/apicatalog/translations.py:87
+#: ckanext/apicatalog/translations.py:88
 msgid "Use the maintainer's common contact information."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:88
+#: ckanext/apicatalog/translations.py:89
 msgid "The name of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:89
+#: ckanext/apicatalog/translations.py:90
 msgid "The email of the maintainer"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:90
+#: ckanext/apicatalog/translations.py:91
 msgid "Limited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:91
+#: ckanext/apicatalog/translations.py:92
 msgid "Allowed organizations"
 msgstr "Allowed organisations"
 
-#: ckanext/apicatalog/translations.py:92
+#: ckanext/apicatalog/translations.py:93
 msgid "Other information"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:93
+#: ckanext/apicatalog/translations.py:94
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:94
+#: ckanext/apicatalog/translations.py:95
 msgid "fi"
 msgstr "in Finnish"
 
-#: ckanext/apicatalog/translations.py:95
+#: ckanext/apicatalog/translations.py:96
 msgid "en"
 msgstr "in English"
 
-#: ckanext/apicatalog/translations.py:96
+#: ckanext/apicatalog/translations.py:97
 msgid "sv"
 msgstr "in Swedish"
 
@@ -726,59 +730,59 @@ msgstr ""
 msgid "X-ROAD Graphs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:23
+#: ckanext/apicatalog/templates/admin/statistics.html:22
 msgid "X-Road Environment:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:31
+#: ckanext/apicatalog/templates/admin/statistics.html:30
 msgid "Subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:39
+#: ckanext/apicatalog/templates/admin/statistics.html:38
 msgid "Members:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:47
+#: ckanext/apicatalog/templates/admin/statistics.html:46
 msgid "SecurityServers:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:55
+#: ckanext/apicatalog/templates/admin/statistics.html:54
 msgid "X-ROAD Catalog - Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:62
+#: ckanext/apicatalog/templates/admin/statistics.html:59
 msgid "SOAP services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:70
+#: ckanext/apicatalog/templates/admin/statistics.html:67
 msgid "REST services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:78
+#: ckanext/apicatalog/templates/admin/statistics.html:75
 msgid "OpenAPI services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:86
+#: ckanext/apicatalog/templates/admin/statistics.html:83
 msgid "X-ROAD Catalog - Distinct Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:93
+#: ckanext/apicatalog/templates/admin/statistics.html:88
 msgid "Distinct services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:101
+#: ckanext/apicatalog/templates/admin/statistics.html:96
 msgid "CKAN"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:108
+#: ckanext/apicatalog/templates/admin/statistics.html:101
 msgid "Public subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:116
+#: ckanext/apicatalog/templates/admin/statistics.html:109
 msgid "Total organizations:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:124
+#: ckanext/apicatalog/templates/admin/statistics.html:117
 msgid "Provider organizations:"
 msgstr ""
 
@@ -1081,7 +1085,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_12mo_stats.html:3
 msgid "API catalog statistics for the last 12 months"
-msgstr "API Catalog statistics for the last 12 months"
+msgstr "API Catalogue statistics for the last 12 months"
 
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_12mo_stats.html:4
 msgid "Visitors"
@@ -1357,7 +1361,7 @@ msgstr ""
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr ""
@@ -1405,33 +1409,29 @@ msgstr "Show organisations without subsystems"
 msgid "Show only service providers"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/edit.html:10
-msgid "Subsystem's information"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-msgid "Resources"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-#: ckanext/apicatalog/templates/package/read.html:64
-msgid "Attachments"
-msgstr "Attachments"
-
-#: ckanext/apicatalog/templates/package/edit.html:13
-msgid "Access request settings"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:14
-msgid "Received access requests"
-msgstr ""
-
 #: ckanext/apicatalog/templates/package/edit_base.html:7
 msgid "Edit subsystem"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 msgid "Cancel editing"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:24
+msgid "Subsystem's information"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:25
+#: ckanext/apicatalog/templates/package/read.html:64
+msgid "Attachments"
+msgstr "Attachments"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:27
+msgid "Access request settings"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/edit_base.html:28
+msgid "Received access requests"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:18
@@ -1734,11 +1734,11 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 msgid "Are you sure you want to delete this resource?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:75
 msgid "Finish"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
@@ -6,18 +6,18 @@
 # 
 # Translators:
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022
-# Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
 # Suvi Nuttunen, 2022
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
+# Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-20 11:06+0000\n"
+"POT-Creation-Date: 2022-09-27 11:17+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2022\n"
+"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -128,61 +128,65 @@ msgstr ""
 "Jos mahdollista, anna organisaation tai asiakaspalvelun sähköpostiosoite, ei"
 " yksittäisen henkilön sähköpostiosoistetta."
 
+#: ckanext/apicatalog/translations.py:27
+msgid "Email {email} is not a valid format"
+msgstr "Sähköpostiosoite {email} on virheellisessä muodossa"
+
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
-#: ckanext/apicatalog/translations.py:27
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:76
+#: ckanext/apicatalog/translations.py:28
 msgid "Discard changes"
 msgstr "Hylkää muutokset"
 
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:36
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_edit_form.html:3
-#: ckanext/apicatalog/translations.py:28
+#: ckanext/apicatalog/translations.py:29
 msgid "Save changes"
 msgstr "Päivitä tiedot"
 
-#: ckanext/apicatalog/translations.py:29
+#: ckanext/apicatalog/translations.py:30
 msgid "Write subsystem description"
 msgstr "Kirjoita alijärjestelmän kuvaus"
 
-#: ckanext/apicatalog/translations.py:30
+#: ckanext/apicatalog/translations.py:31
 msgid "Write attachment description"
 msgstr "Kirjoita liitetiedoston kuvaus"
 
-#: ckanext/apicatalog/translations.py:31
+#: ckanext/apicatalog/translations.py:32
 msgid "Service name will be filled automatically and should not be edited"
 msgstr "Palvelun nimi täydennetään automaattisesti, eikä sitä voi muokata"
 
-#: ckanext/apicatalog/translations.py:32
+#: ckanext/apicatalog/translations.py:33
 msgid "Attachment name will be filled automatically and should not be edited"
 msgstr ""
 "Liitetiedoston nimi täydennetään automaattisesti, eikä sitä voi muokata"
 
-#: ckanext/apicatalog/translations.py:33
+#: ckanext/apicatalog/translations.py:34
 msgid "Service visibility"
 msgstr "Palvelun näkyvyys"
 
-#: ckanext/apicatalog/translations.py:34
+#: ckanext/apicatalog/translations.py:35
 msgid "Service description"
 msgstr "Palvelun kuvaus"
 
-#: ckanext/apicatalog/translations.py:35
+#: ckanext/apicatalog/translations.py:36
 msgid "Service name"
 msgstr "Palvelun nimi"
 
-#: ckanext/apicatalog/translations.py:36
+#: ckanext/apicatalog/translations.py:37
 msgid "Attachment visibility"
 msgstr "Liitetiedoston näkyvyys"
 
-#: ckanext/apicatalog/translations.py:37
+#: ckanext/apicatalog/translations.py:38
 msgid "Attachment description"
 msgstr "Liitetiedoston kuvaus"
 
-#: ckanext/apicatalog/translations.py:38
+#: ckanext/apicatalog/translations.py:39
 msgid "Attachment name"
 msgstr "Liitetiedoston nimi"
 
-#: ckanext/apicatalog/translations.py:39
+#: ckanext/apicatalog/translations.py:40
 msgid ""
 "When service visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
@@ -190,7 +194,7 @@ msgstr ""
 "Kun palvelun näkyvyys on rajoitettu, se näkyy vain oman organisaation ja "
 "sallittujen organisaatioiden käyttäjille."
 
-#: ckanext/apicatalog/translations.py:41
+#: ckanext/apicatalog/translations.py:42
 msgid ""
 "When attachment visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
@@ -198,31 +202,31 @@ msgstr ""
 "Kun liitetiedoston näkyvyys on rajoitettu, se näkyy vain oman organisaation "
 "ja sallittujen organisaatioiden käyttäjille."
 
-#: ckanext/apicatalog/translations.py:43
+#: ckanext/apicatalog/translations.py:44
 msgid "Chargeable"
 msgstr "Maksullinen"
 
-#: ckanext/apicatalog/translations.py:44
+#: ckanext/apicatalog/translations.py:45
 msgid "Free of charge"
 msgstr "Maksuton"
 
-#: ckanext/apicatalog/translations.py:45
+#: ckanext/apicatalog/translations.py:46
 msgid "Mentioned in service description"
 msgstr "Kerrotaan palvelun kuvauksessa"
 
-#: ckanext/apicatalog/translations.py:46
+#: ckanext/apicatalog/translations.py:47
 msgid "No license specified"
 msgstr "Lisenssiä ei määritelty"
 
-#: ckanext/apicatalog/translations.py:47
+#: ckanext/apicatalog/translations.py:48
 msgid "Open Database license"
 msgstr "Open Database lisenssi"
 
-#: ckanext/apicatalog/translations.py:48
+#: ckanext/apicatalog/translations.py:49
 msgid "Web address"
 msgstr "Verkko-osoite"
 
-#: ckanext/apicatalog/translations.py:49
+#: ckanext/apicatalog/translations.py:50
 msgid ""
 "URL will be formed automatically from the name of the application and should"
 " in general not be edited."
@@ -230,23 +234,23 @@ msgstr ""
 "URL muodostetaan sovelluksen nimestä automaattisesti, eikä osoitetta yleensä"
 " tarvitse muokata."
 
-#: ckanext/apicatalog/translations.py:51
+#: ckanext/apicatalog/translations.py:52
 msgid "E-mail address in Finnish"
 msgstr "Sähköpostiosoite suomeksi"
 
-#: ckanext/apicatalog/translations.py:52
+#: ckanext/apicatalog/translations.py:53
 msgid "E-mail address in Swedish"
 msgstr "Sähköpostiosoite ruotsiksi"
 
-#: ckanext/apicatalog/translations.py:53
+#: ckanext/apicatalog/translations.py:54
 msgid "E-mail address in English"
 msgstr "Sähköpostiosoite englanniksi"
 
-#: ckanext/apicatalog/translations.py:54
+#: ckanext/apicatalog/translations.py:55
 msgid "Subsystem's title"
 msgstr "Alijärjestelmän nimi"
 
-#: ckanext/apicatalog/translations.py:55
+#: ckanext/apicatalog/translations.py:56
 msgid ""
 "We recommend that the subsystem is given a clear name that describes its "
 "real name or purpose."
@@ -254,19 +258,19 @@ msgstr ""
 "Suosittelemme, että alijärjestelmälle annetaan selkeä nimi, joka vastaa sen "
 "todellista nimeä tai tarkoitusta."
 
-#: ckanext/apicatalog/translations.py:56
+#: ckanext/apicatalog/translations.py:57
 msgid "The subsystem's name"
 msgstr "Alijärjestelmän nimi"
 
-#: ckanext/apicatalog/translations.py:57
+#: ckanext/apicatalog/translations.py:58
 msgid "Title in Data Exchange Layer"
 msgstr "Nimi palveluväylässä"
 
-#: ckanext/apicatalog/translations.py:58
+#: ckanext/apicatalog/translations.py:59
 msgid "Subsystem description"
 msgstr "Alijärjestelmän kuvaus"
 
-#: ckanext/apicatalog/translations.py:59
+#: ckanext/apicatalog/translations.py:60
 msgid ""
 "General, compact and easy to understand description of the subsystem. You "
 "can use markdown formatting in the description.<br><br><div "
@@ -309,32 +313,32 @@ msgstr ""
 "href=\"https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/5ef313c79a155e0139629cb5\">Liityntäkatalogin"
 " ohjeista</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:77
+#: ckanext/apicatalog/translations.py:78
 msgid "Write the subsystem's description"
 msgstr "Kirjoita alijärjestelmän kuvaus"
 
-#: ckanext/apicatalog/translations.py:78
+#: ckanext/apicatalog/translations.py:79
 msgid "Write the service's description"
 msgstr "Kirjoita palvelun kuvaus"
 
-#: ckanext/apicatalog/translations.py:79
+#: ckanext/apicatalog/translations.py:80
 msgid "Write the attachment's description"
 msgstr "Kirjoita liitetiedoston kuvaus"
 
 #: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
-#: ckanext/apicatalog/translations.py:80
+#: ckanext/apicatalog/translations.py:81
 msgid "Update Service"
 msgstr "Päivitä palvelu"
 
-#: ckanext/apicatalog/translations.py:81
+#: ckanext/apicatalog/translations.py:82
 msgid "Edit service"
 msgstr "Muokkaa palvelua"
 
-#: ckanext/apicatalog/translations.py:82
+#: ckanext/apicatalog/translations.py:83
 msgid "Edit attachment"
 msgstr "Muokkaa liitetiedostoa"
 
-#: ckanext/apicatalog/translations.py:83
+#: ckanext/apicatalog/translations.py:84
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -344,51 +348,51 @@ msgstr ""
 "alijärjestelmiä helposti hakusivun kautta. Valitse vähintään yksi "
 "suomenkielinen avainsana."
 
-#: ckanext/apicatalog/translations.py:85
+#: ckanext/apicatalog/translations.py:86
 msgid "Write a keyword"
 msgstr "Kirjoita avainsana"
 
-#: ckanext/apicatalog/translations.py:86
+#: ckanext/apicatalog/translations.py:87
 msgid "Maintainer's information"
 msgstr "Ylläpitäjän yhteystiedot"
 
-#: ckanext/apicatalog/translations.py:87
+#: ckanext/apicatalog/translations.py:88
 msgid "Use the maintainer's common contact information."
 msgstr "Käytä organisaation yleisiä yhteystietoja."
 
-#: ckanext/apicatalog/translations.py:88
+#: ckanext/apicatalog/translations.py:89
 msgid "The name of the maintainer"
 msgstr "Ylläpitäjän nimi"
 
-#: ckanext/apicatalog/translations.py:89
+#: ckanext/apicatalog/translations.py:90
 msgid "The email of the maintainer"
 msgstr "Ylläpitäjän sähköposti"
 
-#: ckanext/apicatalog/translations.py:90
+#: ckanext/apicatalog/translations.py:91
 msgid "Limited"
 msgstr "Rajoitettu"
 
-#: ckanext/apicatalog/translations.py:91
+#: ckanext/apicatalog/translations.py:92
 msgid "Allowed organizations"
 msgstr "Sallitut organisaatiot"
 
-#: ckanext/apicatalog/translations.py:92
+#: ckanext/apicatalog/translations.py:93
 msgid "Other information"
 msgstr "Voimassaoloaika"
 
-#: ckanext/apicatalog/translations.py:93
+#: ckanext/apicatalog/translations.py:94
 msgid "dd/mm/yyyy"
 msgstr "pp.kk.vvvv"
 
-#: ckanext/apicatalog/translations.py:94
+#: ckanext/apicatalog/translations.py:95
 msgid "fi"
 msgstr "suomeksi"
 
-#: ckanext/apicatalog/translations.py:95
+#: ckanext/apicatalog/translations.py:96
 msgid "en"
 msgstr "englanniksi"
 
-#: ckanext/apicatalog/translations.py:96
+#: ckanext/apicatalog/translations.py:97
 msgid "sv"
 msgstr "ruotsiksi"
 
@@ -741,59 +745,59 @@ msgstr "Ei"
 msgid "X-ROAD Graphs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:23
+#: ckanext/apicatalog/templates/admin/statistics.html:22
 msgid "X-Road Environment:"
 msgstr "X-Road-ympäristö:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:31
+#: ckanext/apicatalog/templates/admin/statistics.html:30
 msgid "Subsystems:"
 msgstr "Alijärjestelmiä:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:39
+#: ckanext/apicatalog/templates/admin/statistics.html:38
 msgid "Members:"
 msgstr "Jäseniä:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:47
+#: ckanext/apicatalog/templates/admin/statistics.html:46
 msgid "SecurityServers:"
 msgstr "Liityntäpalvelimia:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:55
+#: ckanext/apicatalog/templates/admin/statistics.html:54
 msgid "X-ROAD Catalog - Services"
 msgstr "X-ROAD Catalog - Palvelut"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:62
+#: ckanext/apicatalog/templates/admin/statistics.html:59
 msgid "SOAP services:"
 msgstr "SOAP-palvelut:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:70
+#: ckanext/apicatalog/templates/admin/statistics.html:67
 msgid "REST services:"
 msgstr "REST-palvelut:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:78
+#: ckanext/apicatalog/templates/admin/statistics.html:75
 msgid "OpenAPI services:"
 msgstr "OpenAPI-palvelut:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:86
+#: ckanext/apicatalog/templates/admin/statistics.html:83
 msgid "X-ROAD Catalog - Distinct Services"
 msgstr "X-ROAD Catalog - Erilliset palvelut"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:93
+#: ckanext/apicatalog/templates/admin/statistics.html:88
 msgid "Distinct services:"
 msgstr "Erilliset palvelut:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:101
+#: ckanext/apicatalog/templates/admin/statistics.html:96
 msgid "CKAN"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:108
+#: ckanext/apicatalog/templates/admin/statistics.html:101
 msgid "Public subsystems:"
 msgstr "Julkisia alijärjestelmiä:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:116
+#: ckanext/apicatalog/templates/admin/statistics.html:109
 msgid "Total organizations:"
 msgstr "Organisaatioita yhteensä:"
 
-#: ckanext/apicatalog/templates/admin/statistics.html:124
+#: ckanext/apicatalog/templates/admin/statistics.html:117
 msgid "Provider organizations:"
 msgstr "Palveluntarjoajia:"
 
@@ -1410,7 +1414,7 @@ msgstr "Haluatko varmasti poistaa tämän jäsenen?"
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr "Poista"
@@ -1458,27 +1462,6 @@ msgstr "Näytä kaikki organisaatiot"
 msgid "Show only service providers"
 msgstr "Näytä vain palveluntarjoajat"
 
-#: ckanext/apicatalog/templates/package/edit.html:10
-msgid "Subsystem's information"
-msgstr "Alijärjestelmän tiedot"
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-msgid "Resources"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-#: ckanext/apicatalog/templates/package/read.html:64
-msgid "Attachments"
-msgstr "Liitteet"
-
-#: ckanext/apicatalog/templates/package/edit.html:13
-msgid "Access request settings"
-msgstr "Käyttöluvan hallinnointi"
-
-#: ckanext/apicatalog/templates/package/edit.html:14
-msgid "Received access requests"
-msgstr "Saapuneet lupapyynnöt"
-
 #: ckanext/apicatalog/templates/package/edit_base.html:7
 msgid "Edit subsystem"
 msgstr "Muokkaa alijärjestelmää"
@@ -1486,6 +1469,23 @@ msgstr "Muokkaa alijärjestelmää"
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 msgid "Cancel editing"
 msgstr "Peruuta muokkaus"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:24
+msgid "Subsystem's information"
+msgstr "Alijärjestelmän tiedot"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:25
+#: ckanext/apicatalog/templates/package/read.html:64
+msgid "Attachments"
+msgstr "Liitteet"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:27
+msgid "Access request settings"
+msgstr "Käyttöluvan hallinnointi"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:28
+msgid "Received access requests"
+msgstr "Saapuneet lupapyynnöt"
 
 #: ckanext/apicatalog/templates/package/read.html:18
 msgid "Request permission to use this subsystem"
@@ -1808,11 +1808,11 @@ msgstr "Tiedostomuoto"
 msgid "License"
 msgstr "Lisenssi"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 msgid "Are you sure you want to delete this resource?"
 msgstr "Haluatko varmasti poistaa tämän liitetiedoston?"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:75
 msgid "Finish"
 msgstr "Valmis"
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-09-20 11:06+0000\n"
+"POT-Creation-Date: 2022-09-27 11:17+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
 "Last-Translator: Suvi Nuttunen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -129,60 +129,64 @@ msgstr ""
 "Om möjligt, ange e-postadressen till organisationen eller kundtjänsten, inte"
 " e-postadressen till individen."
 
+#: ckanext/apicatalog/translations.py:27
+msgid "Email {email} is not a valid format"
+msgstr ""
+
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:85
-#: ckanext/apicatalog/translations.py:27
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:76
+#: ckanext/apicatalog/translations.py:28
 msgid "Discard changes"
 msgstr "Ignorera ändringar"
 
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:36
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_edit_form.html:3
-#: ckanext/apicatalog/translations.py:28
+#: ckanext/apicatalog/translations.py:29
 msgid "Save changes"
 msgstr "Spara ändringar"
 
-#: ckanext/apicatalog/translations.py:29
+#: ckanext/apicatalog/translations.py:30
 msgid "Write subsystem description"
 msgstr "Skriv subsystemets beskrivning"
 
-#: ckanext/apicatalog/translations.py:30
+#: ckanext/apicatalog/translations.py:31
 msgid "Write attachment description"
 msgstr "Skriv beskrivning av bilagan"
 
-#: ckanext/apicatalog/translations.py:31
+#: ckanext/apicatalog/translations.py:32
 msgid "Service name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:32
+#: ckanext/apicatalog/translations.py:33
 msgid "Attachment name will be filled automatically and should not be edited"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:33
+#: ckanext/apicatalog/translations.py:34
 msgid "Service visibility"
 msgstr "Tjänstens synlighet"
 
-#: ckanext/apicatalog/translations.py:34
+#: ckanext/apicatalog/translations.py:35
 msgid "Service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:35
+#: ckanext/apicatalog/translations.py:36
 msgid "Service name"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:36
+#: ckanext/apicatalog/translations.py:37
 msgid "Attachment visibility"
 msgstr "Synlighet av bilagan"
 
-#: ckanext/apicatalog/translations.py:37
+#: ckanext/apicatalog/translations.py:38
 msgid "Attachment description"
 msgstr "Beskrivning av bilagan"
 
-#: ckanext/apicatalog/translations.py:38
+#: ckanext/apicatalog/translations.py:39
 msgid "Attachment name"
 msgstr "Namn av bilagan"
 
-#: ckanext/apicatalog/translations.py:39
+#: ckanext/apicatalog/translations.py:40
 msgid ""
 "When service visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
@@ -190,59 +194,59 @@ msgstr ""
 "När tjänstens synlighet är privat är den endast synlig för "
 "ägarorganisationen eller användare från tillåtna organisationer"
 
-#: ckanext/apicatalog/translations.py:41
+#: ckanext/apicatalog/translations.py:42
 msgid ""
 "When attachment visibility is private, it is only visible to the owner "
 "organisation or users from allowed organisations"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:43
+#: ckanext/apicatalog/translations.py:44
 msgid "Chargeable"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:44
+#: ckanext/apicatalog/translations.py:45
 msgid "Free of charge"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:45
+#: ckanext/apicatalog/translations.py:46
 msgid "Mentioned in service description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:46
+#: ckanext/apicatalog/translations.py:47
 msgid "No license specified"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:47
+#: ckanext/apicatalog/translations.py:48
 msgid "Open Database license"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:48
+#: ckanext/apicatalog/translations.py:49
 msgid "Web address"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:49
+#: ckanext/apicatalog/translations.py:50
 msgid ""
 "URL will be formed automatically from the name of the application and should"
 " in general not be edited."
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:51
+#: ckanext/apicatalog/translations.py:52
 msgid "E-mail address in Finnish"
 msgstr "E-postadress på finska"
 
-#: ckanext/apicatalog/translations.py:52
+#: ckanext/apicatalog/translations.py:53
 msgid "E-mail address in Swedish"
 msgstr "E-postadress på svenska"
 
-#: ckanext/apicatalog/translations.py:53
+#: ckanext/apicatalog/translations.py:54
 msgid "E-mail address in English"
 msgstr "E-postadress på engelska"
 
-#: ckanext/apicatalog/translations.py:54
+#: ckanext/apicatalog/translations.py:55
 msgid "Subsystem's title"
 msgstr "Subsystemets namn"
 
-#: ckanext/apicatalog/translations.py:55
+#: ckanext/apicatalog/translations.py:56
 msgid ""
 "We recommend that the subsystem is given a clear name that describes its "
 "real name or purpose."
@@ -250,19 +254,19 @@ msgstr ""
 "Vi rekommenderar att subsystemet har ett tydligt namn som beskriver dess "
 "riktiga namnet eller funktion."
 
-#: ckanext/apicatalog/translations.py:56
+#: ckanext/apicatalog/translations.py:57
 msgid "The subsystem's name"
 msgstr "Subsystemets namn"
 
-#: ckanext/apicatalog/translations.py:57
+#: ckanext/apicatalog/translations.py:58
 msgid "Title in Data Exchange Layer"
 msgstr "Namn i Informationsleden"
 
-#: ckanext/apicatalog/translations.py:58
+#: ckanext/apicatalog/translations.py:59
 msgid "Subsystem description"
 msgstr "Subsystemets beskrivning"
 
-#: ckanext/apicatalog/translations.py:59
+#: ckanext/apicatalog/translations.py:60
 msgid ""
 "General, compact and easy to understand description of the subsystem. You "
 "can use markdown formatting in the description.<br><br><div "
@@ -306,32 +310,32 @@ msgstr ""
 "href=\"https://palveluhallinta.suomi.fi/sv/tuki/artikkelit/5ef313c79a155e0139629cb5\">Beskrivning"
 " av tjänster i API-katalogen</a>.</div></div>"
 
-#: ckanext/apicatalog/translations.py:77
+#: ckanext/apicatalog/translations.py:78
 msgid "Write the subsystem's description"
 msgstr "Skriv subsystemets beskrivning"
 
-#: ckanext/apicatalog/translations.py:78
+#: ckanext/apicatalog/translations.py:79
 msgid "Write the service's description"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:79
+#: ckanext/apicatalog/translations.py:80
 msgid "Write the attachment's description"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_edit_form.html:5
-#: ckanext/apicatalog/translations.py:80
+#: ckanext/apicatalog/translations.py:81
 msgid "Update Service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:81
+#: ckanext/apicatalog/translations.py:82
 msgid "Edit service"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:82
+#: ckanext/apicatalog/translations.py:83
 msgid "Edit attachment"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:83
+#: ckanext/apicatalog/translations.py:84
 msgid ""
 "Using keywords the user can easily find this application or similar "
 "applications through the search function. Choose at least one Finnish "
@@ -340,51 +344,51 @@ msgstr ""
 "Med hjälp av nyckelord kan användaren enkelt hitta detta subsystem eller "
 "liknande subsystem genom sök funktionen. Välj minst ett finskt nyckelord."
 
-#: ckanext/apicatalog/translations.py:85
+#: ckanext/apicatalog/translations.py:86
 msgid "Write a keyword"
 msgstr "Skriv ett nyckelord"
 
-#: ckanext/apicatalog/translations.py:86
+#: ckanext/apicatalog/translations.py:87
 msgid "Maintainer's information"
 msgstr "Administratörens kontaktuppgifter"
 
-#: ckanext/apicatalog/translations.py:87
+#: ckanext/apicatalog/translations.py:88
 msgid "Use the maintainer's common contact information."
 msgstr "Använda administratörens allmänna kontaktuppgifter."
 
-#: ckanext/apicatalog/translations.py:88
+#: ckanext/apicatalog/translations.py:89
 msgid "The name of the maintainer"
 msgstr "Namnet av administratören"
 
-#: ckanext/apicatalog/translations.py:89
+#: ckanext/apicatalog/translations.py:90
 msgid "The email of the maintainer"
 msgstr "E-post av administratören"
 
-#: ckanext/apicatalog/translations.py:90
+#: ckanext/apicatalog/translations.py:91
 msgid "Limited"
 msgstr "Begränsad"
 
-#: ckanext/apicatalog/translations.py:91
+#: ckanext/apicatalog/translations.py:92
 msgid "Allowed organizations"
 msgstr "Tillåtna organisationer"
 
-#: ckanext/apicatalog/translations.py:92
+#: ckanext/apicatalog/translations.py:93
 msgid "Other information"
 msgstr "Giltighetstid"
 
-#: ckanext/apicatalog/translations.py:93
+#: ckanext/apicatalog/translations.py:94
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#: ckanext/apicatalog/translations.py:94
+#: ckanext/apicatalog/translations.py:95
 msgid "fi"
 msgstr "på finska"
 
-#: ckanext/apicatalog/translations.py:95
+#: ckanext/apicatalog/translations.py:96
 msgid "en"
 msgstr "på engelska"
 
-#: ckanext/apicatalog/translations.py:96
+#: ckanext/apicatalog/translations.py:97
 msgid "sv"
 msgstr "på svenska"
 
@@ -735,59 +739,59 @@ msgstr "Nej"
 msgid "X-ROAD Graphs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:23
+#: ckanext/apicatalog/templates/admin/statistics.html:22
 msgid "X-Road Environment:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:31
+#: ckanext/apicatalog/templates/admin/statistics.html:30
 msgid "Subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:39
+#: ckanext/apicatalog/templates/admin/statistics.html:38
 msgid "Members:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:47
+#: ckanext/apicatalog/templates/admin/statistics.html:46
 msgid "SecurityServers:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:55
+#: ckanext/apicatalog/templates/admin/statistics.html:54
 msgid "X-ROAD Catalog - Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:62
+#: ckanext/apicatalog/templates/admin/statistics.html:59
 msgid "SOAP services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:70
+#: ckanext/apicatalog/templates/admin/statistics.html:67
 msgid "REST services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:78
+#: ckanext/apicatalog/templates/admin/statistics.html:75
 msgid "OpenAPI services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:86
+#: ckanext/apicatalog/templates/admin/statistics.html:83
 msgid "X-ROAD Catalog - Distinct Services"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:93
+#: ckanext/apicatalog/templates/admin/statistics.html:88
 msgid "Distinct services:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:101
+#: ckanext/apicatalog/templates/admin/statistics.html:96
 msgid "CKAN"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:108
+#: ckanext/apicatalog/templates/admin/statistics.html:101
 msgid "Public subsystems:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:116
+#: ckanext/apicatalog/templates/admin/statistics.html:109
 msgid "Total organizations:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/statistics.html:124
+#: ckanext/apicatalog/templates/admin/statistics.html:117
 msgid "Provider organizations:"
 msgstr ""
 
@@ -1389,7 +1393,7 @@ msgstr "Är du säker på att du vill ta bort medlemmen?"
 #: ckanext/apicatalog/templates/organization/members.html:38
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:29
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 #: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr "Radera"
@@ -1438,27 +1442,6 @@ msgstr "Visa alla organisationer"
 msgid "Show only service providers"
 msgstr "Visa endast tjänsteleverantörer"
 
-#: ckanext/apicatalog/templates/package/edit.html:10
-msgid "Subsystem's information"
-msgstr "Subsystemets information"
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-msgid "Resources"
-msgstr "Resurser"
-
-#: ckanext/apicatalog/templates/package/edit.html:11
-#: ckanext/apicatalog/templates/package/read.html:64
-msgid "Attachments"
-msgstr "Bilagor"
-
-#: ckanext/apicatalog/templates/package/edit.html:13
-msgid "Access request settings"
-msgstr "Administrering av begäran om tillstånd"
-
-#: ckanext/apicatalog/templates/package/edit.html:14
-msgid "Received access requests"
-msgstr ""
-
 #: ckanext/apicatalog/templates/package/edit_base.html:7
 msgid "Edit subsystem"
 msgstr "Redigera subsystem"
@@ -1466,6 +1449,23 @@ msgstr "Redigera subsystem"
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 msgid "Cancel editing"
 msgstr "Avbryt redigering"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:24
+msgid "Subsystem's information"
+msgstr "Subsystemets information"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:25
+#: ckanext/apicatalog/templates/package/read.html:64
+msgid "Attachments"
+msgstr "Bilagor"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:27
+msgid "Access request settings"
+msgstr "Administrering av begäran om tillstånd"
+
+#: ckanext/apicatalog/templates/package/edit_base.html:28
+msgid "Received access requests"
+msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:18
 msgid "Request permission to use this subsystem"
@@ -1779,11 +1779,11 @@ msgstr ""
 msgid "License"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:79
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
 msgid "Are you sure you want to delete this resource?"
 msgstr "Vill du verkligen radera denna resurs?"
 
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:84
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:75
 msgid "Finish"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
@@ -24,6 +24,7 @@ def schema_translatable_strings():
               ' customer service, not an individual number.'),
             _('If possible, enter the email address of the organization or customer service, '
               'not the email address of the individual.'),
+            _('Email {email} is not a valid format'),
             _('Discard changes'),
             _('Save changes'),
             _('Write subsystem description'),

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -29,15 +29,30 @@ def service_permission_application_create(context, data_dict):
     target_organization_id = data_dict.get('target_organization_id')
     if target_organization_id is None or target_organization_id == "":
         errors['target_organization_id'] = _('Missing value')
+
     business_code = data_dict.get('business_code')
     if business_code is None or business_code == "":
         errors['business_code'] = _('Missing value')
+    else:
+        try:
+            # From ckanext-apicatalog
+            tk.get_validator('business_id_validator')(business_code)
+        except tk.Invalid as e:
+            errors['business_code'] = e.error
+
     contact_name = data_dict.get('contact_name')
     if contact_name is None or contact_name == "":
         errors['contact_name'] = _('Missing value')
+
     contact_email = data_dict.get('contact_email')
     if contact_email is None or contact_email == "":
         errors['contact_email'] = _('Missing value')
+    else:
+        try:
+            tk.get_validator('email_validator')(contact_email, context)
+        except tk.Invalid as e:
+            errors['contact_email'] = e.error
+
     ip_address_list = data_dict.get('ip_address_list')
     if ip_address_list is None or ip_address_list == "":
         errors['ip_address_list'] = _('Missing value')


### PR DESCRIPTION
# Description
Validate email and business code values when creating service access requests.

## Jira ticket reference: [LIKA-514](https://jira.dvv.fi/browse/LIKA-514)

## What has changed:
- Added calls to `email_validator` and `business_id_validator` validators when creating applications
- Updated translations because CKAN validation error `"Email {email} is not a valid format"` was not translated

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No


