### PR TITLE
LIKA-516: Fix multiselect showing two checkboxes for each option

### DIFF
--- a/ckanext/ckanext-apicatalog/less/multiselect.less
+++ b/ckanext/ckanext-apicatalog/less/multiselect.less
@@ -83,13 +83,15 @@
     }
 
     [type="checkbox"] {
+      display: none;
+
       & + .custom-checkbox {
-      display: inline-flex;
+        display: inline-flex;
         border: 1px solid @kapa-input-border;
         border-radius: 2px;
         width: 16px;
         height: 16px;
-        margin-right: 0;
+        margin-right: 1ch;
         font-size: 15px;
         color: @suomifi-highlight-base;
         min-width: 16px;


### PR DESCRIPTION
# Description
Multiselect styles were broken and showed two check boxes for each option. Hide the other one.

## Jira ticket reference: [LIKA-516](https://jira.dvv.fi/browse/LIKA-516)

## What has changed:
- Hide the "real" checkbox to only show the styled one.
- Add a one-character margin after the styled checkbox

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/192762933-f86d601c-c75c-4b4c-b3be-029e7675fe6a.png)
