### PR TITLE
LIKA-507: Change service permission application settings upload label

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -58,6 +58,7 @@
                       {{ form.image_upload_dragndrop(
                           settings,
                           errors,
+                          url_label=_('File'),
                           upload_label=_('Add your file'),
                           is_upload_enabled=h.uploads_enabled(),
                           is_url=is_url_additional_file,
@@ -83,6 +84,7 @@
               {{ form.image_upload_dragndrop(
                   settings,
                   errors,
+                  url_label=_('File'),
                   upload_label=_('Add your file'),
                   is_upload_enabled=h.uploads_enabled(),
                   is_url=is_url,


### PR DESCRIPTION
# Description
Changed permission application settings view upload label from "Image URL" to "File"

## Jira ticket reference: [LIKA-507](https://jira.dvv.fi/browse/LIKA-507)

## What has changed:
- Changed input label

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No
![image](https://user-images.githubusercontent.com/726461/193567440-ca86f736-1a8a-4946-bdee-1c72b4297b73.png)

