### PR TITLE
LIKA-511: Move service permission application list to dashboard

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html
@@ -40,15 +40,6 @@
     <span class="text">{{ _('Blog') }}</span>
   </a>
 </li>
-
-{% if h.is_extension_loaded('apply_permissions_for_service') %}
-    <li class="{{ class }}">
-      <a href="{{ h.url_for('apply_permissions.list_permission_applications') }}" title="{{ _('Blog') }}">
-        <i class="fa fa-file-text-o"></i>
-        <span class="text">{{ _('Service access applications') }}</span>
-      </a>
-    </li>
-{% endif %}
 <!-- /ckanext_pages -->
 
 {% block header_account_logged %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/user/dashboard.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/user/dashboard.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+        <ul class="nav nav-tabs">
+          {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}
+          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets'), icon='sitemap') }}
+          {{ h.build_nav_icon('dashboard.organizations', _('My Organizations'), icon='building-o') }}
+          {% if h.is_extension_loaded('apply_permissions_for_service') %}
+            {{ h.build_nav_icon('apply_permissions.dashboard', _('Service access applications'), icon='file-text-o') }}
+          {% endif %}
+        </ul>
+{% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/base.html
@@ -1,5 +1,5 @@
 {% extends 'page.html' %}
 
 {% block breadcrumb_content %}
-    <li>{% link_for _('Service access applications'), named_route='apply_permissions.list_permission_applications' %}</li>
+    <li>{% link_for _('Service access applications'), named_route='apply_permissions.dashboard' %}</li>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
@@ -1,0 +1,16 @@
+{% extends "user/dashboard.html" %}
+
+{% block dashboard_activity_stream_context %}{% endblock %}
+
+{% block page_primary_action %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h2 class="hide-heading">{{ _('Service access applications') }}</h2>
+  {% if applications %}
+    {% snippet 'apply_permissions_for_service/snippets/application_table.html', applications=applications %}
+  {% else %}
+  <p>{{ _('You have not sent any service access applications. You can apply for access to services by clicking the "Request access" button on the service page.') }}</p>
+  {% endif %}
+{% endblock %}
+

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/index.html
@@ -7,50 +7,7 @@
 {% block primary_content_inner %}
 
 {% if applications %}
-    <table class="table table-bordered" style="table-layout:fixed;">
-        <thead>
-            <tr>
-                <th style="width: 28%">{{ _('Applicant information') }}</th>
-                <th style="width: 20%">{{ _('Information about the organization consuming the services') }}</th>
-                <th style="width: 36%">{{ _('Service and API you are applying to access') }}</th>
-                <th style="width: 16%">{{ _('API access application') }}</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for application in applications %}
-            {% set subsystem_code = application.subsystem_code.split('.') %}
-            {% for service in application.services %}
-            <tr>
-                <td>
-                    {{ _('Organization') }} : <b>{% link_for application.organization["title"], named_route='organization.read', id=application.organization_id %}</b><br>
-                    {{ _('Subsystem') }} : <b>{% link_for application.requester_subsystem.name, named_route='dataset.read', id=application.requester_subsystem.id %}</b><br>
-                </td>
-                {% if "intermediate_organization" in application %}
-                <td>
-                    {{ _('Organization') }} : <b>{% link_for h.get_translated(application.intermediate_organization, 'title'),
-                                                             named_route='organization.read',
-                                                             id=application.intermediate_organization_id %}</b><br>
-                    {{ _('Business code') }} : <b>{{ application.intermediate_business_code }}</b><br>
-                </td>
-                {% else %}
-                <td></td>
-                {% endif %}
-                <td>
-                    {{ _('Organization') }} : <b>{% link_for h.get_translated(application.target_organization, 'title'),
-                                                             named_route='organization.read',
-                                                             id=application.target_organization_id %}</b><br>
-                    {{ _('Subsystem') }} : <b>{% link_for subsystem_code[3], named_route='dataset.read', id=application.subsystem.id %}</b><br>
-                    {{ _('Service code') }} : <b>{% link_for service.name,
-                                                             named_route='dataset_resource.read',
-                                                             id=application.requester_subsystem.id,
-                                                             resource_id=service.id %}</b><br>
-                </td>
-                <td>{% link_for _('Preview application'), named_route='apply_permissions.view_permission_application', application_id=application.id %}</td>
-            </tr>
-            {% endfor %}
-        {% endfor %}
-        </tbody>
-    </table>
+  {% snippet 'apply_permissions_for_service/snippets/application_table.html', applications=applications %}
 {% else %}
 <p>{{ _('You have not sent any service access applications. You can apply for access to services by clicking the "Request access" button on the service page.') }}</p>
 {% endif %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/sent.html
@@ -1,7 +1,7 @@
 {% extends 'apply_permissions_for_service/base.html' %}
 
 {% block primary_content_inner %}
-  {% link_for _('All access applications'), named_route='apply_permissions.list_permission_applications', class_='btn', icon='arrow-left' %}
+  {% link_for _('All access applications'), named_route='apply_permissions.dashboard', class_='btn', icon='arrow-left' %}
 
   <p>{{ _('Application sent successfully') }}</p>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
@@ -1,0 +1,44 @@
+<table class="table table-bordered" style="table-layout:fixed;">
+  <thead>
+      <tr>
+          <th style="width: 28%">{{ _('Applicant information') }}</th>
+          <th style="width: 20%">{{ _('Information about the organization consuming the services') }}</th>
+          <th style="width: 36%">{{ _('Service and API you are applying to access') }}</th>
+          <th style="width: 16%">{{ _('API access application') }}</th>
+      </tr>
+  </thead>
+  <tbody>
+  {% for application in applications %}
+      {% set subsystem_code = application.subsystem_code.split('.') %}
+      {% for service in application.services %}
+      <tr>
+          <td>
+              {{ _('Organization') }} : <b>{% link_for application.organization["title"], named_route='organization.read', id=application.organization_id %}</b><br>
+              {{ _('Subsystem') }} : <b>{% link_for application.requester_subsystem.name, named_route='dataset.read', id=application.requester_subsystem.id %}</b><br>
+          </td>
+          {% if "intermediate_organization" in application %}
+          <td>
+              {{ _('Organization') }} : <b>{% link_for h.get_translated(application.intermediate_organization, 'title'),
+                                                       named_route='organization.read',
+                                                       id=application.intermediate_organization_id %}</b><br>
+              {{ _('Business code') }} : <b>{{ application.intermediate_business_code }}</b><br>
+          </td>
+          {% else %}
+          <td></td>
+          {% endif %}
+          <td>
+              {{ _('Organization') }} : <b>{% link_for h.get_translated(application.target_organization, 'title'),
+                                                       named_route='organization.read',
+                                                       id=application.target_organization_id %}</b><br>
+              {{ _('Subsystem') }} : <b>{% link_for subsystem_code[3], named_route='dataset.read', id=application.subsystem.id %}</b><br>
+              {{ _('Service code') }} : <b>{% link_for service.name,
+                                                       named_route='dataset_resource.read',
+                                                       id=application.requester_subsystem.id,
+                                                       resource_id=service.id %}</b><br>
+          </td>
+          <td>{% link_for _('Preview application'), named_route='apply_permissions.view_permission_application', application_id=application.id %}</td>
+      </tr>
+      {% endfor %}
+  {% endfor %}
+  </tbody>
+</table>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -2,6 +2,7 @@ from builtins import next
 import ckan.lib.uploader as uploader
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.helpers as h
+from ckan.views.user import _extra_template_variables as ckan_user_extra_template_variables
 from flask import Blueprint
 from logging import getLogger
 import re
@@ -21,6 +22,19 @@ def index():
         return toolkit.render('apply_permissions_for_service/index.html', extra_vars=extra_vars)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
+
+
+def dashboard():
+    context = {
+        u'user': toolkit.g.user,
+        u'auth_user_obj': toolkit.g.userobj,
+        u'for_view': True
+    }
+    data_dict = {u'user_obj': toolkit.g.userobj}
+    extra_vars = ckan_user_extra_template_variables(context, data_dict)
+    applications = toolkit.get_action('service_permission_application_list')(context, {})
+    extra_vars['applications'] = applications
+    return toolkit.render('apply_permissions_for_service/dashboard.html', extra_vars=extra_vars)
 
 
 def new_post(context, subsystem_id):
@@ -251,6 +265,7 @@ def settings(subsystem_id):
 
 
 apply_permissions.add_url_rule('/', 'list_permission_applications', view_func=index)
+apply_permissions.add_url_rule('/dashboard', 'dashboard', view_func=dashboard)
 apply_permissions.add_url_rule('/new/<subsystem_id>', 'new_permission_application', view_func=new, methods=['GET', 'POST'])
 apply_permissions.add_url_rule('/view/<application_id>', 'view_permission_application', view_func=view)
 apply_permissions.add_url_rule('/preview/<subsystem_id>', 'preview_permission_application', view_func=preview)


### PR DESCRIPTION
# Description
Move service permission application list to dashboard

## Jira ticket reference: [LIKA-511](https://jira.dvv.fi/browse/LIKA-511)

## What has changed:
- Added `apply_permissions.dashboard` view
- Replaced "My groups" with "Service access applications" in user dashboard tabs
- Removed profile menu item for service access applications
- Modified breadcrumbs to point to the dashboard instead of the list view

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/193767417-ce47024d-a8e1-458c-a7a0-4473bf6937d0.png)

