### PR TITLE
LIKA-442: better organization selection inputs for service applications

### DIFF
--- a/ckanext/ckanext-apicatalog/less/layout.less
+++ b/ckanext/ckanext-apicatalog/less/layout.less
@@ -226,7 +226,7 @@
     font-family: SourceSansPro-Light;
     font-size: 40px;
     font-weight: 300;
-    height: 48px;
+    min-height: 48px;
     line-height: 48px;
     margin-top: 0px;
     margin-bottom: 29px;

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -26,6 +26,9 @@ def service_permission_application_create(context, data_dict):
     organization_id = data_dict.get('organization_id')
     if organization_id is None or organization_id == "":
         errors['organization_id'] = _('Missing value')
+
+    intermediate_organization_id = data_dict.get('intermediate_organization')
+
     target_organization_id = data_dict.get('target_organization_id')
     if target_organization_id is None or target_organization_id == "":
         errors['target_organization_id'] = _('Missing value')
@@ -39,6 +42,13 @@ def service_permission_application_create(context, data_dict):
             tk.get_validator('business_id_validator')(business_code)
         except tk.Invalid as e:
             errors['business_code'] = e.error
+
+    intermediate_business_code = data_dict.get('intermediate_business_code')
+    if intermediate_business_code:
+        try:
+            tk.get_validator('business_id_validator')(intermediate_business_code)
+        except tk.Invalid as e:
+            errors['intermediate_business_code'] = e.error
 
     contact_name = data_dict.get('contact_name')
     if contact_name is None or contact_name == "":
@@ -65,9 +75,6 @@ def service_permission_application_create(context, data_dict):
     service_code_list = data_dict.get('service_code_list')
     if service_code_list is None or service_code_list == "":
         errors['service_code_list'] = _('Missing value')
-
-    intermediate_organization_id = data_dict.get('intermediate_organization_id')
-    intermediate_business_code = data_dict.get('intermediate_business_code')
 
     if errors:
         raise tk.ValidationError(errors)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -24,13 +24,17 @@
 {% block primary_content_inner %}
     <script>
     function selectOrganization() {
-        var organizationName = document.getElementById("intermediate_organization").value;
-        document.getElementById("intermediate_organization_id").value = organizationName;
-        document.getElementById("intermediate_business_code").value = organizationName.split('.')[2];
+        var organizationName = document.querySelector('[name=organization]').value;
+        document.querySelector('[name=businessCode]').value = organizationName.split('.')[2];
     }
-    function showOrganization() {
-        var intermediateOrganizationDiv = document.getElementById("intermediate_organization_div");
-        if (intermediateOrganizationDiv.style.display === "none") {
+    function selectIntermediateOrganization() {
+        var organizationName = document.querySelector('[name=intermediateOrganization]').value;
+        document.querySelector('[name=intermediateBusinessCode]').value = organizationName.split('.')[2];
+    }
+    function showIntermediateOrganization() {
+        var show = document.querySelector('[name=enableIntermediateOrganization]').checked;
+        var intermediateOrganizationDiv = document.getElementById("intermediateOrganizationDiv");
+        if (show) {
             intermediateOrganizationDiv.style.display = "block";
         } else {
             intermediateOrganizationDiv.style.display = "none";
@@ -48,9 +52,20 @@
 
   <p>* {{ _('Required field') }}</p>
   {% set user_org = user_managed_organizations[0] if user_managed_organizations else {} %}
-  {# TODO: Should probably be organization select component ? #}
-  {{ form.input('organization', label=_('Organization'), is_required=True, value=values.organization or user_org.name or '') }}
-  {{ form.input('businessCode', label=_('Business code'), is_required=True, value=values.business_code or user_org.xroad_member_code or '') }}
+
+  {% snippet 'apply_permissions_for_service/snippets/organization_select.html',
+             name='organization',
+             value=values.organization or user_org.name or '',
+             select_attrs={'onchange': 'selectOrganization()'},
+             label=_('Organization'),
+             is_required=True,
+             organizations=user_managed_organizations %}
+
+  {{ form.input('businessCode', label=_('Business code'), is_required=True, value=values.business_code) }}
+  {% if not values.business_code %}
+    {# populate value from selected organization #}
+    <script>selectOrganization()</script>
+  {% endif %}
 
   {{ form.input('contactName', label=_('Contact name'), is_required=True, value=values.contact_name or user.fullname) }}
   {{ form.input('contactEmail', label=_('Contact email'), is_required=True, value=values.contact_email or user.email) }}
@@ -60,7 +75,11 @@
       <table>
           <tr>
               <td style="padding-left: 5px; padding-right: 5px;">
-                  <input type="checkbox" id="show_intermediate_organization" name="show_intermediate_organization" onclick="showOrganization()">
+                  <input type="checkbox"
+                         id="enableIntermediateOrganization"
+                         name="enableIntermediateOrganization"
+                         {% if values.intermediate_organization %}checked{% endif %} 
+                         onchange="showIntermediateOrganization()">
               </td>
               <td style="padding-left: 5px; padding-right: 5px;">
                   {{ _('Applying organization acts as an intermediary on behalf of the organizations using the services') }}
@@ -69,24 +88,27 @@
       </table>
   </div>
 
-  {%- set organization_options=[] -%}
-  {% do organization_options.append({'value': '', 'text': ''}) %}
-  {% for organization in user_managed_organizations %}
-      {% do organization_options.append({'value': organization.id, 'text': organization.name}) %}
-  {% endfor %}
 
-  <div id="intermediate_organization_div" style="display:none">
+  <div id="intermediateOrganizationDiv">
     <h3>{{ _('Information about the organization consuming the services') }}</h3>
-    <div class="select-wrapper">
-        {{ form.select('intermediate_organization', id='intermediate_organization', label=_('Organization using the services'), options=organization_options,
-        selected=None, error=None, classes=['control-full'], attrs={'class': 'form-control', 'onchange': 'selectOrganization()'}, is_required=True) }}
-    </div>
-    <div class="form-group control-full">
-        <label class="control-label" for="intermediate_business_code">{{ _('Y-number') }}</label>
-        <input id="intermediate_business_code" type="text" name="intermediate_business_code" value="" placeholder="" readonly />
-        <input id="intermediate_organization_id" type="hidden" name="intermediate_organization_id" />
-    </div>
+    {% snippet 'apply_permissions_for_service/snippets/organization_select.html',
+               name='intermediateOrganization',
+               select_attrs={'onchange': 'selectIntermediateOrganization()'},
+               label=_('Organization using the services'),
+               is_required=True,
+               value=values.intermediate_organization,
+               organizations=user_managed_organizations %}
+
+    {{ form.input('intermediateBusinessCode', label=_('Y-number'),
+                  is_required=True, value=values.intermediate_business_code) }}
+    {% if not values.intermediate_business_code %}
+      {# populate value from selected organization #}
+      <script>selectIntermediateOrganization()</script>
+    {% endif %}
+
   </div>
+  {# Set visibility based on checkbox #}
+  <script>showIntermediateOrganization()</script>
 
   <hr>
   <h3>{{ _('Details of your Security Server and Subsystem') }}</h3>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/organization_select.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/organization_select.html
@@ -1,0 +1,35 @@
+{% import 'macros/form.html' as form %}
+
+{# name: input name
+   label: input label
+   is_required: is a value is_required
+   errors: error list
+   organizations: list of organization options
+   value: ID of selected organization
+   select_attrs: input element attributes
+   #}
+
+{% call form.input_block(name,
+  label=label,
+  error=errors,
+  is_required=is_required,
+  classes=['form-group', 'control-medium'],
+  ) %}
+  <select name={{ name }} data-module="autocomplete"
+          {{ form.attributes(select_attrs) if select_attrs else '' }}>
+    {% if not is_required %}
+      <option value="">
+      {%- if not is_required -%}
+        {{ _('No organization') }}
+      {%- endif -%}
+      </option>
+    {% endif %}
+    {% for organization in organizations %}
+      {% set selected_org = value == organization.id %}
+      <option value="{{ organization.id }}"
+              {%- if selected_org %} selected="selected"{% endif %}>
+        {{ organization.display_name }}
+      </option>
+    {% endfor %}
+  </select>
+{% endcall %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -43,9 +43,9 @@ def new_post(context, subsystem_id):
 
     data_dict = {
             'target_organization_id': form.get('target_organization_id'),
-            'intermediate_organization_id': form.get('intermediate_organization_id'),
+            'intermediate_organization': None,
             'business_code': form.get('businessCode'),
-            'intermediate_business_code': form.get('intermediate_business_code'),
+            'intermediate_business_code': None,
             'contact_name': form.get('contactName'),
             'contact_email': form.get('contactEmail'),
             'subsystem_id': form.get('subsystemId'),
@@ -58,6 +58,10 @@ def new_post(context, subsystem_id):
             'file_url': form.get('file_url'),
             'clear_upload': form.get('clear_upload'),
             }
+
+    if form.get('enableIntermediateOrganization'):
+        data_dict['intermediate_organization'] = form.get('intermediateOrganization')
+        data_dict['intermediate_business_code'] = form.get('intermediateBusinessCode')
 
     try:
         organization = toolkit.get_action('organization_show')(context, {'id': form['organization']})


### PR DESCRIPTION
# Description
Implement proper organization select for service permission application form

## Jira ticket reference: [LIKA-442](https://jira.dvv.fi/browse/LIKA-442)

## What has changed:
- Make prelude have dynamic size, because long headers wrap under content
- Added snippet for organization select
- Rewrite service permission application organization/intermediate organization parts
- Add intermediate organization business code validation
- Harmonize code style

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/194040939-3d910624-8b21-44cb-802b-97bb16e6e7be.png)

