### PR TITLE
LIKA-498: Hide url_type and license from resource read additional inf…

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -321,6 +321,7 @@
     {
       "field_name": "url_type",
       "form_snippet": "hidden.html",
+      "display_snippet": null,
       "validators": "ignore_missing"
     }
   ]

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/package/resource_read.html
@@ -172,12 +172,6 @@
                   <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
                 </tr>
               {%- endblock -%}
-              {%- block resource_license -%}
-                <tr>
-                  <th scope="row">{{ _('License') }}</th>
-                  <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
-                </tr>
-              {%- endblock -%}
               {%- block resource_fields -%}
                 {%- for field in schema.resource_fields -%}
                   {%- if field.field_name not in exclude_fields


### PR DESCRIPTION
# Description
Hide hopefully the last rows from the resource additional info table. (url_type and license)

## Jira ticket reference: [LIKA-498](https://jira.dvv.fi/browse/LIKA-498)

## What has changed:
* Hide url_type from resource_read additional info table (no key and value upload)
* Hide license from resource_read additional info table (this has been removed from schema but was still in the template)

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/194236218-b610dc08-ac99-4be0-96de-ee20d8108bc6.png)

After:
![image](https://user-images.githubusercontent.com/3969176/194236246-1b417a03-b73f-486e-a797-532c19774553.png)


