### PR TITLE
LIKA-522: Remove service application form cancel button

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -140,7 +140,6 @@
   {% endif %}
   {% block application_form_actions %}
     <input class="btn btn-primary" type="submit" value="{{ _('Send access application') }}"></input>
-    <a class="btn btn-secondary">{{ _('Cancel') }}</a>
   {% endblock %}
 </form>
 {% endblock %}


### PR DESCRIPTION
# Description
Remove service permission application form's cancel button as unnecessary.

## Jira ticket reference: [LIKA-522](https://jira.dvv.fi/browse/LIKA-522)

## What has changed:
- Removed cancel button

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Should there be a cancel button? What should it do, as the form opens in a new tab and can't reliably go "back"? Closing the tab is probably not expected and may be disorienting if the form was opened from a link in a new window.

