### PR TITLE
Fix building vagrant environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,8 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
        ansible.inventory_path = "ansible/inventories/vagrant"
        ansible.config_file = "ansible/ansible.cfg"
        ansible.limit = "all"
-       ansible.pip_install_cmd = "sudo apt-get install -y python3-distutils && curl -s https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo python3"
-       ansible.install_mode = "pip"
+       ansible.install_mode = "pip3"
     end
     server.vm.provider "virtualbox" do |vbox|
       vbox.gui = false

--- a/ansible/roles/ckan-extension/tasks/main.yml
+++ b/ansible/roles/ckan-extension/tasks/main.yml
@@ -59,6 +59,9 @@
   when: deployment_environment_id == "vagrant"
 
 - name: Link extension sources
-  command: "{{ virtualenv }}/bin/python setup.py develop chdir={{ ckanext_sync_path }}/{{ ckanext }}"
+  pip:
+    virtualenv: "{{ virtualenv }}"
+    name: "{{ ckanext_sync_path }}/{{ ckanext }}"
+    editable: yes
   notify: Restart CKAN
 


### PR DESCRIPTION
# Description
We don't need ton install pip separately anymore and old linking sources was done using hard coded paths.
