### PR TITLE
LIKA-523: attachment delete auth

### DIFF
--- a/ansible/roles/ckan/files/patches/fix_resource_delete_auth.patch
+++ b/ansible/roles/ckan/files/patches/fix_resource_delete_auth.patch
@@ -1,0 +1,45 @@
+diff --git a/ckan/views/resource.py b/ckan/views/resource.py
+index 1c33333bb..7a2aaeb47 100644
+--- a/ckan/views/resource.py
++++ b/ckan/views/resource.py
+@@ -439,7 +439,7 @@ class EditView(MethodView):
+ 
+ 
+ class DeleteView(MethodView):
+-    def _prepare(self, id):
++    def _prepare(self, resource_id):
+         context = {
+             u'model': model,
+             u'session': model.Session,
+@@ -447,11 +447,11 @@ class DeleteView(MethodView):
+             u'auth_user_obj': g.userobj
+         }
+         try:
+-            check_access(u'package_delete', context, {u'id': id})
++            check_access(u'resource_delete', context, {u'id': resource_id})
+         except NotAuthorized:
+             return base.abort(
+                 403,
+-                _(u'Unauthorized to delete package %s') % u''
++                _(u'Unauthorized to delete resource %s') % u''
+             )
+         return context
+ 
+@@ -461,7 +461,7 @@ class DeleteView(MethodView):
+                 u'{}_resource.edit'.format(package_type),
+                 resource_id=resource_id, id=id
+             )
+-        context = self._prepare(id)
++        context = self._prepare(resource_id)
+ 
+         try:
+             get_action(u'resource_delete')(context, {u'id': resource_id})
+@@ -483,7 +483,7 @@ class DeleteView(MethodView):
+             return base.abort(404, _(u'Resource not found'))
+ 
+     def get(self, package_type, id, resource_id):
+-        context = self._prepare(id)
++        context = self._prepare(resource_id)
+         try:
+             resource_dict = get_action(u'resource_show')(
+                 context, {

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -32,6 +32,7 @@ ckan_patches:
   - { file: "fix_autocomplete_server_error" }
   - { file: "email_attachment" }
   - { file: "fix_updating_resource_filesize" } # https://github.com/ckan/ckan/pull/7103
+  - { file: "fix_resource_delete_auth" } # https://github.com/ckan/ckan/pull/7132
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -970,7 +970,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
                 'package_create': admin_only,
                 'organization_delete': admin_only,
                 'package_delete': admin_only,
-                'resource_delete': admin_only
+                'resource_delete': auth.resource_delete
                 }
 
     # IPermissionLabels

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -110,6 +110,24 @@ class TestApicatalogPlugin():
             helpers.call_action('package_delete', context, id=subsystem['id'])
 
     @pytest.mark.usefixtures('with_request_context')
+    def test_non_sysadmins_should_be_able_to_delete_attachments(self):
+        user = factories.User()
+        org_users = [{"name": user["name"], "capacity": "admin"}]
+        org = factories.Organization(users=org_users)
+
+        subsystem = factories.Dataset(
+            owner_org=org["id"]
+        )
+
+        service = factories.Resource(
+            package_id=subsystem['id'],
+        )
+
+        context = {'ignore_auth': False, 'user': user['name']}
+
+        helpers.call_action('resource_delete', context, id=service['id'])
+
+    @pytest.mark.usefixtures('with_request_context')
     def test_non_sysadmins_should_not_be_able_to_delete_services(self):
         user = factories.User()
         org_users = [{"name": user["name"], "capacity": "admin"}]
@@ -121,6 +139,7 @@ class TestApicatalogPlugin():
 
         service = factories.Resource(
             package_id=subsystem['id'],
+            harvested_from_xroad=True,
         )
 
         context = {'ignore_auth': False, 'user': user['name']}


### PR DESCRIPTION
# Description
Users should be able to delete attachments (resources not harvested from X-Road), but not services.

## Jira ticket reference: [LIKA-523](https://jira.dvv.fi/browse/LIKA-523)

## What has changed:
- Added override auth function for resource_delete
- Added patch to fix ckan.views.resource.DeleteView's auth functions
- Added tests

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

