### PR TITLE
LIKA-534: Work around rjsmin bug to fix multiselect label

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/javascript/multiselect.js
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/javascript/multiselect.js
@@ -106,8 +106,10 @@ ckan.module("multiselect", function($) {
       if (selectedItems.length === 1) {
         return selectedItems[0].dataset.optionLabel;
       }
-
-      return `${selectedItems.length} ${this.options.selectTranslation}`;
+      
+      // Use string concatenation instead of a template string because of a bug in rjsmin
+      // https://github.com/miracle2k/webassets/issues/511
+      return selectedItems.length + ' ' + this.options.selectTranslation;
     },
 
     // Returns array of checkboxes with specific name value combo


### PR DESCRIPTION
# Description
Multiselect elements are missing a space

## Jira ticket reference: [LIKA-534](https://jira.dvv.fi/browse/LIKA-534)

## What has changed:
Use string concatenation instead of template strings. Rjsmin [had a bug that removes spaces from template strings](https://github.com/miracle2k/webassets/issues/511) and CKAN only has the updated version in master through `webassets==2.0` 

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

