### PR TITLE
LIKA-526: Remove Data Exchange Layer info link from header

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/apicatalog_header.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/apicatalog_header.html
@@ -59,10 +59,6 @@
                   {{ h.build_nav('home.index', _('Home')) }}
                   {{ h.build_nav('dataset.search', _('Datasets'), highlight_controllers=['package', 'resource']) }}
                   {{ h.build_nav('organization.index', _('Organizations'), highlight_controllers=['organization']) }}
-                <li><a class="nav-external-link" href="https://palveluhallinta.suomi.fi/{{ lang_code }}/sivut/palveluvayla/esittely" target="_blank">{{ _('Information about National Data Exchange Layer') }} <span class="sr-only">{{ _('link opens in new tab or window') }}</span>
-                  <svg viewbox="0 0 24 24" aria-hidden="true">
-                    <use xlink:href="/base/images/external-link-icon.svg#path-1"></use>
-                  </svg></a></li>
 
                   {% set lang = h.lang().split('_')[0] %}
                   {% set submenu_content = h.get_submenu_content() %}


### PR DESCRIPTION
# Description
Remove Data Exchange Layer info link from header

## Jira ticket reference: [LIKA-526](https://jira.dvv.fi/browse/LIKA-526)

## What has changed:
- Removed link

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No
![image](https://user-images.githubusercontent.com/726461/198999665-9e185d41-c060-4288-9c80-a911b0cee789.png)


