### PR TITLE
LIKA-515: Hide subsystem options in permission application based on selected organization

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/.github/workflows/test.yml
+++ b/ckanext/ckanext-apply_permissions_for_service/.github/workflows/test.yml
@@ -1,0 +1,83 @@
+name: Tests
+on: [push, pull_request, workflow_dispatch, workflow_call]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Install requirements
+        run: pip install flake8 pycodestyle
+      - name: Check syntax
+        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+      - name: Run flake8
+        run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
+
+  test:
+    needs: lint
+    strategy:
+      matrix:
+        ckan-version: [2.9]
+      fail-fast: false
+
+    name: CKAN ${{ matrix.ckan-version }}
+    runs-on: ubuntu-latest
+    container:
+      image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
+    services:
+      solr:
+        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+      postgres:
+        image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:3
+    env:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
+      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
+      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
+      CKAN_SOLR_URL: http://solr:8983/solr/ckan
+      CKAN_REDIS_URL: redis://redis:6379/1
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install requirements
+        run: |
+          git clone https://github.com/vrk-kpa/api-catalog
+          cd api-catalog
+          git submodule update --init --recursive
+
+          cd ckanext/ckanext-apicatalog
+          pip install -e .
+
+          cd ../ckanext-scheming
+          pip install -e .
+
+          cd ../ckanext-fluent
+          pip install -e .
+
+          cd ../ckanext-markdown_editor
+          pip install -e .
+
+          cd ../../..
+
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          pip install -e .
+          # Replace default path to CKAN core config file with the one on the container
+          sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+      - name: Setup extension
+        run: |
+          ckan -c test.ini db init
+      - name: Run tests
+        run: pytest --ckan-ini=test.ini --cov=ckanext.xroad_integration --disable-warnings ckanext/xroad_integration/tests
+      - name: Coveralls
+        uses: AndreMiras/coveralls-python-action@develop

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -69,9 +69,16 @@ def service_permission_application_create(context, data_dict):
     subsystem_id = data_dict.get('subsystem_id')
     if subsystem_id is None or subsystem_id == "":
         errors['subsystem_id'] = _('Missing value')
+
+    # Subsystem code must exist and match a subsystem belonging to the selected utilizing organization
     subsystem_code = data_dict.get('subsystem_code')
     if subsystem_code is None or subsystem_code == "":
         errors['subsystem_code'] = _('Missing value')
+    utilizing_organization_business_code = intermediate_business_code or business_code
+    subsystem = tk.get_action('package_show')(context, {'id': subsystem_code})
+    if not subsystem.get('owner_org', '').endswith(utilizing_organization_business_code):
+        errors['subsystem_code'] = _('Selected subsystem does not belong to the utilizing organization')
+
     service_code_list = data_dict.get('service_code_list')
     if service_code_list is None or service_code_list == "":
         errors['service_code_list'] = _('Missing value')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -94,3 +94,7 @@ class ApplyPermission(Base):
                 pass
 
         return application_dict
+
+
+def init_table(engine):
+    Base.metadata.create_all(engine)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -24,12 +24,22 @@
 {% block primary_content_inner %}
     <script>
     function selectOrganization() {
-        var organizationName = document.querySelector('[name=organization]').value;
-        document.querySelector('[name=businessCode]').value = organizationName.split('.')[2];
+        let element = document.querySelector('[name=businessCode]');
+        let organizationName = document.querySelector('[name=organization]').value;
+        let newValue = organizationName.split('.')[2];
+        if(element.value !== newValue) {
+          element.value = newValue;
+          updateSubsystemSelect();
+        }
     }
     function selectIntermediateOrganization() {
-        var organizationName = document.querySelector('[name=intermediateOrganization]').value;
-        document.querySelector('[name=intermediateBusinessCode]').value = organizationName.split('.')[2];
+        let element = document.querySelector('[name=intermediateBusinessCode]')
+        let organizationName = document.querySelector('[name=intermediateOrganization]').value;
+        let newValue = organizationName.split('.')[2];
+        if(element.value !== newValue) {
+          element.value = newValue;
+          updateSubsystemSelect();
+        }
     }
     function showIntermediateOrganization() {
         var show = document.querySelector('[name=enableIntermediateOrganization]').checked;
@@ -39,6 +49,31 @@
         } else {
             intermediateOrganizationDiv.style.display = "none";
         }
+        updateSubsystemSelect();
+    }
+    function updateSubsystemSelect() {
+      let owner_org = null;
+      if(document.querySelector('[name=enableIntermediateOrganization]').checked) {
+        owner_org = document.querySelector('[name=intermediateOrganization]').value;
+      } else {
+        owner_org = document.querySelector('[name=organization]').value;
+      }
+
+      let selected = null;
+      document.querySelectorAll('[name=subsystemCode] option').forEach(o => {
+        if(o.value.startsWith(owner_org)) {
+          o.removeAttribute('hidden')
+          if(o.selected || !selected) {
+            selected = o
+          }
+        } else {
+          o.setAttribute('hidden', true)
+          o.selected = false
+        }
+      })
+      if(selected) {
+        selected.selected = true
+      }
     }
     </script>
 {% block errors %}{{ form.errors(errors) }}{% endblock %}
@@ -62,10 +97,6 @@
              organizations=user_managed_organizations %}
 
   {{ form.input('businessCode', label=_('Business code'), is_required=True, value=values.business_code) }}
-  {% if not values.business_code %}
-    {# populate value from selected organization #}
-    <script>selectOrganization()</script>
-  {% endif %}
 
   {{ form.input('contactName', label=_('Contact name'), is_required=True, value=values.contact_name or user.fullname) }}
   {{ form.input('contactEmail', label=_('Contact email'), is_required=True, value=values.contact_email or user.email) }}
@@ -101,20 +132,13 @@
 
     {{ form.input('intermediateBusinessCode', label=_('Y-number'),
                   is_required=True, value=values.intermediate_business_code) }}
-    {% if not values.intermediate_business_code %}
-      {# populate value from selected organization #}
-      <script>selectIntermediateOrganization()</script>
-    {% endif %}
-
   </div>
-  {# Set visibility based on checkbox #}
-  <script>showIntermediateOrganization()</script>
 
   <hr>
   <h3>{{ _('Details of your Security Server and Subsystem') }}</h3>
   <p class="input-group-description">{{ _('Fill in the details of the Security Server and subsystem that you are applying permission for, and need the firewall opened to.') }}</p>
 
-  {% set subsystem_options = [] %}
+  {% set subsystem_options = [{'value': '', 'text': ''}] %}
   {% for d in user_managed_datasets %}
     {% set dataset_title = h.xroad_subsystem_path(d) or h.get_translated(d, 'title') %}
     {% do subsystem_options.append({'value': d.id, 'text': dataset_title}) %}
@@ -163,5 +187,18 @@
   {% block application_form_actions %}
     <input class="btn btn-primary" type="submit" value="{{ _('Send access application') }}"></input>
   {% endblock %}
+
+  {% if not values.business_code %}
+    {# populate business code from selected organization #}
+    <script>selectOrganization()</script>
+  {% endif %}
+    {% if not values.intermediate_business_code %}
+      {# populate intermediate organization business code from selected organization #}
+      <script>selectIntermediateOrganization()</script>
+    {% endif %}
+
+  {# Set intermediate organization visibility based on checkbox #}
+  <script>showIntermediateOrganization()</script>
+  <script>updateSubsystemSelect()</script>
 </form>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
@@ -1,0 +1,9 @@
+import pytest
+
+import ckanext.apply_permissions_for_service.model as apply_permissions_for_service_model
+
+
+@pytest.fixture
+def apply_permissions_for_service_setup():
+    import ckan.model as model
+    apply_permissions_for_service_model.init_table(model.meta.engine)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -43,13 +43,18 @@ class TestApplyPermissionsForServicePlugin():
                     ip_address_list=['1.2.3.4'],
                     subsystem_id=dataset1['id'],
                     subsystem_code=dataset2['xroad_subsystemcode'],
-                    service_code_list='.'.join([resource1['xroad_servicecode'],
-                                                resource1['xroad_serviceversion']])
+                    service_code_list=[resource1['id']]
                     )
         call_action('service_permission_application_create',
                     {u"user": user2["name"], "ignore_auth": False},
                     **application
                     )
+
+        applications = call_action('service_permission_application_list', {'ignore_auth': True})
+
+        assert(len(applications) == 1)
+        for key, value in application.items():
+            assert(applications[0][key] == value)
 
     def test_user_creates_application_with_inconsistent_subsystem(self):
         organization1 = Organization()
@@ -85,3 +90,8 @@ class TestApplyPermissionsForServicePlugin():
                         service_code_list='.'.join([resource1['xroad_servicecode'],
                                                     resource1['xroad_serviceversion']])
                         )
+
+        applications = call_action('service_permission_application_list',
+                                   {'ignore_auth': True},
+                                   subsystem_id=dataset1['id'])
+        assert(len(applications) == 0)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -1,5 +1,87 @@
-"""Tests for plugin.py."""
+import pytest
+from ckan.plugins.toolkit import ValidationError
+from ckan.tests.factories import User, Dataset, Organization, Resource
+from ckan.tests.helpers import call_action
+from .fixtures import *
+
+# import unittest.mock as mock
+# from ckan import model
+
+# from ckan.tests import factories
+# import ckan.tests.helpers as helpers
 
 
-def test_plugin():
-    pass
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'apply_permissions_for_service_setup')
+class TestApplyPermissionsForServicePlugin():
+    def test_user_creates_application(self):
+        organization1 = Organization()
+
+        user2 = User()
+        org2_users = [{"name": user2["name"], "capacity": "admin"}]
+
+        organization2 = Organization(id='TEST.ORG.1234567-1',
+                                     users=org2_users,
+                                     xroad_instance='TEST',
+                                     xroad_memberclass='ORG',
+                                     xroad_membercode='1234567-1')
+        dataset1 = Dataset(owner_org=organization1['id'],
+                           name='dataset1')
+        resource1 = Resource(package_id=dataset1['id'],
+                             xroad_servicecode='resource1',
+                             xroad_serviceversion='v1')
+
+        dataset2 = Dataset(owner_org=organization2['id'],
+                           name='dataset2',
+                           xroad_subsystemcode='dataset2')
+
+        application = dict(
+                    organization_id=organization2['id'],
+                    target_organization_id=organization1['id'],
+                    business_code=organization2['xroad_membercode'],
+                    contact_name=user2['name'],
+                    contact_email=user2['email'],
+                    ip_address_list=['1.2.3.4'],
+                    subsystem_id=dataset1['id'],
+                    subsystem_code=dataset2['xroad_subsystemcode'],
+                    service_code_list='.'.join([resource1['xroad_servicecode'],
+                                                resource1['xroad_serviceversion']])
+                    )
+        call_action('service_permission_application_create',
+                    {u"user": user2["name"], "ignore_auth": False},
+                    **application
+                    )
+
+    def test_user_creates_application_with_inconsistent_subsystem(self):
+        organization1 = Organization()
+
+        user2 = User()
+        org2_users = [{"name": user2["name"], "capacity": "admin"}]
+
+        organization2 = Organization(id='TEST.ORG.1234567-1',
+                                     users=org2_users,
+                                     xroad_instance='TEST',
+                                     xroad_memberclass='ORG',
+                                     xroad_membercode='1234567-1')
+        dataset1 = Dataset(owner_org=organization1['id'],
+                           name='dataset1')
+        resource1 = Resource(package_id=dataset1['id'],
+                             xroad_servicecode='resource1',
+                             xroad_serviceversion='v1')
+
+        Dataset(owner_org=organization2['id'],
+                name='dataset2',
+                xroad_subsystemcode='dataset2')
+        with pytest.raises(ValidationError):
+            call_action('service_permission_application_create',
+                        {u"user": user2["name"], "ignore_auth": False},
+                        organization_id=organization2['id'],
+                        target_organization_id=organization1['id'],
+                        business_code=organization2['xroad_membercode'],
+                        contact_name=user2['name'],
+                        contact_email=user2['email'],
+                        ip_address_list=['1.2.3.4'],
+                        subsystem_id=dataset1['id'],
+                        subsystem_code=dataset1['xroad_subsystemcode'],
+                        service_code_list='.'.join([resource1['xroad_servicecode'],
+                                                    resource1['xroad_serviceversion']])
+                        )

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -2,7 +2,7 @@ import pytest
 from ckan.plugins.toolkit import ValidationError
 from ckan.tests.factories import User, Dataset, Organization, Resource
 from ckan.tests.helpers import call_action
-from .fixtures import *
+from .fixtures import apply_permissions_for_service_setup  # noqa
 
 # import unittest.mock as mock
 # from ckan import model

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -52,9 +52,9 @@ class TestApplyPermissionsForServicePlugin():
 
         applications = call_action('service_permission_application_list', {'ignore_auth': True})
 
-        assert(len(applications) == 1)
+        assert len(applications) == 1
         for key, value in application.items():
-            assert(applications[0][key] == value)
+            assert applications[0][key] == value
 
     def test_user_creates_application_with_inconsistent_subsystem(self):
         organization1 = Organization()
@@ -94,4 +94,4 @@ class TestApplyPermissionsForServicePlugin():
         applications = call_action('service_permission_application_list',
                                    {'ignore_auth': True},
                                    subsystem_id=dataset1['id'])
-        assert(len(applications) == 0)
+        assert len(applications) == 0

--- a/ckanext/ckanext-apply_permissions_for_service/test.ini
+++ b/ckanext/ckanext-apply_permissions_for_service/test.ini
@@ -9,11 +9,19 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 
-# Insert any custom config settings to be used when running your extension's
-# tests here.
+ckan.locale_default = fi
 
+ckan.plugins = apply_permissions_for_service apicatalog scheming_datasets scheming_organizations fluent markdown_editor
+
+scheming.presets = ckanext.scheming:presets.json
+                   ckanext.fluent:presets.json
+                   ckanext.apicatalog:presets.json
+                   ckanext.markdown_editor:presets.json
+
+scheming.dataset_schemas = ckanext.apicatalog.schemas:dataset.json
+scheming.organization_schemas = ckanext.apicatalog.schemas:organization.json
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
# Description
Only show subsystems that belong to the selected organization in permission application subsystem select

## Jira ticket reference: [LIKA-515](https://jira.dvv.fi/browse/LIKA-515)

## What has changed:
- Added a function to hide subsystem options that don't belong to the selected (intermediate) organization

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

