### PR TITLE
LIKA-537: Fix failing lang parameter

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/helpers.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/helpers.py
@@ -3,6 +3,7 @@ import copy
 from datetime import datetime
 
 from ckan.plugins.toolkit import get_action, request
+from ckanext.scheming.helpers import scheming_language_text
 
 from ckan.logic import NotFound
 
@@ -93,15 +94,15 @@ def get_announcements(count=3, offset=0):
     return announcements
 
 
-# Override core helper to map en_GB to en
-# TODO: Convert to chained helper once upgraded to ckan 2.9
-def lang():
-    ''' Return the language code for the current locale eg `en` '''
+# Override scheming helper to map en_GB to en
+# TODO: Convert to chained helper once upgraded to ckan 2.10
+def apicatalog_scheming_language_text(text, prefer_lang=None):
     current_lang = request.environ.get('CKAN_LANG')
 
     if current_lang == "en_GB":
-        return "en"
-    return current_lang
+        return scheming_language_text(text, prefer_lang="en")
+
+    return scheming_language_text(text, prefer_lang=prefer_lang)
 
 
 def parse_datetime(t):

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -33,7 +33,8 @@ from ckanext.apicatalog.schema import create_user_to_organization_schema
 from . import validators
 from ckanext.apicatalog import cli
 from ckanext.apicatalog import auth, db
-from ckanext.apicatalog.helpers import with_field_string_replacements, lang as apicatalog_lang, parse_datetime
+from ckanext.apicatalog.helpers import with_field_string_replacements, \
+    apicatalog_scheming_language_text, parse_datetime
 
 from collections import OrderedDict
 
@@ -774,7 +775,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
                 'get_field_from_schema': get_field_from_schema,
                 'max_resource_size': get_max_resource_size,
                 'with_field_string_replacements': with_field_string_replacements,
-                "lang": apicatalog_lang
+                'scheming_language_text': apicatalog_scheming_language_text
                 }
 
     def get_actions(self):


### PR DESCRIPTION
# Description
Overriding lang() broke javascript translations, this fixes the original issue by overriding scheming_language_text instead

## Jira ticket reference: [LIKA-537](https://jira.dvv.fi/browse/LIKA-537)

## What has changed:
Removes overridden lang().
Overrides scheming_language_text()

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

