### PR TITLE
LIKA-518: Style GDPR warning according to design

### DIFF
--- a/ckanext/ckanext-apicatalog/less/components.less
+++ b/ckanext/ckanext-apicatalog/less/components.less
@@ -5,3 +5,4 @@
 @import "components/tags";
 @import "components/drag-n-drop-uploader";
 @import "components/tags";
+@import "components/warning-container";

--- a/ckanext/ckanext-apicatalog/less/components/warning-container.less
+++ b/ckanext/ckanext-apicatalog/less/components/warning-container.less
@@ -1,0 +1,17 @@
+.warning-container {
+  background-color: #fff6e0;
+  border-left: 4px solid #e86717;
+  padding: 20px;
+  display: flex;
+  gap: 15px;
+
+  .warning-container__icon {
+    color: #e86717;
+    font-size: 22px;
+  }
+
+  .warning-container__content {
+    flex-grow: 1;
+    font-size: 16px;
+  }
+}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -49,8 +49,11 @@
                     {{ form.checkbox('require_additional_application_file', label=_('Request additional info with an attachment'), id='additional_application_file', value='True', checked=settings.require_additional_application_file) }}
 
                     <div id="additional_application_file_field">
-                      <div class="module__settings-instructions">
-                        <div class="module__settings-instructions__content">
+                      <div class="warning-container">
+                        <div class="warning-container__icon">
+                          <i class="far fa-exclamation-triangle"></i>
+                        </div>
+                        <div class="warning-container__content">
                           {%- trans -%}
                           Please note that <b>you should not request to provide personal information</b>
                           in the attached files, because the submitted attached files remain available to


### PR DESCRIPTION
# Description
Styled GDPR warning according to design

## Jira ticket reference: [LIKA-518](https://jira.dvv.fi/browse/LIKA-518)

## What has changed:
- Added a LESS component for a warning box like in the design
  - The colors are defined ad-hoc because they don't match suomi.fi colors
- Utilize style in service permission application settings

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/200323301-a97d2e7c-40e1-43e0-9a58-93caf50caf36.png)
