### PR TITLE
LIKA-515: Style organization select component

### DIFF
--- a/ckanext/ckanext-apicatalog/less/forms.less
+++ b/ckanext/ckanext-apicatalog/less/forms.less
@@ -323,12 +323,51 @@ textarea {
   background-image: none;
 }
 
+.select2-container .select2-choice {
+  font-size: 14px;
+  color: @suomifi-text-base;
+  height: 40px;
+  background-color: white;
+  border: 1px solid @kapa-input-border;
+  border-radius: 2px;
+  appearance: none;
+  padding: 6px 16px;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background-image: none;
+  
+  .select2-arrow {
+    display: none;
+    pointer-events: none;
+  }
 
+  &:after {
+    pointer-events: none;
+    font-family: "Font Awesome 5 Pro";
+    content: "\f0d7";
+    font-size: 18px;
+    font-weight: 900;
+    color: @suomifi-text-highlight;
+    position: absolute;
+    right: 10px;
+    bottom: 6px;
+  }
+}
+
+.select2-results {
+  font-size: 14px;
+}
 
 .select2-search-choice-close,
 .select2-container-multi .select2-search-choice-close {
   top: 14px;
   left: 5px;
+}
+
+.select2-search .select2-input:focus {
+  box-shadow: none;
+  font-size: 14px;
+  color: @kapa-black;
 }
 
 .select2-container-multi .select2-choices {

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/organization_select.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/organization_select.html
@@ -16,6 +16,7 @@
   classes=['form-group', 'control-medium'],
   ) %}
   <select name={{ name }} data-module="autocomplete"
+          style="width: 100%"
           {{ form.attributes(select_attrs) if select_attrs else '' }}>
     {% if not is_required %}
       <option value="">


### PR DESCRIPTION
# Description
Made basic select2 component suomi.fi-styled

## Jira ticket reference: [LIKA-515](https://jira.dvv.fi/browse/LIKA-515)

## What has changed:
- Added styling for basic select2 controls
- Made the organization select box explicitly full-width (required by select2 to inherit the width correctly)

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/200564742-07efc249-7b55-401a-9e95-59fde2c66fbf.png)
