### PR TITLE
LIKA-533: Reorganize front page hero links

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/layout1.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/layout1.html
@@ -6,20 +6,23 @@
       <div id="hero-stats" class="col-sm-8 col-sm-offset-2">
         {% set statistics = h.get_statistics() %}
         <div class="col-sm-4">
-          <div class="count">{{statistics.package_count}}</div>
-          <div class="stats-title">{{_('public datasets')}}</div>
-          <div><i class="fa fa-angle-right" aria-hidden="true"></i><a href="{{ h.url_for('dataset.search') }}" aria-label="{{ _('Show all datasets') }}">{{_('Show all')}}</a></div>
+          <a href="{{ h.url_for('dataset.search') }}" aria-label="{{ _('Show all datasets') }}">
+            <div class="count">{{statistics.package_count}}</div>
+            <div class="stats-title">{{_('public datasets')}}</div>
+          </a>
         </div>
 
         <div class="col-sm-4">
-          <div class="count">{{statistics.organization_count}}</div>
-          <div class="stats-title">{{_('total organizations')}}</div>
-          <div><i class="fa fa-angle-right" aria-hidden="true"></i><a href="{{ h.url_for(controller='organization', action='index') }}" aria-label="{{ _('Show all organizations') }}">{{_('Show all')}}</a></div>
+          <a href="{{ h.url_for(controller='organization', action='index') }}" aria-label="{{ _('Show all organizations') }}">
+            <div class="count">{{statistics.organization_count}}</div>
+            <div class="stats-title">{{_('total organizations')}}</div>
+          </a>
         </div>
         <div class="col-sm-4">
-          <div class="count">{{statistics.provider_organizations}}</div>
-          <div class="stats-title">{{_('service providers')}}</div>
-          <div><i class="fa fa-angle-right" aria-hidden="true"></i><a href="{{ h.url_for(controller='organization', action='index', provider_orgs=True) }}" aria-label="{{ _('Show all service provider organizations') }}">{{_('Show all')}}</a></div>
+          <a href="{{ h.url_for(controller='organization', action='index', provider_orgs=True) }}" aria-label="{{ _('Show all service provider organizations') }}">
+            <div class="count">{{statistics.provider_organizations}}</div>
+            <div class="stats-title">{{_('service providers')}}</div>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description
Remove "show all" links from hero, make the text itself a link

## Jira ticket reference: [LIKA-533](https://jira.dvv.fi/browse/LIKA-533)

## What has changed:
- Reorganize hero links

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/200570960-56d8066c-6f90-4181-bca6-3d59e1ce67c8.png)

