### PR TITLE
Lika 529 validate resource name

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -179,12 +179,10 @@
       "label": "Title",
       "additional_description": "Attachment name will be filled automatically and should not be edited",
       "input_title": ["Attachment name"],
-      "only_default_lang_required": true,
       "display_hr": true,
       "final": true,
+      "required": true,
       "form_placeholder": "AttachmentName",
-      "form_languages": ["en"],
-      "form_snippet": "fluent_title.html",
       "display_snippet": null
     },
     {

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 from ckan.tests.factories import User, Dataset, Organization, Resource
-from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized
+from ckan.plugins.toolkit import get_action, ObjectNotFound, NotAuthorized, ValidationError
 from ckan.tests.helpers import call_action
 
 import unittest.mock as mock
@@ -187,3 +187,11 @@ class TestApicatalogPlugin():
 
         with pytest.raises(NotAuthorized):
             helpers.call_action('user_invite', context, **params)
+
+    @pytest.mark.usefixtures('with_request_context')
+    def test_inserting_resource_with_no_name_should_fail(self):
+        subsystem = factories.Dataset()
+
+        with pytest.raises(ValidationError):
+            factories.Resource(package_id=subsystem['id'], name='')
+


### PR DESCRIPTION
# Description
Due to a bug in schema, it was possible to leave the name field of a resource empty, fix the bug.

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
- Made the name field into a required non-multilingual field

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

