### PR TITLE
LIKA-535: Fix service permission application link language

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
@@ -19,7 +19,7 @@
     {% endif %}
     {% if delivery_method == 'email' %}
         <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
-        <a class="btn btn-primary" href="{{  url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
+        <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
           <i class="fal fa-external-link-alt btn-icon--right"></i>
         </a>
     {% elif delivery_method == 'file' %}


### PR DESCRIPTION
# Description
Keep selected language when navigating to service permission application

## Jira ticket reference: [LIKA-535](https://jira.dvv.fi/browse/LIKA-535)

## What has changed:
- Use CKAN's `h.url_for` instead of the generic `url_for` to fix the link

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

