### PR TITLE
LIKA-544: Show first 2 cms pages on main nav

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/apicatalog_header.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/apicatalog_header.html
@@ -62,21 +62,23 @@
 
                   {% set lang = h.lang().split('_')[0] %}
                   {% set submenu_content = h.get_submenu_content() %}
-                  {% if submenu_content | length > 1 %}
+                  {% set page_name = request.path.split('/')[-1] %}
+                  {% for item in submenu_content[:2] %}
+                    {% set page = item %}
+                    {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
+                    {% set page_title = page.get('title_' + lang) or page.title %}
+                    <li {% if page_name == page.name %}class="active"{% endif %}>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
+                  {% endfor %}
+                  {% if submenu_content | length > 2 %}
                   <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">{{ _('More options') }}<span class="caret"></span></a>
                        <ul class="dropdown-menu">
-                           {% for page in submenu_content %}
+                           {% for page in submenu_content[2:] %}
                                {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
                                {% set page_title = page.get('title_' + lang) or page.title %}
-                               <li>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
+                               <li {% if page_name == page.name %}class="active"{% endif %}>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
                            {% endfor %}
                        </ul>
                   </li>
-                  {% elif submenu_content | length == 1 %}
-                      {% set page = submenu_content[0] %}
-                      {% set type_ = 'blog' if page['page_type'] == 'blog' else 'pages' %}
-                      {% set page_title = page.get('title_' + lang) or page.title %}
-                      <li>{{ h.literal('<a href="/%s/%s/%s">%s</a>' % (lang, type_, page.name, page_title)) }}</li>
                   {% endif %}
 
                 {% if c.userobj %}

--- a/ckanext/ckanext-apicatalog/less/dropdown.less
+++ b/ckanext/ckanext-apicatalog/less/dropdown.less
@@ -5,4 +5,16 @@
     border: 1px solid rgba(0, 0, 0, 0.15);
     background-color: #FFF;
     width: auto;
+
+    li a {
+        padding-left: 6px;
+        padding-right: 6px;
+        margin-right: 0;
+    }
+
+    li.active {
+        a:hover {
+            color: @kapa-black
+        }
+    }
 }

--- a/ckanext/ckanext-apicatalog/less/masthead.less
+++ b/ckanext/ckanext-apicatalog/less/masthead.less
@@ -208,9 +208,10 @@
       font-weight: normal;
       line-height: 27px;
       margin-right: 64px;
+      border-bottom: 4px solid transparent;
     }
     li.active a,
-    li:hover a {
+    li a:hover {
       border-bottom: 4px solid rgb(42, 110, 187);
       background-color: @mastheadBackgroundColor;;
     }


### PR DESCRIPTION
# Description
Previously if there was only one CMS page it was shown in the main nav otherwise they were all collapsed into a dropdown. But with the removal of (tietoa palveluväylästä hard coded nav item) there's enough space to show the 2 first CMS pages and collapse rest under the "more options" dropdown menu.

## Jira ticket reference: [LIKA-544](https://jira.dvv.fi/browse/LIKA-544)

## What has changed:
* Show first 2 CMS pages on main nav and collapse the rest into a dropdown menu

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/202664593-fcc84dbf-5af6-4693-aa6a-65bc9f20c434.png)

After:
![image](https://user-images.githubusercontent.com/3969176/202664304-63606165-72dd-44f7-a305-27697f8576f3.png)
