### PR TITLE
LIKA-545: Give access request settings page more width

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -14,7 +14,7 @@
     <p class="module__instructions">{{ _('You can allow permission requests for authenticated API-Catalog users. Permission requests are disabled by default in a new subsystem.') }}</p>
     {% block errors %}{{ form.errors(errors) }}{% endblock %}
     <div class="row">
-      <form class="col-sm-7" method="POST" enctype="multipart/form-data" data-module="form-change-listener" data-module-confirm-modal-selector>
+      <form class="col-sm-12" method="POST" enctype="multipart/form-data" data-module="form-change-listener" data-module-confirm-modal-selector>
         {{ form.hidden('subsystemId', value=subsystem_id) }}
         <div data-module="mutexfield">
           <div class="select-wrapper">


### PR DESCRIPTION
# Description
Changed access request settings form to use the whole page width

## Jira ticket reference: [LIKA-545](https://jira.dvv.fi/browse/LIKA-545)

## What has changed:
* Increased the width access request settings view uses

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/202716060-e28ded73-7c98-4c41-8120-e471b4342107.png)
After:
![image](https://user-images.githubusercontent.com/3969176/202716085-c52290a0-78f3-452b-98b9-0e8c8c59fbc2.png)

