### PR TITLE
LIKA-546: Fix harvested_from_xroad disappearing from resources

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/dataset.json
@@ -283,7 +283,7 @@
       "label": "Harvested from X-Road",
       "form_snippet": false,
       "display_snippet": null,
-      "validators": "keep_old_value_if_missing default_value(false) boolean_validator ignore_not_sysadmin"
+      "validators": "ignore_not_sysadmin keep_old_value_if_missing default_value(false) boolean_validator"
     },
     {
       "field_name": "xroad_servicecode",


### PR DESCRIPTION
# Description
Validator order with ignore_not_sysadmin being the last validator caused the harvested_from_xroad to be dropped from all resources of the dataset when dataset changes were saved by a non-sysadmin user

## Jira ticket reference: [LIKA-546](https://jira.dvv.fi/browse/LIKA-546)

## What has changed:
* Changed validator order with ignore_not_sysadmin being the first validator like in it already was for the other fields

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No


