### PR TITLE
LIKA-539: Separate sent and received access requests

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/user/dashboard.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/user/dashboard.html
@@ -1,12 +1,45 @@
 {% ckan_extends %}
 
-{% block content_primary_nav %}
-        <ul class="nav nav-tabs">
-          {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}
-          {{ h.build_nav_icon('dashboard.datasets', _('My Datasets'), icon='sitemap') }}
-          {{ h.build_nav_icon('dashboard.organizations', _('My Organizations'), icon='building-o') }}
-          {% if h.is_extension_loaded('apply_permissions_for_service') %}
-            {{ h.build_nav_icon('apply_permissions.dashboard', _('Service access applications'), icon='file-text-o') }}
-          {% endif %}
-        </ul>
+{% block primary %}
+  <article class="module">
+    {% block page_header %}
+      <header class="module-content page-header hug">
+        <div class="content_action">
+          {% link_for _('Profile settings'), named_route='user.edit', id=user.name, class_='btn btn-default', icon='cog' %}
+        </div>
+        {% block content_primary_nav %}
+          <ul class="nav nav-tabs">
+            {{ h.build_nav_icon('dashboard.index', _('News feed'), icon='list') }}
+            {{ h.build_nav_icon('dashboard.datasets', _('My Datasets'), icon='sitemap') }}
+            {{ h.build_nav_icon('dashboard.organizations', _('My Organizations'), icon='building-o') }}
+            {% if h.is_extension_loaded('apply_permissions_for_service') %}
+              {{ h.build_nav_icon('apply_permissions.dashboard', _('Service access applications'), icon='file-text-o', app_type='sent') }}
+            {% endif %}
+          </ul>
+        {% endblock %}
+      </header>
+    {% endblock %}
+    {% block container %}
+    <div class="module-content">
+      {% if self.page_primary_action() | trim %}
+        <div class="page_primary_action">
+          {% block page_primary_action %}{% endblock %}
+        </div>
+      {% endif %}
+      {% block primary_content_inner %}
+        <div data-module="dashboard">
+          {% snippet 'user/snippets/followee_dropdown.html', context=dashboard_activity_stream_context, followees=followee_list %}
+          <h2 class="page-heading">
+            {% block page_heading %}
+              {{ _('News feed') }}
+            {% endblock %}
+            <small>{{ _("Activity from items that I'm following") }}</small>
+          </h2>
+          {% snippet 'snippets/activity_stream.html', activity_stream=dashboard_activity_stream %}
+        </div>
+      {% endblock %}
+    </div>
+  </article>
+  {% endblock %}
 {% endblock %}
+

--- a/ckanext/ckanext-apicatalog/less/layout.less
+++ b/ckanext/ckanext-apicatalog/less/layout.less
@@ -395,3 +395,7 @@
     padding-top: 6.25px;
   }
 }
+
+.no-padding {
+  padding: 0;
+}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -165,7 +165,21 @@ def service_permission_application_list(context, data_dict):
 
     applications = applications.all()
 
-    return [application.as_dict() for application in applications]
+    if not subsystem_id:
+        membership_organizations = tk.get_action('organization_list_for_user')(context, {'permission': 'read'})
+        organization_id_list = [org['id'] for org in membership_organizations]
+        response = {'received': [], 'sent': []}
+        for application in applications:
+            application_dict = application.as_dict()
+            if len(application_dict.get('services')) > 0:
+                if application_dict.get('organization_id') in organization_id_list:
+                    response['sent'].append(application_dict)
+                if application_dict.get('target_organization_id') in organization_id_list:
+                    response['received'].append(application_dict)
+    else:
+        response = [application.as_dict() for application in applications]
+
+    return response
 
 
 @side_effect_free

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -3,7 +3,10 @@ from ckanext.apply_permissions_for_service import model
 
 
 def service_permission_application_list(context, data_dict):
-    return {'success': True}
+    if data_dict.get('subsystem_id'):
+        return {'success': toolkit.check_access('package_update', context, {'id': data_dict['subsystem_id']})}
+    else:
+        return {'success': True}
 
 
 def service_permission_application_show(context, data_dict):

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -77,8 +77,14 @@ class ApplyPermission(Base):
             {'ignore_auth': True}, {'id': application_dict['subsystem_code']})
         application_dict['member'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['subsystem']['owner_org']})
-        application_dict['services'] = [toolkit.get_action('resource_show')(
-            {'ignore_auth': True}, {'id': service}) for service in application_dict['service_code_list']]
+
+        application_dict['services'] = []
+        for service in application_dict['service_code_list']:
+            try:
+                resource = toolkit.get_action('resource_show')({'ignore_auth': True}, {'id': service})
+                application_dict['services'].append(resource)
+            except NotFound:
+                pass
 
         application_dict['organization'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['organization_id']})

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
@@ -5,12 +5,39 @@
 {% block page_primary_action %}
 {% endblock %}
 
+
+{% set page_name = request.path.split('/')[-1] %}
+{% block container %}
+  <section class="pull-left col-sm-3 no-padding">
+    <section class="module module-narrow">
+      <div class="module">
+        <div class="module-content dataset-sidebar">
+          <li {% if page_name=="sent" %}class="active"{% endif %}>
+            {% link_for _('Sent access requests'), named_route='apply_permissions.dashboard', app_type='sent'%}
+          </li>
+          <li {% if page_name=="received" %}class="active"{% endif %}>
+            {% link_for _('Received access requests'), named_route='apply_permissions.dashboard', app_type='received'%}
+          </li>
+        </div>
+      </div>
+    </section>
+  </section>
+  <section class="pull-right col-sm-9 no-padding">
+    {{ super() }}
+  </section>
+{% endblock %}
+
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('Service access applications') }}</h2>
   {% if applications %}
     {% snippet 'apply_permissions_for_service/snippets/application_table.html', applications=applications %}
   {% else %}
-  <p>{{ _('You have not sent any service access applications. You can apply for access to services by clicking the "Request access" button on the service page.') }}</p>
+    {% if page_name=="sent" %}
+      <p>{{ _('You have not sent any service access applications. You can apply for access to services by clicking the "Request access" button on the service page.') }}</p>
+    {% endif %}
+    {% if page_name=="received" %}
+      <p>{{ _('Your organizations have not received any service access applications.') }}</p>
+    {% endif %}
   {% endif %}
 {% endblock %}
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
@@ -10,7 +10,6 @@
   <tbody>
   {% for application in applications %}
       {% set subsystem_code = application.subsystem_code.split('.') %}
-      {% for service in application.services %}
       <tr>
           <td>
               {{ _('Organization') }} : <b>{% link_for application.organization["title"], named_route='organization.read', id=application.organization_id %}</b><br>
@@ -31,14 +30,18 @@
                                                        named_route='organization.read',
                                                        id=application.target_organization_id %}</b><br>
               {{ _('Subsystem') }} : <b>{% link_for subsystem_code[3], named_route='dataset.read', id=application.subsystem.id %}</b><br>
-              {{ _('Service code') }} : <b>{% link_for service.name,
-                                                       named_route='dataset_resource.read',
-                                                       id=application.requester_subsystem.id,
-                                                       resource_id=service.id %}</b><br>
+              {{ _('Service code') }} :
+              {% for service in application.services %}
+                <b>{% link_for service.name,
+                      named_route='dataset_resource.read',
+                      id=application.requester_subsystem.id,
+                      resource_id=service.id %}
+                </b>
+                <br>
+            {% endfor %}
           </td>
           <td>{% link_for _('Preview application'), named_route='apply_permissions.view_permission_application', application_id=application.id %}</td>
       </tr>
-      {% endfor %}
   {% endfor %}
   </tbody>
 </table>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -24,7 +24,7 @@ def index():
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
 
-def dashboard():
+def dashboard(app_type='sent'):
     context = {
         u'user': toolkit.g.user,
         u'auth_user_obj': toolkit.g.userobj,
@@ -33,7 +33,11 @@ def dashboard():
     data_dict = {u'user_obj': toolkit.g.userobj}
     extra_vars = ckan_user_extra_template_variables(context, data_dict)
     applications = toolkit.get_action('service_permission_application_list')(context, {})
-    extra_vars['applications'] = applications
+    if app_type == 'received':
+        extra_vars['applications'] = applications.get('received')
+    else:
+        extra_vars['applications'] = applications.get('sent')
+
     return toolkit.render('apply_permissions_for_service/dashboard.html', extra_vars=extra_vars)
 
 
@@ -161,7 +165,7 @@ def manage(subsystem_id):
     package = toolkit.get_action('package_show')(context, {'id': subsystem_id})
     toolkit.c.pkg_dict = package
 
-    data_dict = {'subsystem_id': subsystem_id}
+    data_dict = {'subsystem_id': package.get('id')}
     applications = toolkit.get_action('service_permission_application_list')(context, data_dict)
 
     extra_vars = {
@@ -269,6 +273,7 @@ def settings(subsystem_id):
 
 
 apply_permissions.add_url_rule('/', 'list_permission_applications', view_func=index)
+apply_permissions.add_url_rule('/dashboard/<app_type>', 'dashboard', view_func=dashboard)
 apply_permissions.add_url_rule('/dashboard', 'dashboard', view_func=dashboard)
 apply_permissions.add_url_rule('/new/<subsystem_id>', 'new_permission_application', view_func=new, methods=['GET', 'POST'])
 apply_permissions.add_url_rule('/view/<application_id>', 'view_permission_application', view_func=view)


### PR DESCRIPTION
# Description
In user's dashboard the view to access requests (apply_permissions_for_service) it used to list ALL access requests (and I mean ALL). Now it was split to show the access requests sent by the organizations the user has read permissions to and received by the organizations the user had read permissions to

## Jira ticket reference: [LIKA-539](https://jira.dvv.fi/browse/LIKA-539)

## What has changed:
* Changed auth function to take into account package_update permissions if fetching specific package's access requests
* Changed API to return dict with user's(/user's org's) sent and received access requests lists 
* Implemented sub navigation to the access requests page in dashboard
* Changed the page to list only one request per subsystem even if it includes requests for multiple services

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/205040167-65c00710-aff5-4ed9-8c74-65b4ed6a7f17.png)

After:
![image](https://user-images.githubusercontent.com/3969176/205040176-e074690e-ac05-4a87-a4c6-dafd3a6d2200.png)

