### PR TITLE
LIKA-428: Remove attachments from subsystem edit nav

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
@@ -4,7 +4,7 @@
     <div class="prelude-dataset prelude-dataset-edit">
         {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
         {% set group_type = pkg.organization.type %}
-        <h1>{% blockpage_title %}{{ _('Edit subsystem')  }}{% endblock %}</h1>
+        <h1>{% block page_title %}{{ _('Edit subsystem')  }}{% endblock %}</h1>
     </div>
 
 {% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
@@ -4,7 +4,7 @@
     <div class="prelude-dataset prelude-dataset-edit">
         {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
         {% set group_type = pkg.organization.type %}
-        <h1>{{ _('Edit subsystem')  }}</h1>
+        <h1>{% blockpage_title %}{{ _('Edit subsystem')  }}{% endblock %}</h1>
     </div>
 
 {% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/edit_base.html
@@ -23,7 +23,6 @@
         <div class="module-content dataset-sidebar">
             {% block side_navigation %}
                 {{ h.build_nav_icon(pkg.type + '.edit', _("Subsystem's information"), id=pkg.name) }}
-                {{ h.build_nav_icon(pkg.type ~ '.resources', _('Attachments'), id=pkg.name) }}
             {% endblock %}
         </div>
     </div>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resources.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resources.html
@@ -1,5 +1,9 @@
 {% ckan_extends %}
 
+{% block page_title %}
+    {{ _('Reorder resources')  }}
+{% endblock %}
+
 {#
     Moved cancel edit button from content_action to page_primary_action as simply emptying page_primary_action breaks javascript adding reorder resources button.
     it's appended to .page_primary_action https://github.com/ckan/ckan/blob/0d714b258668ee78a0b19182c53b34689629df37/ckan/public/base/javascript/modules/resource-reorder.js#L58
@@ -13,4 +17,7 @@
         <i class="far fa-long-arrow-left"></i>
         {{ _('Cancel editing') }}
     </a>
+{% endblock %}
+
+{% block secondary_content %}
 {% endblock %}


### PR DESCRIPTION
# Description
(Branched from blocking issue LIKA-427/PR https://github.com/vrk-kpa/api-catalog/pull/339)
Remove attachments link from subsystem edit side navigation (the add attachment button was added to subsystem read in LIKA-427). Since attachments link took to the same place as the newly added "reorder resources" button it's page title was also changed and the side nav removed.

## Jira ticket reference: [LIKA-428](https://jira.dvv.fi/browse/LIKA-428)

## What has changed:
* Removed link to 'attachments' from subsystem edit
* Changed the "reorder resources" view (/dataset/resources/) page title to reflect the "new usage" and removed the side nav

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/205047371-6bf3eed5-1d2e-43a2-aac0-c7d720511017.png)
![image](https://user-images.githubusercontent.com/3969176/205047388-1d648d4f-754c-4d29-a795-ccfa685c8627.png)

After:
![image](https://user-images.githubusercontent.com/3969176/205047406-d4257fb7-f0ab-4dbc-901c-daa3d85d982f.png)
![image](https://user-images.githubusercontent.com/3969176/205047413-3314f33c-fe53-4eb3-a207-5f75baa8e550.png)


