### PR TITLE
LIKA-538: Resource description always in finnish

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -59,7 +59,7 @@ def ensure_translated(s):
     elif ts == str:
         return six.text_type(s)
     elif ts == dict:
-        language = get_lang_prefix()
+        language = i18n.get_lang()
         return ensure_translated(s.get(language, u""))
 
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -59,7 +59,7 @@ def ensure_translated(s):
     elif ts == str:
         return six.text_type(s)
     elif ts == dict:
-        language = i18n.get_lang()
+        language = get_lang_prefix()
         return ensure_translated(s.get(language, u""))
 
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
@@ -18,11 +18,12 @@
               {% endif %}
             {% endblock %}
             {% block resource_item_description %}
+            {% set description = h.markdown_extract(h.get_translated(res, 'description'), extract_length=80) %}
+            {% if description %}
               <p class="description">
-                {% if res.description_translated %}
-                  {{ h.markdown_extract(h.ensure_translated(res.description_translated), extract_length=80) }}
-                {% endif %}
+                  {{ description }}
               </p>
+              {% endif %}
               {% if res.valid_content == 'no' %}<span class="label label-danger">{{ _("Invalid content") }}</span>{% endif %}
             {% endblock %}
           </div>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
@@ -19,7 +19,7 @@
             {% endblock %}
             {% block resource_item_description %}
               <p class="description">
-                {% if res.description %}
+                {% if res.description_translated %}
                   {{ h.markdown_extract(h.ensure_translated(res.description_translated), extract_length=80) }}
                 {% endif %}
               </p>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resource_item.html
@@ -20,7 +20,7 @@
             {% block resource_item_description %}
               <p class="description">
                 {% if res.description %}
-                  {{ h.markdown_extract(h.ensure_translated(res.description), extract_length=80) }}
+                  {{ h.markdown_extract(h.ensure_translated(res.description_translated), extract_length=80) }}
                 {% endif %}
               </p>
               {% if res.valid_content == 'no' %}<span class="label label-danger">{{ _("Invalid content") }}</span>{% endif %}


### PR DESCRIPTION
# Description
On subsystem page the resources lists (services and attachments) always showed finnish description regaradless of current_lang. Seems like description was used instead of description_translated so translations were never even used. When description_translated was used there was still issue with i18n.get_lang returning 'en_GB' and not matching that against 'en' translation

## Jira ticket reference: [LIKA-538](https://jira.dvv.fi/browse/LIKA-538)

## What has changed:
* Switched resource_item template to use description_translated instead of description
* Switched to use get_lang_prefix() instead of i18n.get_lang()

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No



