### PR TITLE
LIKA-551: Move link to source code next to some icons

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/footer.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/footer.html
@@ -10,28 +10,26 @@
 					<ul class="nav navbar footer-nav">
 						{{ h.build_nav_main() }}
 						{{ h.build_nav('contact.form', _('Give feedback')) }}
-						<li>
-							<a class="external-link" href="https://github.com/vrk-kpa/api-catalog">{{ _('API Catalog source code')}} <span class="sr-only">{{ _('(Skip twitter feed)') }}</span>
-								<svg viewbox="0 0 24 24" aria-hidden="true">
-									<use xlink:href="/base/images/external-link-icon.svg#path-1"></use>
-								</svg>
-							</a>
-						</li>
 					</ul>
 				</div>
 			</div>
 		</div>
 		<div class="footer-bottom">
 			<div class="container">
-				<div class="footer-bottom-links col-xs-12 col-sm-6 col-sm-offset-6 col-lg-5 col-lg-offset-7">
-					<div class="footer-bottom-link-container"><img src="/base/images/twitter-icon.svg" alt="{{ _('Twitter') }}"/>
+				<div class="footer-bottom-links col-xs-12">
+					<div class="footer-bottom-link-container">
 						<a href="https://twitter.com/suomifiyritys">
-							{{ _('@Suomifiyritys') }}
+							<span class="fab fa-twitter"></span>{{_('@Suomifiyritys')}}
 						</a>
 					</div>
-					<div class="footer-bottom-link-container"><img src="/base/images/facebook-icon.svg" alt="{{ _('Facebook') }}" />
+					<div class="footer-bottom-link-container">
 						<a href="https://www.facebook.com/Suomifiyritykselle">
-							{{ _('@Suomifiyritykselle') }}
+							<span class="fab fa-facebook-square"></span>{{_('@Suomifiyritykselle')}}
+						</a>
+					</div>
+					<div class="footer-bottom-link-container">
+						<a href="https://github.com/vrk-kpa/api-catalog">
+							<span class="fab fa-github"></span>@vrk-kpa/api-catalog
 						</a>
 					</div>
 				</div>

--- a/ckanext/ckanext-apicatalog/less/footer.less
+++ b/ckanext/ckanext-apicatalog/less/footer.less
@@ -121,7 +121,9 @@
   }
 
   a {
-    margin-left: 8px;
+    span {
+      margin-right: 5px;
+    }
     font-size: 16px;
     line-height: 20px;
     color: white;


### PR DESCRIPTION
# Description
Moved link to source code in the top part of the footer down to the bottom part next to social media icons

## Jira ticket reference: [LIKA-551](https://jira.dvv.fi/browse/LIKA-551)

## What has changed:
* Moved link to source code in the top part of the footer down to the bottom part next to social media icons

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/205301396-13f8ec28-b598-4d8c-a026-c78027e8e119.png)

After:
![image](https://user-images.githubusercontent.com/3969176/205301418-e1c78c63-ec62-4eca-b124-9012912f1396.png)

