### PR TITLE
LIKA-543: Modify organization user add API to allow adding existing users to organizations

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/cli.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/cli.py
@@ -145,10 +145,12 @@ def create_organization_users(ctx, retry):
                                                            {'retry': retry}).get('result', {})
 
     created = result.get('created', [])
+    added = result.get('added', [])
     invalid = result.get('invalid', [])
     ambiguous = result.get('ambiguous', [])
     duplicate = result.get('duplicate', [])
     click.echo('Created users: %s' % ', '.join(created))
+    click.echo('Existing users added to organizations: %s' % ', '.join(added))
     click.echo('Duplicate users: %s' % ', '.join(duplicate))
     click.echo('Unknown business ids: %s' % ', '.join(invalid))
     click.echo('Ambiguous business ids: %s' % ', '.join(ambiguous))

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/fixtures.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/fixtures.py
@@ -1,0 +1,9 @@
+import pytest
+
+import ckanext.apicatalog.db as apicatalog_model
+
+
+@pytest.fixture
+def apicatalog_setup():
+    import ckan.model as model
+    apicatalog_model.init_table(model.meta.engine)

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -9,7 +9,7 @@ from ckan import model
 from ckan.tests import factories
 import ckan.tests.helpers as helpers
 
-from .fixtures import apicatalog_setup
+from .fixtures import apicatalog_setup  # noqa
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'apicatalog_setup')

--- a/ckanext/ckanext-apicatalog/test.ini
+++ b/ckanext/ckanext-apicatalog/test.ini
@@ -21,6 +21,7 @@ scheming.presets = ckanext.scheming:presets.json
                    ckanext.markdown_editor:presets.json
 
 scheming.dataset_schemas = ckanext.apicatalog.schemas:dataset.json
+scheming.organization_schemas = ckanext.apicatalog.schemas:organization.json
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
# Description
Previously `create_organization_users` discarded applications that referred to email addresses of existing users. Modified the process to interpret such applications as requests to add existing users to organizations.

## Jira ticket reference: [LIKA-543](https://jira.dvv.fi/browse/LIKA-543)

## What has changed:
- Modified `create_organization_users`  to handle applications for existing users
- Modified apicatalog CLI to report the added users separately
- Added tests for both cases

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

