### PR TITLE
LIKA-550: Reduce content width on pages without side nav

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.6'
+          python-version: '3.8'
           cache: 'pip'
       - name: Install requirements
         run: pip install flake8 pycodestyle

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read_base.html
@@ -23,16 +23,16 @@
 {% block wrapper_class %}dataset-edit{% endblock %}
 
 {% block secondary_content %}
-    <section class="module module-narrow">
-        <div class="module context-info">
-            <div class="module-content dataset-sidebar">
-                {% block side_navigation %}
-                    {{ h.build_nav_icon(pkg.type ~ '.read', _("Subsystem's information"), id=pkg.name) }}
-                    {% if h.check_access('organization_update', {'id': pkg.owner_org}) %}
+    {% if h.check_access('organization_update', {'id': pkg.organization.id}) %}
+        <section class="module module-narrow">
+            <div class="module context-info">
+                <div class="module-content dataset-sidebar">
+                    {% block side_navigation %}
+                        {{ h.build_nav_icon(pkg.type ~ '.read', _("Subsystem's information"), id=pkg.name) }}
                         {{ h.build_nav_icon(pkg.type ~ '.activity', _('Activity Stream'), id=pkg.name, icon=None) }}
-                    {% endif %}
-                {% endblock %}
+                    {% endblock %}
+                </div>
             </div>
-        </div>
-    </section>
+        </section>
+    {% endif %}
 {% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resource_edit.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/resource_edit.html
@@ -26,7 +26,7 @@
 
 {% block primary_content %}
     <section id="main_content" class="module">
-        <div class="module-content" style="width: 60%">
+        <div class="module-content">
             {% block primary_content_inner %}
                 <p class="control-required-message"><span>*&nbsp;</span>{{ _('Required field') }}</p>
                 {{ super() }}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/page.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/page.html
@@ -76,7 +76,7 @@
             {% endblock %}
 
             {% block primary %}
-            <div class="primary border-left col-xs-12 {% if not no_nav %}{% block primary_col %}col-sm-8{% endblock %}{% endif %}">
+            <div class="primary border-left {% if no_nav %} col-xs-8 {% endif %} {% if not no_nav %}{% block primary_col %}col-sm-8{% endblock %}{% endif %}">
 
                 {#
                 The primary_content block can be used to add content to the page.

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/package/read_base.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/package/read_base.html
@@ -2,7 +2,5 @@
 
 {% block side_navigation %}
     {{ super() }}
-    {% if h.check_access('organization_update', {'id': pkg.organization.id}) %}
-        {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), subsystem_id=pkg.name) }}
-    {% endif %}
+    {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), subsystem_id=pkg.name) }}
 {% endblock %}


### PR DESCRIPTION
# Description
At some point some read pages with no side nav got too wide and it was starting to get difficult to read full page wide content. This changes pages without side nav to only use 8/12 cols instead of all 12. Also tweaks side navs to not appear with only one link as it was felt such navs are pointless.

I'm not particularly happy with simply moving the package_update check around the secondary content as it's not particularly intuitive but all the other links were already using that check so it sort of made sense to simply expand it.

## Jira ticket reference: [LIKA-550](https://jira.dvv.fi/browse/LIKA-550)

## What has changed:
* Only show side nav if there's more than one link
* If no nav reduce primary content width
* Updated python-version from 3.6 to 3.8 as 3.6 reached end of life 

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/206127119-6f18f60a-83e2-4691-bf4f-a79472edf33e.png)
![image](https://user-images.githubusercontent.com/3969176/206127141-e11abf8c-e665-4e40-a063-f782f0e8fc97.png)

After:
![image](https://user-images.githubusercontent.com/3969176/206127262-2b1cbaa6-b90a-40be-b783-082f42d9e45a.png)



