### PR TITLE
LIKA-552: Add data_processing_outside_eu boolean option to org schema

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -91,6 +91,17 @@
       "form_languages": ["fi", "sv", "en"]
     },
     {
+      "field_name": "data_processing_outside_eu",
+      "form_snippet": "multiple_checkbox.html",
+      "choices": [
+        {
+          "value": "true",
+          "label": "Organization processes data outside the EU/EAA countries."
+        }
+      ],
+      "label": "Data processing"
+    },
+    {
       "field_name": "webpage_address",
       "label": "Webpage address",
       "preset": "fluent_text",

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/about.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/about.html
@@ -80,7 +80,7 @@
                     </dl>
                 {% endif %}
                 {% if c.group_dict['company_type'] or c.group_dict['company_language']
-                        or c.group_dict['company_registeration_date'] %}
+                        or c.group_dict['company_registeration_date'] or c.group_dict['data_processing_outside_eu'] %}
                 <h2>{{ _('Additional information') }}</h2>
                 <dl>
 
@@ -103,6 +103,13 @@
                         {% set field = h.scheming_field_by_name(c.scheming_fields, 'company_registeration_date') %}
                         <dt>{{ h.scheming_language_text(field.label) }}:</dt>
                         <dd>{%- snippet 'scheming/snippets/display_field.html',
+          field=field, data=c.group_dict, schema=schema -%}</dd>
+                    {% endif %}
+
+                    {% if c.group_dict['data_processing_outside_eu'] %}
+                        {% set field = h.scheming_field_by_name(c.scheming_fields, 'data_processing_outside_eu') %}
+                        <dt>{{ h.scheming_language_text(field.label) }}:</dt>
+                        <dd>{%- snippet 'scheming/display_snippets/multiple_choice.html',
           field=field, data=c.group_dict, schema=schema -%}</dd>
                     {% endif %}
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/form_snippets/multiple_checkbox.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/form_snippets/multiple_checkbox.html
@@ -1,0 +1,27 @@
+{% import 'macros/form.html' as form %}
+
+{%- call form.input_block(
+    label=h.scheming_language_text(field.label),
+    classes=field.classes if 'classes' in field else ['control-medium'],
+    error=errors[field.field_name],
+    is_required=h.scheming_field_required(field)) -%}
+  {%- set choices = [] -%}
+  {%- for c in h.scheming_field_choices(field) -%}
+    {%- do choices.append(
+      (c.value, h.scheming_language_text(c.label))) -%}
+  {%- endfor -%}
+  {%- if field.get('sorted_choices') -%}
+    {%- set choices = choices|sort(case_sensitive=false, attribute=1) -%}
+  {%- endif -%}
+    <fieldset class="checkboxes">
+        {%- for val, label in choices -%}
+        <input id="field-{{ field.field_name }}-{{ val }}"
+                type="checkbox"
+                name="{{ field.field_name }}"
+                value="{{ val }}"
+                {{"checked " if val in data[field.field_name] }} />
+            <label for="field-{{ field.field_name }}-{{ val }}">{{ label }}</label>
+        {%- endfor -%}
+    </fieldset>
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{%- endcall -%}

--- a/ckanext/ckanext-apicatalog/less/forms.less
+++ b/ckanext/ckanext-apicatalog/less/forms.less
@@ -335,7 +335,7 @@ textarea {
   -moz-appearance: none;
   -webkit-appearance: none;
   background-image: none;
-  
+
   .select2-arrow {
     display: none;
     pointer-events: none;
@@ -516,4 +516,18 @@ textarea {
 // Danger and error appear as red
 .btn-danger {
   .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
+}
+
+fieldset.checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+
+  input {
+    min-height: 20px;
+    width: 20px;
+    margin: -2px 5px 0 0;
+  }
+  label::after {
+    content: ""
+  }
 }


### PR DESCRIPTION
# Description
Add option to save information regarding organization's data processing outside EU. Simple checkbox on org level.

## Jira ticket reference: [LIKA-552](https://jira.dvv.fi/browse/LIKA-552)

## What has changed:
* Add a single checkbox to org form / boolean to org schema and simple text on org about page if it's set.

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

New checkbox to edit form and simple text on org about page if it's set.
![image](https://user-images.githubusercontent.com/3969176/206189198-88169332-d9f9-472a-91e5-3437ef2f7cb1.png)
![image](https://user-images.githubusercontent.com/3969176/206189212-631adc6b-de71-49be-9b60-acdccc62634f.png)


