### PR TITLE
LIKA-554: List only provider orgs by default

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -317,8 +317,8 @@ def custom_organization_list(params):
 
     results = list(organization_generator(context, organization_list_options))
 
-    provider_orgs = params.get('provider_orgs', '').lower() in ('true', '1', 'yes')
-    if provider_orgs:
+    all_orgs = params.get('all_orgs', '').lower() in ('true', '1', 'yes')
+    if not all_orgs:
         results = [group for group in results if group.get('xroad_member_type') == "provider"]
 
     def sort_by_providers_first(g):
@@ -341,7 +341,7 @@ def custom_organization_list(params):
         'organizations': results[page_start:page_end],
         'count': len(results),
         'page': custom_page,
-        "provider_orgs": provider_orgs
+        "all_orgs": all_orgs
     }
 
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/layout1.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/home/layout1.html
@@ -19,7 +19,7 @@
           </a>
         </div>
         <div class="col-sm-4">
-          <a href="{{ h.url_for(controller='organization', action='index', provider_orgs=True) }}" aria-label="{{ _('Show all service provider organizations') }}">
+          <a href="{{ h.url_for(controller='organization', action='index') }}" aria-label="{{ _('Show all service provider organizations') }}">
             <div class="count">{{statistics.provider_organizations}}</div>
             <div class="stats-title">{{_('service providers')}}</div>
           </a>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/index.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/index.html
@@ -49,5 +49,5 @@
   {% set symbol_previous %}
     <span aria-hidden='true'>«</span><span class='sr-only'>{{ _('Previous') }}</span>
   {% endset %}
-  {{ org_list.page.pager(q=q or '', sort=c.sort_by_selected or '', provider_orgs=org_list.provider_orgs or '', link_attr={'aria-label': _('Go to page')}, symbol_next=symbol_next, symbol_previous=symbol_previous) }}
+  {{ org_list.page.pager(q=q or '', sort=c.sort_by_selected or '', all_orgs=org_list.all_orgs or '', link_attr={'aria-label': _('Go to page')}, symbol_next=symbol_next, symbol_previous=symbol_previous) }}
 {% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/snippets/search_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/snippets/search_form.html
@@ -4,14 +4,14 @@
   {{ super() }}
   <label for="apis-selection">{{ _('Filter by role') }}</label>
   <div>
-  {% if request.args.provider_orgs %}
+  {% if request.args.all_orgs %}
       <a name="apis-selection" href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected) }}">
-          {{ _('Show organizations without APIs') }}
-      </a>
-      <input type="hidden" name="provider_orgs" value="True"></input>
-  {% else %}
-      <a name="apis-selection" href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected, provider_orgs=True) }}">
           {{ _('Show only service providers') }}
+      </a>
+      <input type="hidden" name="all_orgs" value="True"></input>
+  {% else %}
+      <a name="apis-selection" href="{{ h.url_for(controller='organization', action='index', q=c.q, sort=sorting_selected, all_orgs=True) }}">
+          {{ _('Show organizations without APIs') }}
       </a>
   {% endif %}
   </div>


### PR DESCRIPTION
# Description
Switch organizations page to list only provider orgs by default (old provider_orgs filter) and move all orgs behind request param.

## Jira ticket reference: [LIKA-554](https://jira.dvv.fi/browse/LIKA-554)

## What has changed:
* Change default organizations list to be filtered to only provider orgs

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


