### PR TITLE
LIKA-553: Add optional guide text to apply permission settings

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
@@ -13,22 +13,28 @@
   {% endblock %}
 
   {% block page_heading %}
-    {%- set delivery_method = pkg.get('service_permission_settings', {}).get('delivery_method') -%}
+    {%- set settings = pkg.get('service_permission_settings', {}) -%}
+    {%- set delivery_method = settings.get('delivery_method') -%}
     {% if delivery_method not in (None, 'none') %}
       <h2>{{ _('Request permission to use this subsystem') }}</h2>
     {% endif %}
+    {% set guide_text = h.get_translated(settings, 'guide_text_translated') %}
+    {% set guide_text_markdown = h.render_markdown(guide_text) if guide_text else '' %}
     {% if delivery_method == 'email' %}
         <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
+        {{guide_text_markdown}}
         <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
           <i class="fal fa-external-link-alt btn-icon--right"></i>
         </a>
     {% elif delivery_method == 'file' %}
         <p>{{ _('Request permission to use this subsystem in the Suomi.fi Data Exchange Layer if you want to have access to one or several of its services. Download and complete the form below and submit it to the email address provided by the owner of the subsystem. See the form and the subsystem description for more detailed instructions. Note that some subsystems may require that you apply for data access authorisation before you can request permission in the API Catalogue.') }}</p>
+        {{guide_text_markdown}}
         <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('file_url')}}" target="_blank">{{ _('Download file') }}
           <i class="fal fa-arrow-down btn-icon--right"></i>
         </a>
     {% elif delivery_method == 'web' %}
         <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
+        {{guide_text_markdown}}
         <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('web')}}" target="_blank">{{ _('Request permission in organizations website') }}
             <i class="fal fa-external-link-alt btn-icon--right"></i>
         </a>

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
@@ -18,7 +18,7 @@
     {% if delivery_method not in (None, 'none') %}
       <h2>{{ _('Request permission to use this subsystem') }}</h2>
     {% endif %}
-    {% set guide_text = h.get_translated(settings, 'guide_text_translated') %}
+    {% set guide_text = h.get_translated(settings, 'guide_text') %}
     {% set guide_text_markdown = h.render_markdown(guide_text) if guide_text else '' %}
     {% if delivery_method == 'email' %}
         <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -221,7 +221,8 @@ def service_permission_settings_update(context, data_dict):
 
     settings = {field: data_dict[field]
                 for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename',
-                              'require_additional_application_file', 'additional_file_url', 'original_additional_filename')
+                              'require_additional_application_file', 'additional_file_url', 'original_additional_filename',
+                              'guide_text_translated')
                 if field in data_dict}
 
     tk.get_action('package_patch')(context, {

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -117,9 +117,11 @@
               {{ form.input('web', label=_('Webpage URL'), value=settings.web) }}
             </div>
             <div>
+              <h3 class="api-catalog-group-title">{{ _('Description of the user permit application process') }}</h3>
+              <h5 class="api-catalog-group-description">{{ _('Describe the user permit application process of your subsystem here. Describe also other possible permits required for the implementation of your services.') }}</h5>
               {% set field_name = 'guide_text_translated' %}
-              {% set field_placeholder = _('Write a helpful guide text describing the request process') %}
-              {% set field_label = _('Guide text') %}
+              {% set field_placeholder = _('Describe the user permit application process') %}
+              {% set field_label = _('Description') %}
               {%- for lang in h.fluent_form_languages() -%}
                 {% set form_attrs = {'data-module': 'ckeditor5-markdown', 'data-module-language': h.get_lang_prefix()} %}
                 {% call form.textarea(

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -1,12 +1,14 @@
 {% extends 'package/edit_base.html' %}
 {% import 'macros/form.html' as form %}
-{% resource 'apicatalog_ui/javascript/mutexfield.js' %}
+
 
 {% block content_action %}
 {% link_for _('Exit the settings'), named_route=pkg.type ~ '.read', id=pkg.name, class_='btn btn-default' %}
 {% endblock %}
 
 {% block primary_content %}
+{% asset 'markdown_editor/markdown_editor-js' %}
+
 <section id="main_content" class="module">
   <div class="module-content">
     {% block primary_content_inner %}
@@ -113,6 +115,24 @@
             </div>
             <div data-mutex-value="web">
               {{ form.input('web', label=_('Webpage URL'), value=settings.web) }}
+            </div>
+            <div>
+              {% set field_name = 'guide_text_translated' %}
+              {% set field_placeholder = _('Write a helpful guide text describing the request process') %}
+              {% set field_label = _('Guide text') %}
+              {%- for lang in h.fluent_form_languages() -%}
+                {% set form_attrs = {'data-module': 'ckeditor5-markdown', 'data-module-language': h.get_lang_prefix()} %}
+                {% call form.textarea(
+                  field_name + '-' + lang,
+                  id='field-' + field_name + '-' + lang,
+                  label=_(field_label) + ' ' + _(lang),
+                  placeholder=h.scheming_language_text(field_placeholder, lang),
+                  value=settings.get(field_name, {})[lang],
+                  error=errors[field_name + '-' + lang],
+                  attrs=form_attrs
+                  ) %}
+                {% endcall %}
+              {%- endfor -%}
             </div>
             <div class="module__actions">
               <button class="btn btn-primary" type="submit">{{ _('Save') }}</button>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -213,6 +213,11 @@ def settings_post(context, subsystem_id):
         'additional_file_url': form.get('additional_file_url'),
         'original_additional_filename': form.get('original_additional_filename'),
         'additional_file_clear_upload': form.get('additional_file_clear_upload'),
+        'guide_text_translated': {
+            'fi': form.get('guide_text_translated-fi', ''),
+            'en': form.get('guide_text_translated-en', ''),
+            'sv': form.get('guide_text_translated-sv', '')
+        }
     }
 
     if toolkit.check_ckan_version(min_version='2.5'):


### PR DESCRIPTION
# Description
You can now add optional guide text (in all 3 languages) at subsystem level in the access request / apply_permission settings. 
This will be show between the access request button and the original info text.

## Jira ticket reference: [LIKA-553](https://jira.dvv.fi/browse/LIKA-553)

## What has changed:
* Add guide_text_translated markdown field to apply_permission settings
* Add it to subsystem read between the delivery methods' original info text and the button

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/3969176/206453543-6738a3e4-f8a7-4bad-86f7-51de66aa4e35.png)
![image](https://user-images.githubusercontent.com/3969176/206453593-4b08f816-18e1-4a90-a043-921933a182a6.png)



