### PR TITLE
LIKA-547: Added intermediary status to organization schema

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-16 11:16+0000\n"
+"POT-Creation-Date: 2022-12-12 08:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,23 +26,23 @@ msgstr ""
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:830
-#: ckanext/apicatalog/templates/package/read.html:61
+#: ckanext/apicatalog/plugin.py:848
+#: ckanext/apicatalog/templates/package/read.html:58
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:831
+#: ckanext/apicatalog/plugin.py:849
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:832
+#: ckanext/apicatalog/plugin.py:850
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:833
+#: ckanext/apicatalog/plugin.py:851
 msgid "Formats"
 msgstr ""
 
@@ -351,6 +351,22 @@ msgstr ""
 msgid "sv"
 msgstr ""
 
+#: ckanext/apicatalog/translations.py:98
+msgid "Organization acts as an intermediary for other organizations."
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:99
+msgid "Organization processes data outside the EU/EAA countries."
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:100
+msgid "Intermediary organization"
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:101
+msgid "Data processing"
+msgstr ""
+
 #: ckanext/apicatalog/validators.py:54
 msgid "Package contains invalid resources"
 msgstr ""
@@ -431,7 +447,7 @@ msgstr ""
 #: ckanext/apicatalog/templates/apicatalog_header.html:60
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_navmenu.html:5
 #: ckanext/apicatalog/templates/organization/edit_base.html:11
-#: ckanext/apicatalog/templates/organization/read_base.html:8
+#: ckanext/apicatalog/templates/organization/read_base.html:14
 #: ckanext/apicatalog/templates/package/search.html:4
 msgid "Datasets"
 msgstr ""
@@ -442,16 +458,16 @@ msgstr ""
 msgid "Organizations"
 msgstr ""
 
-#: ckanext/apicatalog/templates/apicatalog_header.html:66
+#: ckanext/apicatalog/templates/apicatalog_header.html:73
 msgid "More options"
 msgstr ""
 
-#: ckanext/apicatalog/templates/apicatalog_header.html:85
+#: ckanext/apicatalog/templates/apicatalog_header.html:87
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:20
 msgid "Log in"
 msgstr ""
 
-#: ckanext/apicatalog/templates/apicatalog_header.html:87
+#: ckanext/apicatalog/templates/apicatalog_header.html:89
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:22
 msgid "Register"
 msgstr ""
@@ -466,27 +482,11 @@ msgstr ""
 msgid "Give feedback"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:14
-msgid "API Catalog source code"
-msgstr ""
-
-#: ckanext/apicatalog/templates/footer.html:14
-msgid "(Skip twitter feed)"
-msgstr ""
-
-#: ckanext/apicatalog/templates/footer.html:27
-msgid "Twitter"
-msgstr ""
-
-#: ckanext/apicatalog/templates/footer.html:29
+#: ckanext/apicatalog/templates/footer.html:22
 msgid "@Suomifiyritys"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:32
-msgid "Facebook"
-msgstr ""
-
-#: ckanext/apicatalog/templates/footer.html:34
+#: ckanext/apicatalog/templates/footer.html:27
 msgid "@Suomifiyritykselle"
 msgstr ""
 
@@ -658,7 +658,6 @@ msgid "Resource"
 msgstr ""
 
 #: ckanext/apicatalog/templates/admin/dashboard.html:171
-#: ckanext/apicatalog/templates/package/read_base.html:15
 msgid "Dataset"
 msgstr ""
 
@@ -829,6 +828,10 @@ msgstr ""
 #: ckanext/apicatalog/templates/ckanext_pages/page.html:15
 #: ckanext/apicatalog/templates/organization/edit_base.html:10
 #: ckanext/apicatalog/templates/organization/members.html:35
+#: ckanext/apicatalog/templates/organization/read_base.html:5
+#: ckanext/apicatalog/templates/package/read_base.html:10
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:28
+#: ckanext/apicatalog/templates/user/read_base.html:5
 msgid "Edit"
 msgstr ""
 
@@ -1187,7 +1190,7 @@ msgstr ""
 msgid "Additional information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/about.html:115
+#: ckanext/apicatalog/templates/organization/about.html:122
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -1196,7 +1199,7 @@ msgid "X-Road Errors"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:15
-#: ckanext/apicatalog/templates/organization/read_base.html:12
+#: ckanext/apicatalog/templates/organization/read_base.html:18
 msgid "Members"
 msgstr ""
 
@@ -1311,13 +1314,13 @@ msgstr ""
 msgid "Active APIs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/read_base.html:9
+#: ckanext/apicatalog/templates/organization/read_base.html:15
 #: ckanext/apicatalog/templates/snippets/apicatalog_offcanvas-info-button.html:2
 msgid "About"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/read_base.html:10
-#: ckanext/apicatalog/templates/package/read_base.html:18
+#: ckanext/apicatalog/templates/organization/read_base.html:16
+#: ckanext/apicatalog/templates/package/read_base.html:32
 msgid "Activity Stream"
 msgstr ""
 
@@ -1334,11 +1337,11 @@ msgid "Filter by role"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/snippets/search_form.html:9
-msgid "Show organizations without APIs"
+msgid "Show only service providers"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/snippets/search_form.html:14
-msgid "Show only service providers"
+msgid "Show organizations without APIs"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/edit_base.html:7
@@ -1346,24 +1349,14 @@ msgid "Edit subsystem"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/edit_base.html:14
+#: ckanext/apicatalog/templates/package/resource_edit_base.html:4
+#: ckanext/apicatalog/templates/package/resources.html:18
 msgid "Cancel editing"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/edit_base.html:24
-msgid "Subsystem's information"
-msgstr ""
-
 #: ckanext/apicatalog/templates/package/edit_base.html:25
-#: ckanext/apicatalog/templates/package/read.html:64
-msgid "Attachments"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit_base.html:27
-msgid "Access request settings"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/edit_base.html:28
-msgid "Received access requests"
+#: ckanext/apicatalog/templates/package/read_base.html:31
+msgid "Subsystem's information"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:18
@@ -1402,21 +1395,16 @@ msgid "Request permission in organizations website"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:38
-#: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:20
-msgid "Subsystem information"
+msgid "Description"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:39
+#: ckanext/apicatalog/templates/package/read.html:43
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:49
-msgid "Description"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/read_base.html:16
-msgid "Groups"
+#: ckanext/apicatalog/templates/package/read.html:59
+msgid "Attachments"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/resource_edit.html:13
@@ -1427,6 +1415,15 @@ msgstr ""
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/resource_edit_base.html:6
+msgid "View resource"
+msgstr ""
+
+#: ckanext/apicatalog/templates/package/resources.html:4
+#: ckanext/apicatalog/templates/package/snippets/resources_list.html:22
+msgid "Reorder resources"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/search.html:5
@@ -1503,18 +1500,18 @@ msgstr ""
 msgid "Update Resource"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/snippets/resource_item.html:26
+#: ckanext/apicatalog/templates/package/snippets/resource_item.html:27
 msgid "Invalid content"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/snippets/resource_item.html:37
-#: ckanext/apicatalog/templates/package/snippets/resource_item.html:39
+#: ckanext/apicatalog/templates/package/snippets/resource_item.html:38
+#: ckanext/apicatalog/templates/package/snippets/resource_item.html:40
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:43
 msgid "Download"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/snippets/resource_item.html:42
-#: ckanext/apicatalog/templates/package/snippets/resource_item.html:44
+#: ckanext/apicatalog/templates/package/snippets/resource_item.html:43
+#: ckanext/apicatalog/templates/package/snippets/resource_item.html:45
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:40
 msgid "Go to resource"
 msgstr ""
@@ -1540,15 +1537,8 @@ msgstr ""
 msgid "Your browser does not support iframes."
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/snippets/resources_list.html:26
-#, python-format
-msgid ""
-"<p class=\"empty\">This dataset has no data, <a href=\"%(url)s\">why not add "
-"some?</a></p>"
-msgstr ""
-
-#: ckanext/apicatalog/templates/package/snippets/resources_list.html:30
-msgid "This dataset has no data"
+#: ckanext/apicatalog/templates/package/snippets/resources_list.html:17
+msgid "Add new resource"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/tags.html:4
@@ -1575,8 +1565,8 @@ msgstr ""
 msgid "Are you sure you want to delete this Organization?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:28
-msgid "Manage"
+#: ckanext/apicatalog/templates/scheming/package/read.html:16
+msgid "No description"
 msgstr ""
 
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:37
@@ -1647,6 +1637,10 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
 msgid "Format"
+msgstr ""
+
+#: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:20
+msgid "Subsystem information"
 msgstr ""
 
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:70
@@ -1730,20 +1724,29 @@ msgstr ""
 msgid "Go"
 msgstr ""
 
-#: ckanext/apicatalog/templates/user/dashboard.html:5
+#: ckanext/apicatalog/templates/user/dashboard.html:8
+msgid "Profile settings"
+msgstr ""
+
+#: ckanext/apicatalog/templates/user/dashboard.html:12
+#: ckanext/apicatalog/templates/user/dashboard.html:34
 msgid "News feed"
 msgstr ""
 
-#: ckanext/apicatalog/templates/user/dashboard.html:6
+#: ckanext/apicatalog/templates/user/dashboard.html:13
 msgid "My Datasets"
 msgstr ""
 
-#: ckanext/apicatalog/templates/user/dashboard.html:7
+#: ckanext/apicatalog/templates/user/dashboard.html:14
 msgid "My Organizations"
 msgstr ""
 
-#: ckanext/apicatalog/templates/user/dashboard.html:9
+#: ckanext/apicatalog/templates/user/dashboard.html:16
 msgid "Service access applications"
+msgstr ""
+
+#: ckanext/apicatalog/templates/user/dashboard.html:36
+msgid "Activity from items that I'm following"
 msgstr ""
 
 #: ckanext/apicatalog/templates/user/edit_user_form.html:9

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
@@ -7,9 +7,10 @@
 # Translators:
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
-# Suvi Nuttunen, 2022
 # Roosa Lampinen, 2022
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
+# Suvi Nuttunen, 2022
+# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # 
 #, fuzzy
 msgid ""
@@ -18,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2022-11-16 11:16+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2022\n"
+"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1462,7 +1463,7 @@ msgstr "Liitteet"
 
 #: ckanext/apicatalog/templates/package/edit_base.html:27
 msgid "Access request settings"
-msgstr "Käyttöluvan hallinnointi"
+msgstr "Lupapyyntöjen asetukset"
 
 #: ckanext/apicatalog/templates/package/edit_base.html:28
 msgid "Received access requests"
@@ -1876,7 +1877,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/user/dashboard.html:7
 msgid "My Organizations"
-msgstr ""
+msgstr "Minun organisaationi"
 
 #: ckanext/apicatalog/templates/user/dashboard.html:9
 msgid "Service access applications"

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -91,6 +91,17 @@
       "form_languages": ["fi", "sv", "en"]
     },
     {
+      "field_name": "is_intermediary",
+      "form_snippet": "multiple_checkbox.html",
+      "choices": [
+        {
+          "value": "false",
+          "label": "Organization acts as an intermediary for other organizations."
+        }
+      ],
+      "label": "Intermediary organization"
+    },
+    {
       "field_name": "data_processing_outside_eu",
       "form_snippet": "multiple_checkbox.html",
       "choices": [

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
@@ -95,4 +95,8 @@ def schema_translatable_strings():
             _('fi'),
             _('en'),
             _('sv'),
+            _('Organization acts as an intermediary for other organizations.'),
+            _('Organization processes data outside the EU/EAA countries.'),
+            _('Intermediary organization'),
+            _('Data processing'),
             ]


### PR DESCRIPTION
# Description
Added intermediary status to organization schema, controlled with a checkbox

## Jira ticket reference: [LIKA-547](https://jira.dvv.fi/browse/LIKA-547)

## What has changed:
- Added `is_intermediary` schema field
- Updated translations and added missing ones from the organization form

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/207003317-e06f79f3-552c-4424-9c55-b6dcd7864d88.png)


