### PR TITLE
LIKA-483: Add missing validation for additional file and permission application pdf

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/macros/form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/macros/form.html
@@ -85,7 +85,7 @@
   {% endif %}
 
 
-   {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full']) }}
+   {{ input(field_url, label=url_label, id='field-image-url', type='url', placeholder=placeholder, value=data.get(field_url), error='', classes=['control-full']) }}
 
 
   {% if is_upload_enabled %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -225,6 +225,15 @@ def service_permission_settings_update(context, data_dict):
                               'guide_text_translated')
                 if field in data_dict}
 
+    if settings.get('delivery_method') == 'file' and not settings.get('file_url', None):
+        raise tk.ValidationError({'file_url': _("You must provide application file when \
+                                                 'Organisation’s downloadable application (PDF)' is selected")})
+
+    if (settings.get('delivery_method') == 'email' and settings.get('require_additional_application_file') and
+            not settings.get('additional_file_url', None)):
+        raise tk.ValidationError({'additional_file_url': _("You must provide additional file when \
+                                                            'Request additional info with an attachment' is selected")})
+
     tk.get_action('package_patch')(context, {
         'id': data_dict['subsystem_id'],
         'service_permission_settings': json.dumps(settings)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -225,7 +225,7 @@ def settings_post(context, subsystem_id):
     else:
         upload = uploader.Upload('apply_permission')
 
-    if (data_dict.get('delivery_method') == 'file'):
+    if (data_dict.get('delivery_method') == 'file' and data_dict.get('file_url', None)):
         upload.update_data_dict(data_dict, 'file_url',
                                 'file', 'clear_upload')
         upload.upload(max_size=uploader.get_max_resource_size())
@@ -240,7 +240,8 @@ def settings_post(context, subsystem_id):
             )
             data_dict['file_url'] = file_url
 
-    if (data_dict.get('delivery_method') == 'email' and data_dict.get('require_additional_application_file')):
+    if (data_dict.get('delivery_method') == 'email' and data_dict.get('require_additional_application_file') and
+            data_dict.get('additional_file_url', None)):
         upload.update_data_dict(data_dict, 'additional_file_url',
                                 'additional_file', 'additional_file_clear_upload')
         upload.upload(max_size=uploader.get_max_resource_size())


### PR DESCRIPTION
# Description
On apply permission settings add validators to raise an error when additional file or permission application file is missing

## Jira ticket reference: [LIKA-483](https://jira.dvv.fi/browse/LIKA-483)

## What has changed:
- Additional file required -validation
- Permission application file missing -validation
- Disabled wrongly shown errors from drag-n-drop uploader

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

