### PR TITLE
LIKA-560: Fix too narrow pages

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/group_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/group_form.html
@@ -6,7 +6,7 @@
         might not be compatible with ckanext-scheming
     </p>
 {%- endif -%}
-<div class="module-content-medium">
+<div class="module-content">
 <form class="dataset-form form-horizontal" method="post" data-module="basic-form" enctype="multipart/form-data">
     <p class="control-required-message"><span>*&nbsp;</span>{{ _('Required field') }}</p>
   {% block error_summary %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -77,7 +77,7 @@
     }
     </script>
 {% block errors %}{{ form.errors(errors) }}{% endblock %}
-<form class="col-sm-8" method="POST" enctype="multipart/form-data" data-module="form-change-listener" data-module-confirm-modal-selector>
+<form method="POST" enctype="multipart/form-data" data-module="form-change-listener" data-module-confirm-modal-selector>
   {{ form.hidden('subsystemId', value=subsystem_id) }}
   <h3>{{ _('API access application') }}</h3>
   <p class="input-group-description">{{ _('Use this form to apply for a permission to use a service that is available in the National Data Exchange Layer. Your application will be submitted to the organization providing the service. When your application has been approved, Valtori is automatically notified of the needed firewall configurations.') }}</p>
@@ -109,7 +109,7 @@
                   <input type="checkbox"
                          id="enableIntermediateOrganization"
                          name="enableIntermediateOrganization"
-                         {% if values.intermediate_organization %}checked{% endif %} 
+                         {% if values.intermediate_organization %}checked{% endif %}
                          onchange="showIntermediateOrganization()">
               </td>
               <td style="padding-left: 5px; padding-right: 5px;">


### PR DESCRIPTION
# Description
Some pages / forms were accidentally made too narrow when narrowing content on some other pages in LIKA-550 by narrowing the container around them. This fixes all found views with too narrow content (that was previously narrowed in those views specifically and thus ended up being double narrowed) which incidentally were the ones specified in the issue. 

## Jira ticket reference: [LIKA-560](https://jira.dvv.fi/browse/LIKA-560)

## What has changed:
* Removed content narrowing scheming/organization/group_form (outer container is already narrowed)
* Removed content narrowing apply_permissions_for_service/new (outer container is already narrowed)

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/207855746-0b4474c5-856d-4e40-95fe-78ebd2e032a6.png)
![image](https://user-images.githubusercontent.com/3969176/207855761-1b6d6c87-85e9-4c96-95f4-79f674eebf72.png)

After:
![image](https://user-images.githubusercontent.com/3969176/207855856-a0f31c71-74e6-4fba-8d2d-ac6b0d34556d.png)
![image](https://user-images.githubusercontent.com/3969176/207855878-7980c90a-3f68-4ad3-8f7d-08c469110cc7.png)


