### PR TITLE
LIKA-438: Include sitesearch extension.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "ckanext/ckanext-markdown_editor"]
 	path = ckanext/ckanext-markdown_editor
 	url = https://github.com/vrk-kpa/ckanext-markdown_editor
+[submodule "ckanext/ckanext-sitesearch"]
+	path = ckanext/ckanext-sitesearch
+	url = git@github.com:vrk-kpa/ckanext-sitesearch.git

--- a/ansible/deploy-all.yml
+++ b/ansible/deploy-all.yml
@@ -41,6 +41,7 @@
     - { role: ckan-extension, ckanext: ckanext-apply_permissions_for_service }
     - { role: ckan-extension, ckanext: ckanext-forcetranslation }
     - { role: ckan-extension, ckanext: ckanext-markdown_editor }
+    - { role: ckan-extension, ckanext: ckanext-sitesearch }
     - ckan
     - { role: ckan-ui }
     - nginx

--- a/ansible/deploy-extensions.yml
+++ b/ansible/deploy-extensions.yml
@@ -22,6 +22,7 @@
     - { role: ckan-extension, ckanext: ckanext-openapiviewer }
     - { role: ckan-extension, ckanext: ckanext-apply_permissions_for_service }
     - { role: ckan-extension, ckanext: ckanext-markdown_editor }
+    - { role: ckan-extension, ckanext: ckanext-sitesearch }
     - ckan
     - ckan-translations
   handlers:

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -139,7 +139,7 @@
   cron: name="X-Road organization data update" special_time=daily job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" xroad update-xroad-organizations"
 
 - name: Ensure tracking cronjob
-  cron: name="Tracking update" special_time=hourly job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" tracking update && {{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" search-index rebuild -r"
+  cron: name="Tracking update" special_time=hourly job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" tracking update && {{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" search-index rebuild -r && {{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" sitesearch rebuild organizations"
 
 - name: Ensure link validation cronjob
   cron: name="Link validator update" special_time=weekly job="{{ virtualenv }}/bin/ckan --config "{{ ckan_ini }}" links crawl"

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -31,7 +31,7 @@ who.log_file = %(cache_dir)s/who_log.ini
 # Secure cookie & 4h timeout
 who.secure = True
 who.timeout = 14400
-who.samesite = Strict
+who.samesite = {{ ckan_who_samesite  | default('Strict') }}
 
 sqlalchemy.url = postgres://{{ database_ckan.username }}:{{ database_ckan.password }}@{{ database_ckan.host }}/{{ database_ckan.name }}
 

--- a/ansible/roles/solr-reindex/tasks/main.yml
+++ b/ansible/roles/solr-reindex/tasks/main.yml
@@ -3,3 +3,6 @@
 # For now (as there is very little data), let's always reindex to catch Solr problems.
 - name: Force Solr reindex
   shell: ./bin/ckan --config "{{ ckan_ini }}" search-index rebuild chdir={{ virtualenv }}
+
+- name: Force Solr reindex for organizations
+  shell: ./bin/ckan --config "{{ ckan_ini }}" sitesearch rebuild organizations chdir={{ virtualenv }}

--- a/ansible/vars/environment-specific/prod.yml
+++ b/ansible/vars/environment-specific/prod.yml
@@ -103,6 +103,7 @@ apicatalog_path: "{{ server_path }}/ckanext/ckanext-apicatalog/"
 
 ckan_plugins:
   - apicatalog
+  - sitesearch
   - scheming_datasets
   - scheming_organizations
   - fluent

--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -103,6 +103,7 @@ apicatalog_path: "{{ server_path }}/ckanext/ckanext-apicatalog/"
 
 ckan_plugins:
   - apply_permissions_for_service
+  - sitesearch
   - apicatalog
   - scheming_datasets
   - scheming_organizations

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -98,6 +98,7 @@ apicatalog_path: "{{ server_path }}/ckanext/ckanext-apicatalog/"
 
 ckan_plugins:
   - apply_permissions_for_service
+  - sitesearch
   - apicatalog
   - scheming_datasets
   - scheming_organizations

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -7,6 +7,7 @@ ckan_site_name: Liityntäkatalogi
 ckan_site_logo: /base/images/lika-logo-test.svg
 ckan_featured_orgs:
 ckan_test_environment: True
+ckan_who_samesite: Lax
 
 analytics_server_public_facing_hostname: 10.100.10.11
 analytics_internal_hostname: analytics-vagrant
@@ -109,6 +110,7 @@ robots_allowed: true
 
 ckan_plugins:
   - apply_permissions_for_service
+  - sitesearch
   - apicatalog
   - scheming_datasets
   - scheming_organizations


### PR DESCRIPTION
# Description
Includes sitesearch extension and adds organizations SOLR indexing.

## Jira ticket reference: [LIKA-438](https://jira.dvv.fi/browse/LIKA-438)

## What has changed:
- Add sitesearch extension
- Include sitesearch extension in plugins
- Include sitesearch organization indexing in places where search-index is rebuilt
- Add new optional configuration variable for ckan.who.samesite with default to Strict

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

