### PR TITLE
LIKA-438: Use sitesearch extension in organization list

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
@@ -36,7 +36,7 @@ def organization_generator(context, options={}, page_size=None):
     for index in itertools.count(start=0, step=page_size):
         data_dict.update({'rows': page_size, 'start': index})
         organizations = organization_list(context, data_dict)
-        
+
         # Empty page, previous must have been the last one
         if not organizations.get('results', None):
             return

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
@@ -25,22 +25,25 @@ def organization_generator(context, options={}, page_size=None):
         # Default value for ckan.group_and_organization_list_max is 25
         page_size = toolkit.config.get('ckan.group_and_organization_list_max', 25)
 
-    organization_list = toolkit.get_action('organization_list')
+    organization_list = toolkit.get_action('organization_search')
+
+    data_dict = options.copy()
+    del data_dict['include_extras']
+    del data_dict['all_fields']
 
     # Loop through all items. Each page has {page_size} items.
     # Stop iteration when all items have been looped.
     for index in itertools.count(start=0, step=page_size):
-        data_dict = options.copy()
-        data_dict.update({'limit': page_size, 'offset': index})
+        data_dict.update({'rows': page_size, 'start': index})
         organizations = organization_list(context, data_dict)
-
+        
         # Empty page, previous must have been the last one
-        if not organizations:
+        if not organizations.get('results', None):
             return
 
-        for organization in organizations:
+        for organization in organizations.get('results', None):
             yield organization
 
         # Incomplete page, must be the last one
-        if len(organizations) < page_size:
+        if len(organizations.get('results', [])) < page_size:
             return

--- a/tools/generate_organizations.py
+++ b/tools/generate_organizations.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+
+"""
+This generates deterministically random organizations as bulk process
+"""
+
+import sys
+import ckanapi
+import datetime
+import random
+import re
+import requests
+
+def name_generator(seed):
+    words = [x.strip() for x in open('/usr/share/dict/words', 'r') if re.match('^[A-Za-z]*$', x)]
+    random.seed(seed)
+    while True:
+        yield "-".join([random.choice(words) for i in range(3)]).lower()
+
+def create_root_organization(api, name):
+    print("Creating root organization %s" % name)
+    api.call_action('organization_create', {
+        'name': name,
+        'title_translated': {'fi': name},
+        'xroad_membercode': 'asdf'
+    })
+    return name
+
+def create_organization(api, name, parent_name):
+    print("Creating organization %s" % name)
+    org = api.call_action('organization_create', {
+        'name': name,
+        'title_translated': {'fi': name},
+        'groups': [{"capacity": "public", "name": parent_name}],
+    })
+    return name
+
+if __name__ == '__main__':
+
+    usage = """
+    Usage: ./generate_orgs.py API_URL API_KEY NUM_ROOTS NUM_LEVELS NUM_CHILDREN
+    API_URL:      Url to CKAN excluding api directory and without trailing forward slash,
+                  e.g. http://beta.opendata.fi/data
+    API_KEY:      API key of the authorized user whose permissions are used for the requests,
+                  e.g. 12345678-90ab-f000-f000-f0d9e8c7b6aa
+    NUM_ROOTS:    Number of root organizations
+    NUM_LEVELS:   Depth of organization hierarchy
+    NUM_CHILDREN: Number of children per level"""
+
+
+
+    if len(sys.argv) != 6:
+        print (usage)
+        sys.exit()
+
+    binary_name, api_url, api_key, num_roots, num_levels, num_children = sys.argv
+    num_roots, num_levels, num_children = int(num_roots), int(num_levels), int(num_children)
+
+    example_id = "generate_orgs-{:%Y%m%d%H%M%S%f}".format(datetime.datetime.utcnow())
+
+    session = requests.Session()
+    session.verify = False
+    api = ckanapi.RemoteCKAN(api_url,
+                                  apikey=api_key,
+                                  user_agent='avoindata_ckanapi_organize_orgs/1.0 ({0})'.format(example_id),
+                                  session=session)
+
+    names = name_generator(random.randrange(0, 1000000))
+    root_ids = [create_root_organization(api, next(names)) for i in range(num_roots)]
+
+    def create_children(parent_id):
+        return [create_organization(api, next(names), parent_id) for i in range(num_children)]
+
+    def create_level(parent_ids):
+        return [x for parent_id in parent_ids for x in create_children(parent_id)]
+
+    level_ids = root_ids
+    for level in range(num_levels):
+        level_ids = create_level(level_ids)
+
+
+
+
+


### PR DESCRIPTION
# Description
Change organization list to use solr instead of sql to make it faster

## Jira ticket reference: [LIKA-438](https://jira.dvv.fi/browse/LIKA-438)

## What has changed:
- Combine list of organizations with faster solr queries
- Add organization generate script in tools

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

