### PR TITLE
hotfix: subsystem page should work without apply_permissions_for_service extension

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
@@ -13,32 +13,34 @@
   {% endblock %}
 
   {% block page_heading %}
-    {% if h.check_access('service_permission_application_create') %}
-      {%- set settings = pkg.get('service_permission_settings', {}) -%}
-      {%- set delivery_method = settings.get('delivery_method') -%}
-      {% if delivery_method not in (None, 'none') %}
-        <h2>{{ _('Request permission to use this subsystem') }}</h2>
-      {% endif %}
-      {% set guide_text = h.get_translated(settings, 'guide_text') %}
-      {% set guide_text_markdown = h.render_markdown(guide_text) if guide_text else '' %}
-      {% if delivery_method == 'email' %}
-          <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
-          {{guide_text_markdown}}
-          <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
-            <i class="fal fa-external-link-alt btn-icon--right"></i>
-          </a>
-      {% elif delivery_method == 'file' %}
-          <p>{{ _('Request permission to use this subsystem in the Suomi.fi Data Exchange Layer if you want to have access to one or several of its services. Download and complete the form below and submit it to the email address provided by the owner of the subsystem. See the form and the subsystem description for more detailed instructions. Note that some subsystems may require that you apply for data access authorisation before you can request permission in the API Catalogue.') }}</p>
-          {{guide_text_markdown}}
-          <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('file_url')}}" target="_blank">{{ _('Download file') }}
-            <i class="fal fa-arrow-down btn-icon--right"></i>
-          </a>
-      {% elif delivery_method == 'web' %}
-          <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
-          {{guide_text_markdown}}
-          <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('web')}}" target="_blank">{{ _('Request permission in organizations website') }}
+    {% if h.is_extension_loaded('apply_permissions_for_service') %}
+      {% if h.check_access('service_permission_application_create') %}
+        {%- set settings = pkg.get('service_permission_settings', {}) -%}
+        {%- set delivery_method = settings.get('delivery_method') -%}
+        {% if delivery_method not in (None, 'none') %}
+          <h2>{{ _('Request permission to use this subsystem') }}</h2>
+        {% endif %}
+        {% set guide_text = h.get_translated(settings, 'guide_text') %}
+        {% set guide_text_markdown = h.render_markdown(guide_text) if guide_text else '' %}
+        {% if delivery_method == 'email' %}
+            <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
+            {{guide_text_markdown}}
+            <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
               <i class="fal fa-external-link-alt btn-icon--right"></i>
-          </a>
+            </a>
+        {% elif delivery_method == 'file' %}
+            <p>{{ _('Request permission to use this subsystem in the Suomi.fi Data Exchange Layer if you want to have access to one or several of its services. Download and complete the form below and submit it to the email address provided by the owner of the subsystem. See the form and the subsystem description for more detailed instructions. Note that some subsystems may require that you apply for data access authorisation before you can request permission in the API Catalogue.') }}</p>
+            {{guide_text_markdown}}
+            <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('file_url')}}" target="_blank">{{ _('Download file') }}
+              <i class="fal fa-arrow-down btn-icon--right"></i>
+            </a>
+        {% elif delivery_method == 'web' %}
+            <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
+            {{guide_text_markdown}}
+            <a class="btn btn-primary" href="{{pkg.get('service_permission_settings').get('web')}}" target="_blank">{{ _('Request permission in organizations website') }}
+                <i class="fal fa-external-link-alt btn-icon--right"></i>
+            </a>
+        {% endif %}
       {% endif %}
     {% endif %}
     <div class="dataset__subsystem-information">


### PR DESCRIPTION
# Description
Subsystem page template depended on apply_permissions_for_service. 

## Jira ticket reference: -

## What has changed:
- Added if around the permission application stuff

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

