### PR TITLE
LIKA-424: New stylings for bulk-edit page for organization datasets

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/bulk_process.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/bulk_process.html
@@ -1,0 +1,102 @@
+{% ckan_extends %}
+
+{% block subtitle %}{{ _('Edit datasets') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block page_primary_action %}
+  {% snippet 'snippets/add_dataset.html', group=group_dict.id %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <div class="row">
+    <h1 class="hide-heading">{{ _('Edit datasets') }}</h1>
+    <div class="primary col-md-12">
+      {% block search_form %}
+        {% set sorting = [
+            (_('Name Ascending'), 'title_string asc'),
+            (_('Name Descending'), 'title_string desc'),
+            (_('Last Modified'), 'data_modified desc') ]
+                %}
+        {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=c.q, count=page.item_count, sorting_disabled=True, sorting=sorting, sorting_selected=sort_by_selected, no_title=true, search_class=' ', no_bottom_border=True %}
+      {% endblock %}
+
+      <h3 class="page-heading">
+        {% block page_heading %}
+          {%- if page.item_count -%}
+            {{ page.item_count }} datasets{{ _(" found for \"{query}\"").format(query=c.q) if c.q }}
+          {%- elif request.params -%}
+            {{ _('Sorry no datasets found for "{query}"').format(query=c.q) }}
+          {%- else -%}
+            {{ _('Datasets') }}
+          {%- endif -%}
+        {% endblock %}
+      </h3>
+
+      {% block form %}
+        {% if page.item_count %}
+          <form method="POST" data-module="basic-form">
+            <div class="bulk_process-actions">
+                <button name="bulk_action.public" value="public" class="btn btn-default" type="submit">
+                    {{ _('Make public') }}
+                </button>
+                <button name="bulk_action.private" value="private" class="btn btn-default" type="submit">
+                    {{ _('Make private') }}
+                </button>
+                <button name="bulk_action.delete" value="delete" class="btn btn-delete" type="submit">
+                    <i class="fal fa-trash"></i>
+                    {{ _('Delete') }}
+                </button>
+            </div>
+            <table class="table table-striped table-header table-hover table-bulk-edit table-edit-hover" data-module="table-selectable-rows">
+              <col width="11">
+              <col width="120">
+              <thead>
+                <tr>
+                  <th class="table-checkbox"></th>
+                  <th>
+                    {{ _('Select all') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for package in packages %}
+                  {% set truncate = truncate or 180 %}
+                  {% set truncate_title = truncate_title or 80 %}
+                  {% set title = package.title or package.name %}
+                  {% set notes = h.markdown_extract(package.notes, extract_length=truncate) %}
+                  <tr>
+                    <td class="table-checkbox">
+                      <input type="checkbox" name="dataset_{{ package.id }}">
+                    </td>
+                    <td class="context">
+                        <a href="{% url_for package.type ~ '.edit', id=package.name %}" class="edit pull-right">
+                            {{ _('Edit') }}
+                        </a>
+                        {{ h.link_to(h.truncate(title, truncate_title), h.url_for(package.type ~ '.read', id=package.name)) }}
+                        {% if package.get('state', '').startswith('draft') %}
+                            <span class="label label-info">{{ _('Draft') }}</span>
+                        {% elif package.get('state', '').startswith('deleted') %}
+                            <span class="label label-danger">{{ _('Deleted') }}</span>
+                        {% endif %}
+                        {% if package.private %}
+                            <span class="label label-danger">{{ _('Private') }}</span>
+                        {% endif %}
+                      {% if notes %}
+                        <p>{{ notes|urlize }}</p>
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </form>
+        {% else %}
+          <p class="empty">{{ _('This organization has no datasets associated to it') }}</p>
+        {% endif %}
+      {% endblock %}
+    </div>
+  </div>
+  {{ page.pager() }}
+{% endblock %}
+
+{% block secondary_content %}
+{% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/snippets/search_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/snippets/search_form.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
   {% block search_sortby %}
-    {% if sorting %}
+    {% if sorting and not sorting_disabled %}
       <div class="form-select">
         <label for="field-order-by">{{ _('Order by') }}</label>
         <div class="select-wrapper">

--- a/ckanext/ckanext-apicatalog/less/components.less
+++ b/ckanext/ckanext-apicatalog/less/components.less
@@ -1,6 +1,7 @@
 @import "components/apply-permissions-for-service";
 @import "components/banner";
 @import "components/button";
+@import "components/bulk-process";
 @import "components/form";
 @import "components/tags";
 @import "components/drag-n-drop-uploader";

--- a/ckanext/ckanext-apicatalog/less/components/bulk-process.less
+++ b/ckanext/ckanext-apicatalog/less/components/bulk-process.less
@@ -1,0 +1,70 @@
+#organization-datasets-search-form {
+    [type='submit'] {
+        background-color: @suomifi-highlight-base;
+
+        i {
+            color: @white;
+            font-weight: 300;
+        }
+    }
+
+    label {
+        font-weight: 600;
+    }
+}
+
+.bulk_process-actions {
+    margin: @gutterY -(@gutterX / 4);
+
+    .btn {
+        margin: 0 (@gutterX / 4);
+        font-weight: 600;
+        color: @suomifi-highlight-base;
+        border-color: @suomifi-highlight-base;
+    }
+
+    .btn-delete {
+        i {
+            margin-right: (@gutterX / 4);
+        }
+    }
+}
+
+.table-bulk-edit {
+    border: 1px solid @suomifi-depth-light1;
+    border-top: 2px solid @suomifi-highlight-base;
+    font-size: 18px;
+    font-weight: 600;
+
+    > thead > tr > th,
+    > thead > tr > td {
+        font-weight: normal;
+        font-size: 16px;
+    }
+
+    > thead > tr > th,
+    > thead > tr > td,
+    > tbody > tr > th,
+    > tbody > tr > td {
+        border: none;
+        border-bottom: 1px solid @suomifi-depth-light1;
+        vertical-align: middle;
+    }
+
+    > thead > tr > th,
+    > thead > tr > td,
+    > tbody > tr:nth-child(even) > th,
+    > tbody > tr:nth-child(even) > td {
+        background-color: @white;
+
+    }
+    > tbody > tr:nth-child(odd) > th,
+    > tbody > tr:nth-child(odd) > td {
+        background-color: @suomifi-striped-background;
+    }
+
+    .table-checkbox {
+        padding-left: (@gutterX / 2);
+        padding-right: (@gutterX / 2);
+    }
+}

--- a/ckanext/ckanext-apicatalog/less/search.less
+++ b/ckanext/ckanext-apicatalog/less/search.less
@@ -28,7 +28,7 @@
     }
   }
 
-  &:not(.header-search) {
+  &:not(.header-search):not(.no-bottom-border) {
     margin-bottom: 20px;
     padding-bottom: 25px;
     border-bottom: 1px solid @genericBorderColor;


### PR DESCRIPTION
# Description
Added stylings for bulk-edit view in organizations datasets

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
- Styles
- Structure of that pages layout

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.

![Screenshot from 2022-12-20 15-18-32](https://user-images.githubusercontent.com/13560443/208676486-d01686fd-be74-430b-87cf-f71de62ba99a.png)
