### PR TITLE
LIKA-371: Match info box styles with suomi.fi like design

### DIFF
--- a/ckanext/ckanext-apicatalog/less/forms.less
+++ b/ckanext/ckanext-apicatalog/less/forms.less
@@ -257,16 +257,13 @@ textarea {
     i.far,
     i.fas,
     i.fal {
-      color: #c33932;
+      color: @color--danger;
     }
   }
 
   &.alert-info {
     display: flex;
     align-items: start;
-    border: 1px solid @suomifi-highlight-base;
-    width: 100%;
-    background-color: #d1e4ff;
     color: @suomifi-text-base;
     margin-top: 25px;
 

--- a/ckanext/ckanext-apicatalog/less/layout.less
+++ b/ckanext/ckanext-apicatalog/less/layout.less
@@ -193,21 +193,38 @@
 
 .flash-messages {
   display: flex;
+  flex-direction: column;
   position: absolute;
   left: 0;
   right: 0;
+  padding-left: @gutterX / 2;
+  padding-right: @gutterX / 2;
 
   .alert {
-    box-shadow: 0px 4px 8px 0px fade(@suomifi-text-base, 20%);
+    box-shadow: 0px 4px 8px 0px fade(@suomifi-text-base, 14%);
     color: @suomifi-text-base;
     margin-left: auto;
-    border-top: 4px solid #fff;
-    background: #fff;
-    border-radius: 3px;
+    border-top: 4px solid @white;
+    background: @white;
+    border-radius: 4px;
     z-index: 1000;
+    border: none;
+    border-top-width: 4px;
+    border-top-style: solid;
+    width: auto;
+    margin-top: @gutterY / 2;
 
     &.alert-success {
       border-top-color: @color--success;
+    }
+
+    &.alert-info {
+      border-top-color: @color--info;
+    }
+
+    &.alert-danger,
+    &.alert-error {
+      border-top-color: @color--danger;
     }
 
     button.close {

--- a/ckanext/ckanext-apicatalog/less/variables/palette.less
+++ b/ckanext/ckanext-apicatalog/less/variables/palette.less
@@ -1,5 +1,7 @@
 /** Base colors */
-@color--success: #09a580;
+@color--info: #2e78cc;
+@color--danger: #c33932;
+@color--success: #09ae87;
 
 /** Brand colors */
 @suomifi-brand--extra-light: #f7fafd;


### PR DESCRIPTION
# Description
Update info box styles.

## Jira ticket reference: [LIKA-371](https://jira.dvv.fi/browse/LIKA-371)

## What has changed:
- Styles for alert/danger/success/info toasts/alerts

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.
![Screenshot from 2022-12-21 15-12-03](https://user-images.githubusercontent.com/13560443/208914018-1d994318-25ca-4387-8473-ea17be50df50.png)

