### PR TITLE
LIKA-435: Separate resource page side nav to services and attachments

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resources.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/snippets/resources.html
@@ -1,12 +1,30 @@
 {% ckan_extends %}
 
-{% block resources_list %}
-  <ul class="list-unstyled nav nav-simple attachments-list">
-    {% for resource in resources %}
-      <li class="nav-item{{ ' active' if active == resource.id }}">
-        {% set service_type = ' (' + resource.xroad_service_type|upper + ')' if resource.xroad_service_type and resource.xroad_service_type else '' %}
-        {% link_for h.resource_display_name(resource) + service_type, 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
-      </li>
-    {% endfor %}
-  </ul>
+{% block resources_inner %}
+  {% set services = resources|selectattr('harvested_from_xroad')|list %}
+  {% set attachments = resources|rejectattr('harvested_from_xroad')|list %}
+
+  {% if services %}
+    <h2>{{ _("Services") }}</h2>
+    <ul class="list-unstyled nav nav-simple attachments-list">
+      {% for resource in services %}
+        <li class="nav-item{{ ' active' if active == resource.id }}">
+          {% set service_type = ' (' + resource.xroad_service_type|upper + ')' if resource.xroad_service_type and resource.xroad_service_type else '' %}
+          {% link_for h.resource_display_name(resource) + service_type, 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+
+  {% if attachments %}
+    <h2>{{ _("Attachments") }}</h2>
+    <ul class="list-unstyled nav nav-simple attachments-list">
+      {% for resource in attachments %}
+        <li class="nav-item{{ ' active' if active == resource.id }}">
+          {% set service_type = ' (' + resource.xroad_service_type|upper + ')' if resource.xroad_service_type and resource.xroad_service_type else '' %}
+          {% link_for h.resource_display_name(resource) + service_type, 'resource_read', id=pkg.name, resource_id=resource.id, inner_span=true %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Description
This change separates the resource pages side nav according to resource type i.e. services and attachments

## Jira ticket reference: [LIKA-435](https://jira.dvv.fi/browse/LIKA-435)

## What has changed:
* Split resource page side nav to services and attachments

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
![image](https://user-images.githubusercontent.com/3969176/210251261-57d42831-3d0b-477d-a074-078cd226055e.png)

After:
![image](https://user-images.githubusercontent.com/3969176/210251269-d535bac5-197c-4964-a044-74ef3b2a5f72.png)

