### PR TITLE
Handling pip-requirements is no longer needed

### DIFF
--- a/ansible/roles/ckan-extension/tasks/main.yml
+++ b/ansible/roles/ckan-extension/tasks/main.yml
@@ -36,17 +36,9 @@
   stat: path="{{ ckanext_sync_path }}/{{ ckanext }}/requirements.txt"
   register: requirements
 
-- name: Register extension pip-requirements.txt
-  stat: path="{{ ckanext_sync_path }}/{{ ckanext }}/pip-requirements.txt"
-  register: piprequirements
-
 - name: Install extension requirements
   pip: requirements="{{ ckanext_sync_path }}/{{ ckanext }}/requirements.txt" virtualenv={{ virtualenv}} chdir="{{ ckanext_sync_path }}/{{ ckanext }}"
   when: requirements.stat.exists
-
-- name: Install extension piprequirements
-  pip: requirements="{{ ckanext_sync_path }}/{{ ckanext }}/pip-requirements.txt" virtualenv={{ virtualenv}}
-  when: piprequirements.stat.exists
 
 - block:
     - name: Register extension dev-requirements.txt


### PR DESCRIPTION
# Description
Only remaining pip-requirements.txt is in harvest which is a symlink to requirements.txt so this is no longer needed. 

