### PR TITLE
Use https url for sitesearch extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,4 +30,4 @@
 	url = https://github.com/vrk-kpa/ckanext-markdown_editor
 [submodule "ckanext/ckanext-sitesearch"]
 	path = ckanext/ckanext-sitesearch
-	url = git@github.com:vrk-kpa/ckanext-sitesearch.git
+	url = https://github.com/vrk-kpa/ckanext-sitesearch


### PR DESCRIPTION
# Description

Clones fail with git url if host keys are not added.