### PR TITLE
LIKA-270: Guess relevant organizations for broken link scan results

### DIFF
--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -68,6 +68,7 @@ def define_tables():
         Column('id', types.UnicodeText, primary_key=True, default=make_uuid),
         Column('result_id', types.UnicodeText, ForeignKey('link_validation_result.id')),
         Column('url', types.UnicodeText, nullable=False),
+        Column('organization', types.UnicodeText, nullable=True),
     )
     link_validation_referrer_table = Table('link_validation_referrer', metadata,
                                            *link_validation_referrer_columns)
@@ -93,9 +94,20 @@ def clear_tables():
 
 
 def migrate():
-    q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_result';"
-    current_cols = list([m[0] for m in Session.execute(q)])
-    if "reason" not in current_cols:
-        Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason "
-                        "character varying NOT NULL default 'Reason was not stored in database.'")
-        Session.commit()
+    def add_link_validation_result_reason():
+        q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_result';"
+        current_cols = list([m[0] for m in Session.execute(q)])
+        if "reason" not in current_cols:
+            Session.execute("ALTER TABLE link_validation_result ADD COLUMN reason "
+                            "character varying NOT NULL default 'Reason was not stored in database.'")
+            Session.commit()
+
+    def add_link_validation_referrer_organization():
+        q = "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'link_validation_referrer';"
+        current_cols = list([m[0] for m in Session.execute(q)])
+        if "organization" not in current_cols:
+            Session.execute("ALTER TABLE link_validation_referrer ADD COLUMN organization character varying")
+            Session.commit()
+
+    add_link_validation_result_reason()
+    add_link_validation_referrer_organization()

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/templates/admin/broken_links.html
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/templates/admin/broken_links.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% block primary_content_inner %}
+{% block primary %}
 <h1>{{ _('Broken links') }}</h1>
 <table class="table">
   <thead>
@@ -7,6 +7,7 @@
       <th>{{_('URL') }}</th>
       <th>{{ _('Referrers') }}</th>
       <th>{{ _('Reason') }}</th>
+      <th>{{ _('Organizations') }}</th>
     </tr>
   </thead>
   <tbody>
@@ -21,6 +22,13 @@
         </ul>
       </td>
       <td>{{ r.reason }}</td>
+      <td>
+        <ul class="list-unstyled">
+        {% for o in r.organizations %}
+        <li>{{ h.link_to(o.display_name, h.url_for('organization_read', id=o.id)) }}</a></li>
+        {% endfor %}
+        </ul>
+      </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/views.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/views.py
@@ -22,5 +22,16 @@ def read():
     define_tables()
     a_week_ago = datetime.today().date() - timedelta(weeks=1)
     results = LinkValidationResult.get_since(a_week_ago)
+
+    def get_org(name):
+        try:
+            return toolkit.get_action('organization_show')({'ignore_auth': True}, {'id': name})
+        except toolkit.ObjectNotFound:
+            return None
+
+    for result in results:
+        organization_ids = {r.organization for r in result.referrers if r.organization}
+        result.organizations = [o for o in (get_org(oid) for oid in organization_ids) if o]
+
     extra_vars = {'results': results}
     return toolkit.render('admin/broken_links.html', extra_vars=extra_vars)


### PR DESCRIPTION
# Description
- Try to guess the organization whose content has invalid links during crawling
- Show the organizations in broken link report

## Jira ticket reference: [LIKA-270](https://jira.dvv.fi/browse/LIKA-270)

## What has changed:
- Added `organization` field to `LinkValidationReferrer` and updated `links migrate` cli command to migrate database
- Store guessed organization in the field
- Show organization links in broken links report
- Updated ckanext-contact to clean up flask developer toolbar template tab

## Checklist  

- [x] Contains schema changes.
- [x] Schema changes require migration of existing data.
- [x] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/210792831-e4313d65-21b5-4d47-92f3-b4bdf5aa5236.png)


