### PR TITLE
If stored old_business_ids is a empty string, output it as list

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
@@ -386,6 +386,8 @@ def list_to_json_string(value):
 
 def json_string_to_list(value):
     if isinstance(value, str):
+        if value == "":
+            return []
         try:
             return json.loads(value)
         except json.JSONDecodeError:


### PR DESCRIPTION
# Description
Old organization have old_business_ids stored as empty strings and updates fail.

## What has changed:
If old_business_ids is a empty string, output it as list which can be stored again.

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No