### PR TITLE
LIKA-270: Added broken links tab to organization pages for admins

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
@@ -21,6 +21,9 @@
 			{{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
 			{% if h.check_access('organization_update', {'id': c.group_dict.name} ) %}
 				{{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=c.group_dict.id) }}
+        {% if h.organization_has_broken_links(c.group_dict.id) %}
+          {{ h.build_nav_icon('broken_links.organization_read', _('Broken links'), organization_id=c.group_dict.id) }}
+        {% endif %}
 			{% endif %}
 			{% if h.check_access('read_members') %}
 				{{ h.build_nav_icon('organization.members', _('Members'), id=c.group_dict.name) }}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
@@ -14,21 +14,21 @@
 
 {% block secondary_content %}
 <section class="module module-narrow">
-	<div class="module context-info">
-		<div class="module-content dataset-sidebar">
-			{{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
-			{{ h.build_nav_icon(group_type + '_about', _('About the organization'), id=c.group_dict.name) }}
-			{{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
-			{% if h.check_access('organization_update', {'id': c.group_dict.name} ) %}
-				{{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=c.group_dict.id) }}
+  <div class="module context-info">
+    <div class="module-content dataset-sidebar">
+      {{ h.build_nav_icon(group_type + '_read', _('Datasets'), id=c.group_dict.name) }}
+      {{ h.build_nav_icon(group_type + '_about', _('About the organization'), id=c.group_dict.name) }}
+      {{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
+      {% if h.check_access('organization_update', {'id': c.group_dict.name} ) %}
+        {{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=c.group_dict.id) }}
         {% if h.organization_has_broken_links(c.group_dict.id) %}
           {{ h.build_nav_icon('broken_links.organization_read', _('Broken links'), organization_id=c.group_dict.id) }}
         {% endif %}
-			{% endif %}
-			{% if h.check_access('read_members') %}
-				{{ h.build_nav_icon('organization.members', _('Members'), id=c.group_dict.name) }}
-			{% endif %}
-		</div>
-	</div>
+      {% endif %}
+      {% if h.check_access('read_members') %}
+        {{ h.build_nav_icon('organization.members', _('Members'), id=c.group_dict.name) }}
+      {% endif %}
+    </div>
+  </div>
 </section>
 {% endblock %}

--- a/ckanext/ckanext-validate_links/.tx/config
+++ b/ckanext/ckanext-validate_links/.tx/config
@@ -1,0 +1,9 @@
+[main]
+host = https://www.transifex.com
+
+[o:avoindata:p:liityntakatalogi:r:ckanext-validate_links]
+file_filter = ckanext/validate_links/i18n/<lang>/LC_MESSAGES/ckanext-validate_links.po
+source_file = ckanext/validate_links/i18n/ckanext-validate_links.pot
+source_lang = en
+type        = PO
+

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -38,6 +38,7 @@ class LinkValidationResult(DomainObject):
                 .filter(cls.timestamp > t)
                 .all())
 
+
 class LinkValidationReferrer(DomainObject):
     pass
 

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/model/__init__.py
@@ -30,6 +30,13 @@ class LinkValidationResult(DomainObject):
                 .filter(cls.timestamp > t)
                 .all())
 
+    @classmethod
+    def get_for_organization_since(cls, organization_id, t):
+        return (model.Session.query(cls)
+                .join(link_validation_referrer_table)
+                .filter(LinkValidationReferrer.organization == organization_id)
+                .filter(cls.timestamp > t)
+                .all())
 
 class LinkValidationReferrer(DomainObject):
     pass

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/plugin.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/plugin.py
@@ -2,21 +2,28 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckanext.validate_links.cli as cli
 import ckanext.validate_links.views as views
+from ckan.lib.plugins import DefaultTranslation
+
+from .model import define_tables
+from .helpers import organization_has_broken_links
 
 
 def admin_only(context, data_dict=None):
     return {'success': False, 'msg': 'Access restricted to system administrators'}
 
 
-class Validate_LinksPlugin(plugins.SingletonPlugin):
+class Validate_LinksPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IClick)
+    plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.ITranslation)
 
     # IConfigurer
 
     def update_config(self, config):
+        define_tables()
         toolkit.add_ckan_admin_tab(config, 'admin_broken_links.read', 'Broken links')
         toolkit.add_template_directory(config, 'templates')
         toolkit.add_public_directory(config, 'public')
@@ -36,3 +43,8 @@ class Validate_LinksPlugin(plugins.SingletonPlugin):
 
     def get_commands(self):
         return cli.get_commands()
+
+    # ITemplateHelpers
+
+    def get_helpers(self):
+        return {'organization_has_broken_links': organization_has_broken_links}

--- a/ckanext/ckanext-validate_links/ckanext/validate_links/views.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/views.py
@@ -1,31 +1,34 @@
 import flask
 from datetime import datetime, timedelta
 import ckan.plugins.toolkit as toolkit
-from ckanext.validate_links.model import LinkValidationResult, define_tables
+from .model import LinkValidationResult
 
 
 admin_broken_links = flask.Blueprint('admin_broken_links', __name__, url_prefix='/ckan-admin')
+broken_links = flask.Blueprint('broken_links', __name__)
 
 
 def get_blueprint():
-    return [admin_broken_links]
+    return [admin_broken_links, broken_links]
 
 
 @admin_broken_links.route('/admin_broken_links')
 def read():
     context = {
         u'user': toolkit.g.user,
-        u'for_view': True,
         u'auth_user_obj': toolkit.g.userobj
     }
-    toolkit.check_access('admin_broken_links', context)
-    define_tables()
+    try:
+        toolkit.check_access('admin_broken_links', context)
+    except toolkit.NotAuthorized:
+        toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
+
     a_week_ago = datetime.today().date() - timedelta(weeks=1)
     results = LinkValidationResult.get_since(a_week_ago)
 
     def get_org(name):
         try:
-            return toolkit.get_action('organization_show')({'ignore_auth': True}, {'id': name})
+            return toolkit.get_action('organization_show')(context, {'id': name})
         except toolkit.ObjectNotFound:
             return None
 
@@ -35,3 +38,22 @@ def read():
 
     extra_vars = {'results': results}
     return toolkit.render('admin/broken_links.html', extra_vars=extra_vars)
+
+
+@broken_links.route('/organization/broken_links/<organization_id>')
+def organization_read(organization_id):
+    context = {
+        u'user': toolkit.g.user,
+        u'auth_user_obj': toolkit.g.userobj
+    }
+    try:
+        toolkit.check_access('organization_update', context, {"id": organization_id})
+    except toolkit.NotAuthorized:
+        toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
+
+    a_week_ago = datetime.today().date() - timedelta(weeks=1)
+    results = LinkValidationResult.get_for_organization_since(organization_id, a_week_ago)
+    organization = toolkit.get_action('organization_show')(context, {'id': organization_id})
+    toolkit.c.group_dict = organization
+    extra_vars = {'results': results, 'group_type': 'organization', 'group_dict': organization}
+    return toolkit.render('organization/broken_links.html', extra_vars=extra_vars)

--- a/ckanext/ckanext-validate_links/setup.cfg
+++ b/ckanext/ckanext-validate_links/setup.cfg
@@ -1,21 +1,21 @@
 [extract_messages]
 keywords = translate isPlural
 add_comments = TRANSLATORS:
-output_file = i18n/ckanext-validate_links.pot
+output_file = ckanext/validate_links/i18n/ckanext-validate_links.pot
 width = 80
 
 [init_catalog]
 domain = ckanext-validate_links
-input_file = i18n/ckanext-validate_links.pot
-output_dir = i18n
+input_file = ckanext/validate_links/i18n/ckanext-validate_links.pot
+output_dir = ckanext/validate_links/i18n
 
 [update_catalog]
 domain = ckanext-validate_links
-input_file = i18n/ckanext-validate_links.pot
-output_dir = i18n
+input_file = ckanext/validate_links/i18n/ckanext-validate_links.pot
+output_dir = ckanext/validate_links/i18n
 previous = true
 
 [compile_catalog]
 domain = ckanext-validate_links
-directory = i18n
+directory = ckanext/validate_links/i18n
 statistics = true


### PR DESCRIPTION
# Description
- Added tab for viewing organization's broken links
- Added translations

## Jira ticket reference: [LIKA-270](https://jira.dvv.fi/browse/LIKA-270)

## What has changed:
Add list of changes here.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/726461/211523701-25878d01-866c-4471-9198-0395944eeb8e.png)
![image](https://user-images.githubusercontent.com/726461/211523770-6ba18a0f-5a26-4640-8ae4-9c2d50dd3aae.png)

