### PR TITLE
LIKA-424: Return navigation and sorting to org/bulk_process

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/bulk_process.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/bulk_process.html
@@ -1,4 +1,4 @@
-{% ckan_extends %}
+{% extends "organization/edit_base.html" %}
 
 {% block subtitle %}{{ _('Edit datasets') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
@@ -16,7 +16,9 @@
             (_('Name Descending'), 'title_string desc'),
             (_('Last Modified'), 'data_modified desc') ]
                 %}
-        {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=c.q, count=page.item_count, sorting_disabled=True, sorting=sorting, sorting_selected=sort_by_selected, no_title=true, search_class=' ', no_bottom_border=True %}
+        <div class="sorter-wrapper">
+          {% snippet 'snippets/search_form.html', form_id='organization-datasets-search-form', type='dataset', query=c.q, count=page.item_count, sorting=sorting, sorting_selected=sort_by_selected, no_title=true, search_class=' ', no_bottom_border=True %}
+        </div>
       {% endblock %}
 
       <h3 class="page-heading">
@@ -98,5 +100,3 @@
   {{ page.pager() }}
 {% endblock %}
 
-{% block secondary_content %}
-{% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/snippets/search_form.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/snippets/search_form.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
   {% block search_sortby %}
-    {% if sorting and not sorting_disabled %}
+    {% if sorting %}
       <div class="form-select">
         <label for="field-order-by">{{ _('Order by') }}</label>
         <div class="select-wrapper">


### PR DESCRIPTION
# Description
As the designs in abstract didn't have the side navigation visible nor did it include the sorting option in any way those ended up missing on some pages. This change brings back the navigation and sorting to organization/bulk_process

## Jira ticket reference: [LIKA-424](https://jira.dvv.fi/browse/LIKA-424)

## What has changed:
* Return side navigation
* Return the ability to sort

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before: 
<img width="808" alt="image" src="https://user-images.githubusercontent.com/3969176/211586913-96634064-cb35-4514-a878-10f7e7e846c1.png">

After:
<img width="825" alt="image" src="https://user-images.githubusercontent.com/3969176/211586932-a0019528-f5cd-4d37-bf6b-501d1061ebb6.png">

