### PR TITLE
LIKA-570: Fix organization logo placement

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
@@ -4,6 +4,9 @@
     <div class="org-page-heading">
         <h2>{{ _('About the organization') }}</h2>
     </div>
+    {% if c.group_dict['image_display_url'] %}
+        <img src="{{c.group_dict.image_display_url}}" alt="{{ _('Logo of organization {org}').format(org=h.get_translated(c.group_dict, 'title')) }}"/>
+    {% endif %}
     {% block organization_description %}
         {% if c.group_dict.description %}
         <h3>{{ _('Description') }}</h3>
@@ -126,9 +129,4 @@
         </dl>
         {% endif %}
     {% endblock %}
-</div>
-<div class="col-sm-4">
-    {% if c.group_dict['image_display_url'] %}
-        <img src="{{c.group_dict.image_display_url}}" alt="{{ _('Logo of organization {org}').format(org=h.get_translated(c.group_dict, 'title')) }}"/>
-    {% endif %}
 {% endblock %}

--- a/ckanext/ckanext-apicatalog/less/layout.less
+++ b/ckanext/ckanext-apicatalog/less/layout.less
@@ -339,12 +339,11 @@
   img {
     float: right;
     max-width: 200px;
-    margin-right: 80px;
+    margin-left: 20px;
+    margin-top: 10px;
 
     @media (max-width: @screen-xs-max) {
       float: none;
-      margin-right: 0;
-      margin-top: 30px;
     }
   }
 }


### PR DESCRIPTION
# Description
Placement of the organization's logo on organization/about page got broken most likely when moving the navigation from top to side. This change fixes the logo into a more sensible place on the page.

## Jira ticket reference: [LIKA-570](https://jira.dvv.fi/browse/LIKA-570)

## What has changed:
* Fix placement of the organization logo on organization/about page

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Before:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/3969176/211589256-0ba45bd8-7386-48a9-aaf7-cbd14c51778d.png">

After:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/3969176/211589333-910730e5-d9d3-4d55-8c56-417969b3f71a.png">


