### PR TITLE
LIKA-571: Fix org description in other languages if FI is missing

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
@@ -5,9 +5,10 @@
         <h2>{{ _('About the organization') }}</h2>
     </div>
     {% block organization_description %}
-        {% if c.group_dict.description %}
+    {% set description = h.get_translated(c.group_dict, 'description') %}
+        {% if description %}
         <h3>{{ _('Description') }}</h3>
-            {{ h.render_markdown(h.get_translated(c.group_dict, 'description')) }}
+            {{ h.render_markdown(description) }}
         {% endif %}
     {% endblock %}
     {% block organization_extras %}


### PR DESCRIPTION
# Description
If organization had descriptions in other languages but not in finnish the other translations weren't shown either. This fixes that behavior so that description is shown on selected language if it's set regardless of the finnish description 

## Jira ticket reference: [LIKA-571](https://jira.dvv.fi/browse/LIKA-571)

## What has changed:
* Show en/sv descriptions if given and corresponding lang is selected regardless of the finnish description

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


