### PR TITLE
LIKA-561: Rename org checkbox labels

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -1,15 +1,15 @@
 # Translations template for ckanext-apicatalog.
-# Copyright (C) 2022 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-apicatalog
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-12-21 14:22+0000\n"
+"POT-Creation-Date: 2023-01-10 15:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,23 +26,24 @@ msgstr ""
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:852
+#: ckanext/apicatalog/plugin.py:854
 #: ckanext/apicatalog/templates/package/read.html:67
+#: ckanext/apicatalog/templates/package/snippets/resources.html:8
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:853
+#: ckanext/apicatalog/plugin.py:855
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:854
+#: ckanext/apicatalog/plugin.py:856
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:855
+#: ckanext/apicatalog/plugin.py:857
 msgid "Formats"
 msgstr ""
 
@@ -379,39 +380,49 @@ msgstr ""
 msgid "Data processing"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:54
+#: ckanext/apicatalog/translations.py:105
+msgid ""
+"Choose this if your organization acts as an intermediary for other "
+"organizations."
+msgstr ""
+
+#: ckanext/apicatalog/translations.py:106
+msgid "Choose this if your organization processes data outside the EU/EAA countries."
+msgstr ""
+
+#: ckanext/apicatalog/validators.py:56
 msgid "Package contains invalid resources"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:78 ckanext/apicatalog/validators.py:246
-#: ckanext/apicatalog/validators.py:284
+#: ckanext/apicatalog/validators.py:80 ckanext/apicatalog/validators.py:252
+#: ckanext/apicatalog/validators.py:290
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:81 ckanext/apicatalog/validators.py:249
-#: ckanext/apicatalog/validators.py:281
+#: ckanext/apicatalog/validators.py:83 ckanext/apicatalog/validators.py:255
+#: ckanext/apicatalog/validators.py:287
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:85 ckanext/apicatalog/validators.py:252
-#: ckanext/apicatalog/validators.py:286
+#: ckanext/apicatalog/validators.py:87 ckanext/apicatalog/validators.py:258
+#: ckanext/apicatalog/validators.py:292
 msgid "expecting JSON object"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:89
+#: ckanext/apicatalog/validators.py:91
 #, python-format
 msgid "Required language \"%s\" missing"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:97
+#: ckanext/apicatalog/validators.py:99
 msgid "Missing value"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:131
+#: ckanext/apicatalog/validators.py:137
 msgid "Business id is incorrect format."
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:149
+#: ckanext/apicatalog/validators.py:155
 msgid "Business id verification number does not match business id."
 msgstr ""
 
@@ -469,6 +480,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:60
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_navmenu.html:5
+#: ckanext/apicatalog/templates/organization/bulk_process.html:29
 #: ckanext/apicatalog/templates/organization/read.html:15
 #: ckanext/apicatalog/templates/organization/read_base.html:19
 #: ckanext/apicatalog/templates/package/search.html:4
@@ -635,6 +647,7 @@ msgid "Total package count"
 msgstr ""
 
 #: ckanext/apicatalog/templates/admin/dashboard.html:58
+#: ckanext/apicatalog/templates/organization/bulk_process.html:81
 #: ckanext/apicatalog/templates/package/read.html:8
 #: ckanext/apicatalog/templates/snippets/package_item.html:34
 msgid "Private"
@@ -849,6 +862,7 @@ msgid "Not in menu"
 msgstr ""
 
 #: ckanext/apicatalog/templates/ckanext_pages/page.html:15
+#: ckanext/apicatalog/templates/organization/bulk_process.html:72
 #: ckanext/apicatalog/templates/organization/read_base.html:5
 #: ckanext/apicatalog/templates/package/read_base.html:10
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:28
@@ -1219,6 +1233,70 @@ msgstr ""
 msgid "Activity Stream"
 msgstr ""
 
+#: ckanext/apicatalog/templates/organization/bulk_process.html:3
+#: ckanext/apicatalog/templates/organization/bulk_process.html:11
+msgid "Edit datasets"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:15
+#: ckanext/apicatalog/templates/organization/index.html:11
+#: ckanext/apicatalog/templates/package/search.html:70
+msgid "Name Ascending"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:16
+#: ckanext/apicatalog/templates/organization/index.html:11
+#: ckanext/apicatalog/templates/package/search.html:71
+msgid "Name Descending"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:17
+msgid "Last Modified"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:25
+msgid " found for \"{query}\""
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:27
+msgid "Sorry no datasets found for \"{query}\""
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:39
+msgid "Make public"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:42
+msgid "Make private"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:46
+#: ckanext/apicatalog/templates/organization/members.html:75
+#: ckanext/apicatalog/templates/package/snippets/package_form.html:25
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:81
+#: ckanext/apicatalog/templates/user/edit_user_form.html:53
+msgid "Delete"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:56
+msgid "Select all"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:76
+#: ckanext/apicatalog/templates/snippets/package_item.html:41
+msgid "Draft"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:78
+#: ckanext/apicatalog/templates/snippets/package_item.html:43
+msgid "Deleted"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:93
+msgid "This organization has no datasets associated to it"
+msgstr ""
+
 #: ckanext/apicatalog/templates/organization/edit_base.html:15
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 #: ckanext/apicatalog/templates/package/resource_edit_base.html:4
@@ -1259,16 +1337,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/organization/index.html:11
 msgid "Service providers first"
-msgstr ""
-
-#: ckanext/apicatalog/templates/organization/index.html:11
-#: ckanext/apicatalog/templates/package/search.html:70
-msgid "Name Ascending"
-msgstr ""
-
-#: ckanext/apicatalog/templates/organization/index.html:11
-#: ckanext/apicatalog/templates/package/search.html:71
-msgid "Name Descending"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/index.html:25
@@ -1338,14 +1406,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/organization/members.html:75
 msgid "Are you sure you want to delete this member?"
-msgstr ""
-
-#: ckanext/apicatalog/templates/organization/members.html:75
-#: ckanext/apicatalog/templates/package/snippets/package_form.html:25
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:81
-#: ckanext/apicatalog/templates/user/edit_user_form.html:53
-msgid "Delete"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/new.html:3
@@ -1436,6 +1496,7 @@ msgid "Service bus identifier"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/read.html:68
+#: ckanext/apicatalog/templates/package/snippets/resources.html:20
 msgid "Attachments"
 msgstr ""
 
@@ -1601,11 +1662,11 @@ msgstr ""
 msgid "X-Road related information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/organization/about.html:85
+#: ckanext/apicatalog/templates/scheming/organization/about.html:88
 msgid "Additional information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/organization/about.html:123
+#: ckanext/apicatalog/templates/scheming/organization/about.html:130
 msgid "Logo of organization {org}"
 msgstr ""
 
@@ -1758,14 +1819,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/multiselect.html:25
 msgid "Not selected"
-msgstr ""
-
-#: ckanext/apicatalog/templates/snippets/package_item.html:41
-msgid "Draft"
-msgstr ""
-
-#: ckanext/apicatalog/templates/snippets/package_item.html:43
-msgid "Deleted"
 msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/package_item.html:51

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -95,10 +95,11 @@
       "choices": [
         {
           "value": "false",
-          "label": "Organization acts as an intermediary for other organizations."
+          "label": "Choose this if your organization acts as an intermediary for other organizations."
         }
       ],
-      "label": "Intermediary organization"
+      "label": "Intermediary organization",
+      "display_label": "Organization acts as an intermediary for other organizations."
     },
     {
       "field_name": "data_processing_outside_eu",
@@ -106,10 +107,11 @@
       "choices": [
         {
           "value": "true",
-          "label": "Organization processes data outside the EU/EAA countries."
+          "label": "Choose this if your organization processes data outside the EU/EAA countries."
         }
       ],
-      "label": "Data processing"
+      "label": "Data processing",
+      "display_label": "Organization processes data outside the EU/EAA countries."
     },
     {
       "field_name": "webpage_address",

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/scheming/organization/about.html
@@ -110,18 +110,16 @@
     field=field, data=c.group_dict, schema=schema -%}</dd>
             {% endif %}
 
-            {% if c.group_dict['data_processing_outside_eu'] %}
-                {% set field = h.scheming_field_by_name(c.scheming_fields, 'data_processing_outside_eu') %}
-                <dt>{{ h.scheming_language_text(field.label) }}:</dt>
-                <dd>{%- snippet 'scheming/display_snippets/multiple_choice.html',
-    field=field, data=c.group_dict, schema=schema -%}</dd>
-            {% endif %}
-
             {% if c.group_dict['is_intermediary'] %}
                 {% set field = h.scheming_field_by_name(c.scheming_fields, 'is_intermediary') %}
                 <dt>{{ h.scheming_language_text(field.label) }}:</dt>
-                <dd>{%- snippet 'scheming/display_snippets/multiple_choice.html',
-  field=field, data=c.group_dict, schema=schema -%}</dd>
+                <dd>{{ _(field.display_label) }}</dd>
+            {% endif %}
+
+            {% if c.group_dict['data_processing_outside_eu'] %}
+                {% set field = h.scheming_field_by_name(c.scheming_fields, 'data_processing_outside_eu') %}
+                <dt>{{ h.scheming_language_text(field.label) }}:</dt>
+                <dd>{{ _(field.display_label) }}</dd>
             {% endif %}
         </dl>
         {% endif %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/translations.py
@@ -102,4 +102,6 @@ def schema_translatable_strings():
             _('Organization processes data outside the EU/EAA countries.'),
             _('Intermediary organization'),
             _('Data processing'),
+            _('Choose this if your organization acts as an intermediary for other organizations.'),
+            _('Choose this if your organization processes data outside the EU/EAA countries.'),
             ]


### PR DESCRIPTION
# Description
This change adds "Choose this if " in front of both new org checkboxes in org edit view (data processing & intermediary org). The original label is still used when displaying in the read view.

## Jira ticket reference: [LIKA-561](https://jira.dvv.fi/browse/LIKA-561)

## What has changed:
* Rename is_intermediary choice label to "Choose this if your organization acts as an intermediary for other organizations."
* Move the previous to choice label text to display_label(?) for display purposes ("display_label": "Organization acts as an intermediary for other organizations.")
* Rename data_processing_outside_eu choice label to "Choose this if your organization processes data outside the EU/EAA countries."
* Move the previous to choice label text to display_label(?) for display purposes ("display_label": "Organization processes data outside the EU/EAA countries.")
* Reordered the two fields in the template (it bugged me that the order was different in read vs edit view)

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


