### PR TITLE
LIKA-567: Update upload input width with js

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -34,8 +34,11 @@
                     <script>
                       function listenAdditionalFileCheckbox(event) {
                         var fileField = document.querySelector('#additional_application_file_field');
-
                         fileField.style.display = event.target.checked ? 'block' : 'none';
+
+                        var uploadInput = document.querySelector('#additional_application_file_field input[name="additional_file"]');
+                        var uploadButton = document.querySelector('input#field-image-upload~a');
+                        uploadInput.style.width = uploadButton.clientWidth + 'px';
                       }
 
                       window.addEventListener('DOMContentLoaded', function(event) {


### PR DESCRIPTION
# Description
The 'Request additional info with an attachment' file upload input got incorrect width likely due to the js shenanigans with input being hidden behind a checkbox and not existing/visible when js loaded and gave the input a width (of 0) so only the padding part of the input (first 24px from the left of the button) triggered the file upload popup. This change updates the width of the input to the width of the button when the checkbox is ticked 

## Jira ticket reference: [LIKA-567](https://jira.dvv.fi/browse/LIKA-567)

## What has changed:
* Update the additional_file input width to the button width when the checkbox is toggled

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


