### PR TITLE
LIKA-568: Add description to apply permission settings email fields

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -1,5 +1,6 @@
 {% extends 'package/edit_base.html' %}
 {% import 'macros/form.html' as form %}
+{% import 'scheming/macros/form.html' as form_custom %}
 
 
 {% block content_action %}
@@ -29,7 +30,7 @@
           </div>
           <div data-mutex-field="deliveryMethod">
              <div data-mutex-value="email">
-                  {{ form.input('email', label=_('Email'), value=settings.email) }}
+                  {{ form_custom.input('email', label=_('Email'), value=settings.email, description="Fill in the email address to which the application will be sent.") }}
                   <div class="additional_application_file_container">
                     <script>
                       function listenAdditionalFileCheckbox(event) {
@@ -94,7 +95,7 @@
                 {{ form.hidden('original_filename', value=settings.original_filename) }}
               {% endif %}
 
-              {{ form.input('email', label=_('Email'), value=settings.email) }}
+              {{ form_custom.input('email', label=_('Email'), value=settings.email, description="Fill in the email address to which the application will be sent.") }}
               {% set is_upload = settings.file_url and not settings.file_url.startswith('http') %}
               {% set is_url = settings.file_url and settings.file_url.startswith('http') %}
               {{ form.image_upload_dragndrop(


### PR DESCRIPTION
# Description
This change adds a description text to the access request settings view's email fields. Between the label and the field as per instructions.

## Jira ticket reference: [LIKA-568](https://jira.dvv.fi/browse/LIKA-568)

## What has changed:
* Added description to apply permission settings email fields

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No


<img width="515" alt="image" src="https://user-images.githubusercontent.com/3969176/211776494-e0a51aab-0abd-4c33-a526-e4e5fd57f7e4.png">

