### PR TITLE
LIKA-565: Make the link in access request received email a fully qualified URL

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -64,7 +64,7 @@
   </blockquote>
   </p>
 
-  <p>Voit halutessasi hyväksyä pyynnön Liityntäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.subsystem.name %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
+  <p>Voit halutessasi hyväksyä pyynnön Liityntäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
 
   <p>Ohjeita ja lisätietoja liitynnän luvittamisesta ja alijärjestelmien liittämisestä toisiinsa löydät <a href="https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/591ac1e314bbb10001966f9c">täältä</a> . Tarvittaessa ota yhteys Suomi.fi-palveluväylän asiakaspalveluun osoitteessa palveluvayla@palveluvayla.fi.</p>
 


### PR DESCRIPTION
# Description
The link to the dataset in the access request notification email template was a relative url which resolved incorrectly. This change turns the link into a fully qualified url that takes the ckan.site_url and ckan.root_path settings into account.

## Jira ticket reference: [LIKA-565](https://jira.dvv.fi/browse/LIKA-565)

## What has changed:
* Use absolute url instead of relative

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No


