### PR TITLE
LIKA-566: Let sidenav element height flex for multiline text

### DIFF
--- a/ckanext/ckanext-apicatalog/less/module.less
+++ b/ckanext/ckanext-apicatalog/less/module.less
@@ -54,7 +54,7 @@
   border-bottom: 2px solid #f0f6ff;
   padding-left: 10px;
   margin: 0;
-  height: 54px;
+  min-height: 54px;
   padding-top: 13.5px;
   padding-bottom: 13.5px;
 


### PR DESCRIPTION
# Description
The sidenav layout got broken if navigation elements text wrapped to multiple lines. This change lets the height flex correctly in case the text doesn't fit on one line

## Jira ticket reference: [LIKA-566](https://jira.dvv.fi/browse/LIKA-566)

## What has changed:
* Changed sidenav li set height to min-height to let it flex upwards

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x Yes 
- [ ] No

Before:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/3969176/211787012-34bf8910-4057-44d4-a144-2d4fc094a204.png">

After:
<img width="284" alt="image" src="https://user-images.githubusercontent.com/3969176/211787030-ba4b631b-ecd7-466e-9577-2c3bc7cc80ef.png">

