### PR TITLE
LIKA-563: Change cookieconsent info url

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/cookieconsent/ckan-cookieconsent.js
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/fanstatic/cookieconsent/ckan-cookieconsent.js
@@ -12,8 +12,8 @@ ckan.module('cookie_consent', function (jQuery){
                     message: this._('This website uses cookies to ensure you get the best experience on our website.'),
                     allow: this._('Allow cookies'),
                     deny: this._('Decline'),
-                    link: this._('Learn more')
-
+                    link: this._('Learn more'),
+                    href: ckan.LOCALE_ROOT + '/pages/tietoa-evasteista'
                 },
                 onStatusChange: function(status, chosenBefore) {
                     let type = this.options.type;


### PR DESCRIPTION
# Description
The cookieconsent library's info url was never changed so it pointed to the lib's default. This changes it to use the simple cms page tietoa-evasteista instead 

## Jira ticket reference: [LIKA-563](https://jira.dvv.fi/browse/LIKA-563)

## What has changed:
* Added info url to the cookieconsent.initialise 

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No



