### PR TITLE
LIKA-569: Enable apply_permissions_for_service in prod

### DIFF
--- a/ansible/vars/environment-specific/prod.yml
+++ b/ansible/vars/environment-specific/prod.yml
@@ -102,6 +102,7 @@ robots_allowed: true
 apicatalog_path: "{{ server_path }}/ckanext/ckanext-apicatalog/"
 
 ckan_plugins:
+  - apply_permissions_for_service
   - apicatalog
   - sitesearch
   - scheming_datasets


### PR DESCRIPTION
# Description
Enable apply_permissions_for_service in prod

## Jira ticket reference: [LIKA-569](https://jira.dvv.fi/browse/LIKA-569)

## What has changed:
* Added apply_permissions_for_service to list of prod plugins

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


