### PR TITLE
LIKA-573: Add note of filter to org list org count

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/index.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/index.html
@@ -5,7 +5,15 @@
 {% block prelude %}
 <h1>{{ _('Organizations') }}</h1>
 <p>{% trans %}Organizations are used to create, manage and publish APIs and datasets. Users may have various roles and privileges to create, modify and publish APIs within an organization.{% endtrans %}</p>
-<div class="result-count">{{ _('{0} organizations').format(org_list.count) }}</div>
+
+<div class="result-count">{{ _('{0} organizations').format(org_list.count) }}
+  {% if not request.args.get('all_orgs') %}
+    {{ _('with filter') }}&nbsp;"{{ _('Show only service providers') }}".
+    <a href="{{ h.url_for(group_type~'.index', q=c.q, sort=sorting_selected, all_orgs=True) }}">
+      {{ _('Show organizations without APIs') }}
+    </a>
+  {% endif %}
+</div>
 {% endblock %}
 
 {% set sorting = [(_('Service providers first'), ''), (_('Name Ascending'), 'title asc'), (_('Name Descending'), 'title desc')] %}


### PR DESCRIPTION
# Description
Since the organization index page was changed from listing all organizations by default to filtering to only service providers by default, the change wasn't made very apparent and it might have looked like hundreds of organizations just disappeared. This change adds a mention after the lists organization count that the filter is on and gives you a link shortcut to showing all orgs instead.

## Jira ticket reference: [LIKA-573](https://jira.dvv.fi/browse/LIKA-573)

## What has changed:
Add list of changes here.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://user-images.githubusercontent.com/3969176/212276799-00616596-89a7-4762-961c-334c19c05b7d.png)


