### PR TITLE
LIKA-572: Fix several issues with apply_permissions_for_service

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/read.html
@@ -25,7 +25,7 @@
         {% if delivery_method == 'email' %}
             <p>{{ _('Request permission if you want to have access on some of this subsystems services. Please note that some subsystems might require information permit before you can request permission in API-Catalog') }}</p>
             {{guide_text_markdown}}
-            <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
+            <a class="btn btn-primary" href="{{ h.url_for('apply_permissions.new_permission_application', target_subsystem_id=pkg.id) }}" target="_blank">{{ _('Request permission') }}
               <i class="fal fa-external-link-alt btn-icon--right"></i>
             </a>
         {% elif delivery_method == 'file' %}

--- a/ckanext/ckanext-apicatalog/less/components/apply-permissions-for-service.less
+++ b/ckanext/ckanext-apicatalog/less/components/apply-permissions-for-service.less
@@ -1,7 +1,8 @@
 .application-file {
     display: flex;
     align-content: center;
-    
+    word-break: break-all;
+
     i {
         color: @suomifi-highlight-base;
         font-size: 31px;
@@ -17,6 +18,7 @@
     padding: @gutterSmallY @gutterSmallX;
 
     .btn {
+        max-height: 36px;
         i {
             margin-right: @margin-right__download-icon;
         }

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import requests
 import json
 
 from ckan.plugins import toolkit as tk
@@ -27,28 +26,28 @@ def service_permission_application_create(context, data_dict):
     if organization_id is None or organization_id == "":
         errors['organization_id'] = _('Missing value')
 
-    intermediate_organization_id = data_dict.get('intermediate_organization')
+    intermediate_organization_id = data_dict.get('intermediate_organization_id')
 
     target_organization_id = data_dict.get('target_organization_id')
     if target_organization_id is None or target_organization_id == "":
         errors['target_organization_id'] = _('Missing value')
 
-    business_code = data_dict.get('business_code')
-    if business_code is None or business_code == "":
-        errors['business_code'] = _('Missing value')
+    member_code = data_dict.get('member_code')
+    if member_code is None or member_code == "":
+        errors['member_code'] = _('Missing value')
     else:
         try:
             # From ckanext-apicatalog
-            tk.get_validator('business_id_validator')(business_code)
+            tk.get_validator('business_id_validator')(member_code)
         except tk.Invalid as e:
-            errors['business_code'] = e.error
+            errors['member_code'] = e.error
 
-    intermediate_business_code = data_dict.get('intermediate_business_code')
-    if intermediate_business_code:
+    intermediate_member_code = data_dict.get('intermediate_member_code')
+    if intermediate_member_code:
         try:
-            tk.get_validator('business_id_validator')(intermediate_business_code)
+            tk.get_validator('business_id_validator')(intermediate_member_code)
         except tk.Invalid as e:
-            errors['intermediate_business_code'] = e.error
+            errors['intermediate_member_code'] = e.error
 
     contact_name = data_dict.get('contact_name')
     if contact_name is None or contact_name == "":
@@ -66,23 +65,23 @@ def service_permission_application_create(context, data_dict):
     ip_address_list = data_dict.get('ip_address_list')
     if not (isinstance(ip_address_list, list) and any(ip_address_list)):
         errors['ip_address_list'] = _('Missing value')
+    target_subsystem_id = data_dict.get('target_subsystem_id')
+    if target_subsystem_id is None or target_subsystem_id == "":
+        errors['target_subsystem_id'] = _('Missing value')
+
+    # subsystem_id (previously subsystem_code) must exist and match subsystem belonging to the selected utilizing organization
     subsystem_id = data_dict.get('subsystem_id')
     if subsystem_id is None or subsystem_id == "":
         errors['subsystem_id'] = _('Missing value')
-
-    # Subsystem code must exist and match a subsystem belonging to the selected utilizing organization
-    subsystem_code = data_dict.get('subsystem_code')
-    if subsystem_code is None or subsystem_code == "":
-        errors['subsystem_code'] = _('Missing value')
     else:
-        utilizing_organization_business_code = intermediate_business_code or business_code
-        subsystem = tk.get_action('package_show')(context, {'id': subsystem_code})
-        if not subsystem.get('owner_org', '').endswith(utilizing_organization_business_code):
-            errors['subsystem_code'] = _('Selected subsystem does not belong to the utilizing organization')
+        utilizing_organization_member_code = intermediate_member_code or member_code
+        subsystem = tk.get_action('package_show')(context, {'id': subsystem_id})
+        if not subsystem.get('owner_org', '').endswith(utilizing_organization_member_code):
+            errors['subsystem_id'] = _('Selected subsystem does not belong to the utilizing organization')
 
-    service_code_list = data_dict.get('service_code_list')
-    if not service_code_list:
-        errors['service_code_list'] = _('Missing value')
+    service_id_list = data_dict.get('service_id_list')
+    if not service_id_list:
+        errors['service_id_list'] = _('Missing value')
 
     if errors:
         raise tk.ValidationError(errors)
@@ -99,14 +98,14 @@ def service_permission_application_create(context, data_dict):
     application_id = model.ApplyPermission.create(organization_id=organization_id,
                                                   target_organization_id=target_organization_id,
                                                   intermediate_organization_id=intermediate_organization_id,
-                                                  business_code=business_code,
-                                                  intermediate_business_code=intermediate_business_code,
+                                                  member_code=member_code,
+                                                  intermediate_member_code=intermediate_member_code,
                                                   contact_name=contact_name,
                                                   contact_email=contact_email,
                                                   ip_address_list=ip_address_list,
+                                                  target_subsystem_id=target_subsystem_id,
                                                   subsystem_id=subsystem_id,
-                                                  subsystem_code=subsystem_code,
-                                                  service_code_list=service_code_list,
+                                                  service_id_list=service_id_list,
                                                   usage_description=usage_description,
                                                   request_date=request_date,
                                                   application_filename=application_filename)
@@ -114,22 +113,7 @@ def service_permission_application_create(context, data_dict):
     service_permission_settings = package.get('service_permission_settings', {})
     delivery_method = service_permission_settings.get('delivery_method', 'email')
 
-    if delivery_method == 'api':
-        application = model.ApplyPermission.get(application_id).as_dict()
-        try:
-            api_url = service_permission_settings.get('api')
-
-            data = data_dict.copy()
-            data['subsystem_code'] = package.get('xroad_subsystemcode') or package['title']
-            service_code_list = [r['xroad_servicecode'] or r['name'] for r in package.get('resources')
-                                 if r['id'] in data_dict['service_code_list']]
-            data['service_code_list'] = service_code_list
-
-            requests.post(api_url, data=json.dumps(data), timeout=5).raise_for_status()
-        except Exception as e:
-            log.error('Error calling request application API: %s', e)
-
-    elif delivery_method == 'email':
+    if delivery_method == 'email':
         email_address = service_permission_settings.get('email', owner_org.get('email_address'))
         if email_address:
             log.info('Sending permission application notification email to {}'.format(email_address))
@@ -159,13 +143,13 @@ def service_permission_application_list(context, data_dict):
     check_access('service_permission_application_list', context, data_dict)
     applications = ckan_model.Session.query(model.ApplyPermission)
 
-    subsystem_id = data_dict.get('subsystem_id')
-    if subsystem_id:
-        applications = applications.filter(model.ApplyPermission.subsystem_id == subsystem_id)
+    target_subsystem_id = data_dict.get('target_subsystem_id')
+    if target_subsystem_id:
+        applications = applications.filter(model.ApplyPermission.target_subsystem_id == target_subsystem_id)
 
     applications = applications.all()
 
-    if not subsystem_id:
+    if not target_subsystem_id:
         membership_organizations = tk.get_action('organization_list_for_user')(context, {'permission': 'read'})
         organization_id_list = [org['id'] for org in membership_organizations]
         response = {'received': [], 'sent': []}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -175,11 +175,16 @@ def service_permission_application_show(context, data_dict):
         raise NotFound
 
     application = model.ApplyPermission.get(application_id).as_dict()
-    if application.get('application_filename'):
+
+    filename = application.get('application_filename')
+    if filename and not filename.startswith('http'):
         application['application_fileurl'] = h.url_for_static(
-            'uploads/apply_permission/%s' % application.get('application_filename'),
+            'uploads/apply_permission/%s' % filename,
             qualified=True
         )
+    elif filename and filename.startswith('http'):
+        application['application_fileurl'] = filename
+
     return application
 
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -204,7 +204,7 @@ def service_permission_settings_update(context, data_dict):
         raise NotFound
 
     settings = {field: data_dict[field]
-                for field in ('delivery_method', 'api', 'web', 'email', 'file_url', 'original_filename',
+                for field in ('delivery_method', 'web', 'email', 'file_url', 'original_filename',
                               'require_additional_application_file', 'additional_file_url', 'original_additional_filename',
                               'guide_text_translated')
                 if field in data_dict}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -69,14 +69,17 @@ def service_permission_application_create(context, data_dict):
     if target_subsystem_id is None or target_subsystem_id == "":
         errors['target_subsystem_id'] = _('Missing value')
 
-    # subsystem_id (previously subsystem_code) must exist and match subsystem belonging to the selected utilizing organization
+    '''
+    subsystem_id (previously subsystem_code) must exist and match subsystem belonging to the selected utilizing organization
+    utilizing organization is always organization(_id), the orgazination using the data regardless of whether they made
+    the application themselves or an intermediate_organization did it for them
+    '''
     subsystem_id = data_dict.get('subsystem_id')
     if subsystem_id is None or subsystem_id == "":
         errors['subsystem_id'] = _('Missing value')
     else:
-        utilizing_organization_member_code = intermediate_member_code or member_code
         subsystem = tk.get_action('package_show')(context, {'id': subsystem_id})
-        if not subsystem.get('owner_org', '').endswith(utilizing_organization_member_code):
+        if not subsystem.get('owner_org', '').endswith(member_code):
             errors['subsystem_id'] = _('Selected subsystem does not belong to the utilizing organization')
 
     service_id_list = data_dict.get('service_id_list')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/auth.py
@@ -3,8 +3,8 @@ from ckanext.apply_permissions_for_service import model
 
 
 def service_permission_application_list(context, data_dict):
-    if data_dict.get('subsystem_id'):
-        return {'success': toolkit.check_access('package_update', context, {'id': data_dict['subsystem_id']})}
+    if data_dict.get('target_subsystem_id'):
+        return {'success': toolkit.check_access('package_update', context, {'id': data_dict['target_subsystem_id']})}
     else:
         return {'success': True}
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/244dd92f445e_add_created_timestamp_column.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/244dd92f445e_add_created_timestamp_column.py
@@ -1,0 +1,24 @@
+"""add created timestamp column
+
+Revision ID: 244dd92f445e
+Revises: d7db14126049
+Create Date: 2023-01-14 20:13:43.577678
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '244dd92f445e'
+down_revision = 'd7db14126049'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('apply_permission', sa.Column('created', sa.DateTime, nullable=False, server_default=sa.func.now()))
+
+
+def downgrade():
+    op.drop_column('apply_permission', 'created')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/d7db14126049_clarify_column_names.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/migration/apply_permissions_for_service/versions/d7db14126049_clarify_column_names.py
@@ -1,0 +1,31 @@
+"""clarify column names
+
+Revision ID: d7db14126049
+Revises: 13981b4847ac
+Create Date: 2023-01-13 14:49:51.270751
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7db14126049'
+down_revision = '13981b4847ac'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('apply_permission', 'subsystem_id', new_column_name='target_subsystem_id')
+    op.alter_column('apply_permission', 'subsystem_code', new_column_name='subsystem_id')
+    op.alter_column('apply_permission', 'business_code', new_column_name='member_code')
+    op.alter_column('apply_permission', 'intermediate_business_code', new_column_name='intermediate_member_code')
+    op.alter_column('apply_permission', 'service_code_list', new_column_name='service_id_list')
+
+
+def downgrade():
+    op.alter_column('apply_permission', 'subsystem_id', new_column_name='subsystem_code')
+    op.alter_column('apply_permission', 'target_subsystem_id', new_column_name='subsystem_id')
+    op.alter_column('apply_permission', 'member_code', new_column_name='business_code')
+    op.alter_column('apply_permission', 'intermediate_member_code', new_column_name='intermediate_business_code')
+    op.alter_column('apply_permission', 'service_id_list', new_column_name='service_code_list')

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -71,10 +71,10 @@ class ApplyPermission(Base):
         application_dict = dictization.table_dictize(self, context)
 
         application_dict['requester_subsystem'] = toolkit.get_action('package_show')(
-            {'ignore_auth': True}, {'id': application_dict['subsystem_id']})
+            {'ignore_auth': True}, {'id': application_dict['subsystem_code']})
 
         application_dict['subsystem'] = toolkit.get_action('package_show')(
-            {'ignore_auth': True}, {'id': application_dict['subsystem_code']})
+            {'ignore_auth': True}, {'id': application_dict['subsystem_id']})
         application_dict['member'] = toolkit.get_action('organization_show')(
             {'ignore_auth': True}, {'id': application_dict['subsystem']['owner_org']})
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/model.py
@@ -26,35 +26,34 @@ class ApplyPermission(Base):
     organization_id = Column(types.UnicodeText, nullable=False)
     intermediate_organization_id = Column(types.UnicodeText, nullable=True)
     target_organization_id = Column(types.UnicodeText, nullable=False)
-    business_code = Column(types.UnicodeText, nullable=False)
-    intermediate_business_code = Column(types.UnicodeText, nullable=True)
+    member_code = Column(types.UnicodeText, nullable=False)
+    intermediate_member_code = Column(types.UnicodeText, nullable=True)
     contact_name = Column(types.UnicodeText, nullable=False)
     contact_email = Column(types.UnicodeText, nullable=False)
     ip_address_list = Column(types.JSON, nullable=False)
+    target_subsystem_id = Column(types.UnicodeText, nullable=False)
     subsystem_id = Column(types.UnicodeText, nullable=False)
-    subsystem_code = Column(types.UnicodeText, nullable=False)
-    service_code_list = Column(types.JSON, nullable=False)
-
+    service_id_list = Column(types.JSON, nullable=False)
     usage_description = Column(types.UnicodeText)
     request_date = Column(types.Date)
     application_filename = Column(types.UnicodeText)
 
     @classmethod
-    def create(cls, organization_id, target_organization_id, intermediate_organization_id, business_code,
-               intermediate_business_code, contact_name, contact_email, ip_address_list, subsystem_code,
-               subsystem_id, service_code_list, usage_description, request_date, application_filename=None):
+    def create(cls, organization_id, target_organization_id, intermediate_organization_id, member_code,
+               intermediate_member_code, contact_name, contact_email, ip_address_list, subsystem_id,
+               target_subsystem_id, service_id_list, usage_description, request_date, application_filename=None):
 
         apply_permission = ApplyPermission(organization_id=organization_id,
                                            target_organization_id=target_organization_id,
                                            intermediate_organization_id=intermediate_organization_id,
-                                           business_code=business_code,
-                                           intermediate_business_code=intermediate_business_code,
+                                           member_code=member_code,
+                                           intermediate_member_code=intermediate_member_code,
                                            contact_name=contact_name,
                                            contact_email=contact_email,
                                            ip_address_list=ip_address_list,
-                                           subsystem_code=subsystem_code,
                                            subsystem_id=subsystem_id,
-                                           service_code_list=service_code_list,
+                                           target_subsystem_id=target_subsystem_id,
+                                           service_id_list=service_id_list,
                                            usage_description=usage_description,
                                            request_date=request_date,
                                            application_filename=application_filename)
@@ -69,17 +68,16 @@ class ApplyPermission(Base):
     def as_dict(self):
         context = {'model': model}
         application_dict = dictization.table_dictize(self, context)
-
-        application_dict['requester_subsystem'] = toolkit.get_action('package_show')(
-            {'ignore_auth': True}, {'id': application_dict['subsystem_code']})
+        print(application_dict)
 
         application_dict['subsystem'] = toolkit.get_action('package_show')(
             {'ignore_auth': True}, {'id': application_dict['subsystem_id']})
-        application_dict['member'] = toolkit.get_action('organization_show')(
-            {'ignore_auth': True}, {'id': application_dict['subsystem']['owner_org']})
+
+        application_dict['target_subsystem'] = toolkit.get_action('package_show')(
+            {'ignore_auth': True}, {'id': application_dict['target_subsystem_id']})
 
         application_dict['services'] = []
-        for service in application_dict['service_code_list']:
+        for service in application_dict['service_id_list']:
             try:
                 resource = toolkit.get_action('resource_show')({'ignore_auth': True}, {'id': service})
                 application_dict['services'].append(resource)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/dashboard.html
@@ -12,7 +12,7 @@
     <section class="module module-narrow">
       <div class="module">
         <div class="module-content dataset-sidebar">
-          <li {% if page_name=="sent" %}class="active"{% endif %}>
+          <li {% if page_name=="sent" or page_name=="dashboard" %}class="active"{% endif %}>
             {% link_for _('Sent access requests'), named_route='apply_permissions.dashboard', app_type='sent'%}
           </li>
           <li {% if page_name=="received" %}class="active"{% endif %}>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/manage.html
@@ -5,7 +5,7 @@
 {% if applications %}
   <ul>
   {% for application in applications %}
-  <li>{% link_for ((h.xroad_subsystem_path(application.requester_subsystem) or application.requester_subsystem.name) + ' → ' + (h.xroad_subsystem_path(application.subsystem) or application.subsystem.name)), named_route='apply_permissions.view_permission_application', application_id=application.id %}</li>
+  <li>{% link_for ((h.xroad_subsystem_path(application.subsystem) or application.subsystem.name) + ' → ' + (h.xroad_subsystem_path(application.target_subsystem) or application.target_subsystem.name)), named_route='apply_permissions.view_permission_application', application_id=application.id %}</li>
   {% endfor %}
   </ul>
 {% else %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -14,7 +14,7 @@
     {% if service %}
     <li>{% link_for h.resource_display_name(service)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=service.id %}</li>
     {% endif %}
-    <li class="active">{% link_for _('Request access'), named_route='apply_permissions.new_permission_application', subsystem_id=subsystem_id, service_id=service_id %}</li>
+    <li class="active">{% link_for _('Request access'), named_route='apply_permissions.new_permission_application', target_subsystem_id=target_subsystem_id, service_id=service_id %}</li>
 {% endblock %}
 
 {% block prelude %}
@@ -23,44 +23,44 @@
 
 {% block primary_content_inner %}
     <script>
-    function selectOrganization() {
-        let element = document.querySelector('[name=businessCode]');
-        let organizationName = document.querySelector('[name=organization]').value;
-        let newValue = organizationName.split('.')[2];
-        if(element.value !== newValue) {
-          element.value = newValue;
-          updateSubsystemSelect();
+    function select_organization() {
+        let element = document.querySelector('[name=member_code]');
+        let organization_name = document.querySelector('[name=organization_id]').value;
+        let new_value = organization_name.split('.')[2];
+        if(element.value !== new_value) {
+          element.value = new_value;
+          update_subsystem_select();
         }
     }
-    function selectIntermediateOrganization() {
-        let element = document.querySelector('[name=intermediateBusinessCode]')
-        let organizationName = document.querySelector('[name=intermediateOrganization]').value;
-        let newValue = organizationName.split('.')[2];
-        if(element.value !== newValue) {
-          element.value = newValue;
-          updateSubsystemSelect();
+    function select_intermediate_organization() {
+        let element = document.querySelector('[name=intermediate_member_code]')
+        let organization_name = document.querySelector('[name=intermediate_organization_id]').value;
+        let new_value = organization_name.split('.')[2];
+        if(element.value !== new_value) {
+          element.value = new_value;
+          update_subsystem_select();
         }
     }
-    function showIntermediateOrganization() {
-        var show = document.querySelector('[name=enableIntermediateOrganization]').checked;
-        var intermediateOrganizationDiv = document.getElementById("intermediateOrganizationDiv");
+    function show_intermediate_organization() {
+        var show = document.querySelector('[name=enable_intermediate_organization]').checked;
+        var intermediate_organization_div = document.getElementById("intermediate_organization_div");
         if (show) {
-            intermediateOrganizationDiv.style.display = "block";
+          intermediate_organization_div.style.display = "block";
         } else {
-            intermediateOrganizationDiv.style.display = "none";
+          intermediate_organization_div.style.display = "none";
         }
-        updateSubsystemSelect();
+        update_subsystem_select();
     }
-    function updateSubsystemSelect() {
+    function update_subsystem_select() {
       let owner_org = null;
-      if(document.querySelector('[name=enableIntermediateOrganization]').checked) {
-        owner_org = document.querySelector('[name=intermediateOrganization]').value;
+      if(document.querySelector('[name=enable_intermediate_organization]').checked) {
+        owner_org = document.querySelector('[name=intermediate_organization_id]').value;
       } else {
-        owner_org = document.querySelector('[name=organization]').value;
+        owner_org = document.querySelector('[name=organization_id]').value;
       }
 
       let selected = null;
-      document.querySelectorAll('[name=subsystemCode] option').forEach(o => {
+      document.querySelectorAll('[name=subsystem_id] option').forEach(o => {
         if(o.value.startsWith(owner_org)) {
           o.removeAttribute('hidden')
           if(o.selected || !selected) {
@@ -78,7 +78,7 @@
     </script>
 {% block errors %}{{ form.errors(errors) }}{% endblock %}
 <form method="POST" enctype="multipart/form-data" data-module="form-change-listener" data-module-confirm-modal-selector>
-  {{ form.hidden('subsystemId', value=subsystem_id) }}
+  {{ form.hidden('target_subsystem_id', value=target_subsystem_id) }}
   <h3>{{ _('API access application') }}</h3>
   <p class="input-group-description">{{ _('Use this form to apply for a permission to use a service that is available in the National Data Exchange Layer. Your application will be submitted to the organization providing the service. When your application has been approved, Valtori is automatically notified of the needed firewall configurations.') }}</p>
   <hr>
@@ -89,17 +89,17 @@
   {% set user_org = user_managed_organizations[0] if user_managed_organizations else {} %}
 
   {% snippet 'apply_permissions_for_service/snippets/organization_select.html',
-             name='organization',
-             value=values.organization or user_org.name or '',
-             select_attrs={'onchange': 'selectOrganization()'},
+             name='organization_id',
+             value=values.organization_id or user_org.name or '',
+             select_attrs={'onchange': 'select_organization()'},
              label=_('Organization'),
              is_required=True,
              organizations=user_managed_organizations %}
 
-  {{ form.input('businessCode', label=_('Business code'), is_required=True, value=values.business_code, error=[errors.business_code]) }}
+  {{ form.input('member_code', label=_('Business code'), is_required=True, value=values.member_code, error=[errors.member_code]) }}
 
-  {{ form.input('contactName', label=_('Contact name'), is_required=True, value=values.contact_name or user.fullname, error=[errors.contact_name]) }}
-  {{ form.input('contactEmail', label=_('Contact email'), is_required=True, value=values.contact_email or user.email, error=[errors.contact_email]) }}
+  {{ form.input('contact_name', label=_('Contact name'), is_required=True, value=values.contact_name or user.fullname, error=[errors.contact_name]) }}
+  {{ form.input('contact_email', label=_('Contact email'), is_required=True, value=values.contact_email or user.email, error=[errors.contact_email]) }}
 
   <hr>
   <div class="control-group">
@@ -107,10 +107,10 @@
           <tr>
               <td style="padding-left: 5px; padding-right: 5px;">
                   <input type="checkbox"
-                         id="enableIntermediateOrganization"
-                         name="enableIntermediateOrganization"
+                         id="enable_intermediate_organization"
+                         name="enable_intermediate_organization"
                          {% if values.intermediate_organization %}checked{% endif %}
-                         onchange="showIntermediateOrganization()">
+                         onchange="show_intermediate_organization()">
               </td>
               <td style="padding-left: 5px; padding-right: 5px;">
                   {{ _('Applying organization acts as an intermediary on behalf of the organizations using the services') }}
@@ -120,20 +120,20 @@
   </div>
 
 
-  <div id="intermediateOrganizationDiv">
+  <div id="intermediate_organization_div">
     <h3>{{ _('Information about the organization consuming the services') }}</h3>
     <p class="input-group-description">{{ _('Fill in the information on behalf of the organisation that you apply user permit for.') }}</p>
     {% snippet 'apply_permissions_for_service/snippets/organization_select.html',
-               name='intermediateOrganization',
-               select_attrs={'onchange': 'selectIntermediateOrganization()'},
+               name='intermediate_organization_id',
+               select_attrs={'onchange': 'select_intermediate_organization()'},
                label=_('Organization using the services'),
                is_required=True,
-               value=values.intermediate_organization,
+               value=values.intermediate_organization_id,
                organizations=user_managed_organizations %}
 
-    {{ form.input('intermediateBusinessCode', label=_('Y-number'),
-                  is_required=True, value=values.intermediate_business_code,
-                  error=[errors.intermediate_business_code]) }}
+    {{ form.input('intermediate_member_code', label=_('Business code'),
+                  is_required=True, value=values.intermediate_member_code,
+                  error=[errors.intermediate_member_code]) }}
   </div>
 
   <hr>
@@ -146,12 +146,12 @@
     {% do subsystem_options.append({'value': d.id, 'text': dataset_title}) %}
   {% endfor %}
 
-  {% call form.input_multiple('ipAddress', label=_('IP address'), value=values.ip_address_list, is_required=True, placeholder=_('Write the IP address'), description=_('Select one or several IP addresses of your organization\'s security servers'), add_input='add-ip-address', error=[errors.ip_address_list]) %}
+  {% call form.input_multiple('ip_address_list', label=_('IP address'), value=values.ip_address_list, is_required=True, placeholder=_('Write the IP address'), description=_('Select one or several IP addresses of your organization\'s security servers'), add_input='add-ip-address', error=[errors.ip_address_list]) %}
     <button class="btn btn-default" name="add-ip-address"><i class="fa fa-plus"></i>{{ _('Add an IP address') }}</button>
   {% endcall %}
 
   <div class="select-wrapper">
-    {{ form.select_with_description('subsystemCode', description=_('Select the subsystem of your organization for which you want to apply permission'), label=_('Subsystem code'), options=subsystem_options, is_required=True, selected=values.subsystem_code, error=[errors.subsystem_code]) }}
+    {{ form.select_with_description('subsystem_id', description=_('Select the subsystem of your organization for which you want to apply permission'), label=_('Subsystem code'), options=subsystem_options, is_required=True, selected=values.subsystem_id, error=[errors.subsystem_id]) }}
   </div>
 
   <hr>
@@ -171,14 +171,14 @@
   {{ form.hidden('target_organization_id', org.id) }}
 
   {% set service_options = [] %}
-  {% set service_selected = values.service_code_list or ([service_id] if service_id else []) %}
+  {% set service_selected = values.service_id_list or ([service_id] if service_id else []) %}
   {% for res in pkg.resources %}
     {% do service_options.append({'value': res.id, 'text': res.xroad_service_code or res.name}) %}
   {% endfor %}
 
-  {{ form.select_multiple('serviceCode', label=_('Service code'), options=service_options, is_required=True, selected=service_selected, description=_('Select one or several APIs you are applying to access'), error=[errors.service_code_list]) }}
-  {{ form.textarea('usageDescription', label=_('Explain how the service will be used'), value=values.usage_description, placeholder=_('Reason for requesting access')) }}
-  {{ form.input('requestDate', type='date', label=_('Date when access is needed'), value=values.request_date, error=[errors.request_date]) }}
+  {{ form.select_multiple('service_id_list', label=_('Service code'), options=service_options, is_required=True, selected=service_selected, description=_('Select one or several APIs you are applying to access'), error=[errors.service_id_list]) }}
+  {{ form.textarea('usage_description', label=_('Explain how the service will be used'), value=values.usage_description, placeholder=_('Reason for requesting access')) }}
+  {{ form.input('request_date', type='date', label=_('Date when access is needed'), value=values.request_date, error=[errors.request_date]) }}
 
   <hr>
   {% if pkg.get('service_permission_settings', {}).get('delivery_method') == 'email' and pkg.get('service_permission_settings', {}).get('require_additional_application_file') == True %}
@@ -190,17 +190,17 @@
     <input class="btn btn-primary" type="submit" value="{{ _('Send access application') }}"></input>
   {% endblock %}
 
-  {% if not values.business_code %}
-    {# populate business code from selected organization #}
-    <script>selectOrganization()</script>
+  {% if not values.member_code %}
+    {# populate member code from selected organization #}
+    <script>select_organization()</script>
   {% endif %}
-    {% if not values.intermediate_business_code %}
-      {# populate intermediate organization business code from selected organization #}
-      <script>selectIntermediateOrganization()</script>
+    {% if not values.intermediate_member_code %}
+      {# populate intermediate organization member code from selected organization #}
+      <script>select_intermediate_organization()</script>
     {% endif %}
 
   {# Set intermediate organization visibility based on checkbox #}
-  <script>showIntermediateOrganization()</script>
-  <script>updateSubsystemSelect()</script>
+  <script>show_intermediate_organization()</script>
+  <script>update_subsystem_select()</script>
 </form>
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/new.html
@@ -182,7 +182,7 @@
 
   <hr>
   {% if pkg.get('service_permission_settings', {}).get('delivery_method') == 'email' and pkg.get('service_permission_settings', {}).get('require_additional_application_file') == True %}
-    {% snippet "apply_permissions_for_service/snippets/additional_application_info.html", pkg=pkg, errors=errors %}
+    {% snippet "apply_permissions_for_service/snippets/additional_application_info.html", data=values, pkg=pkg, errors=errors %}
 
     <hr>
   {% endif %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -5,14 +5,14 @@
   <title></title>
 </head>
 <body>
-  {% set subsystem_title =  h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') %}
+  {% set target_subsystem_title =  h.xroad_subsystem_path(application.target_subsystem) or h.get_translated(application.target_subsystem, 'title') %}
   <p>Hei,</p>
 
-  <p>{{ application.organization['title'] }} pyytää lupaa käyttää Suomi.fi-palveluväylässä tarjoamaasi palvelua {{ subsystem_title }}.</p>
+  <p>{{ application.organization['title'] }} pyytää lupaa käyttää Suomi.fi-palveluväylässä tarjoamaasi palvelua {{ target_subsystem_title }}.</p>
 
   <p><strong>Lupaa pyydetään palveluusi:</strong>
     <ul>
-      <li>{{ subsystem_title }}</li>
+      <li>{{ target_subsystem_title }}</li>
       {% for service in application.services %}
       <li> {{ service.xroad_servicecode or service.name }}</li>
       {% endfor %}
@@ -23,7 +23,7 @@
   <p><strong>Luvan pyytäjän tiedot:</strong>
     <ul>
       <li>Organisaatio: {{ application.organization['title'] }}</li>
-      <li>Yritystunnus: {{ application.business_code }}</li>
+      <li>Yritystunnus: {{ application.member_code }}</li>
       <li>Yhteyshenkilö: {{ application.contact_name }} </li>
       <li>Yhteyshenkilön sähköposti: {{ application.contact_email }}</li>
     </ul>
@@ -32,13 +32,13 @@
     <p><strong>Palveluita käyttävän organisaatioin tiedot:</strong>
         <ul>
         <li>Organisaatio: {{ application.intermediate_organization['title'] }}</li>
-        <li>Yritystunnus: {{ application.intermediate_business_code }}</li>
+        <li>Yritystunnus: {{ application.intermediate_member_code }}</li>
         </ul>
     </p>
   {% endif %}
   <p><strong>Luvan pyytäjän alijärjestelmän tiedot:</strong>
     <ul>
-      <li>Alijärjestelmän tunnus: {{ h.xroad_subsystem_path(application.requester_subsystem) or h.get_translated(application.requester_subsystem, 'title') }}</li>
+      <li>Alijärjestelmän tunnus: {{ h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') }}</li>
       <li>IP-osoite, mihin palomuuriavausta pyydetään: {{ application.ip_address_list|join(', ') }}</li>
     </ul>
   </p>
@@ -64,7 +64,7 @@
   </blockquote>
   </p>
 
-  <p>Voit halutessasi hyväksyä pyynnön Liityntäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
+  <p>Voit halutessasi tarkistaa pyynnön Liityntäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.target_subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
 
   <p>Ohjeita ja lisätietoja liitynnän luvittamisesta ja alijärjestelmien liittämisestä toisiinsa löydät <a href="https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/591ac1e314bbb10001966f9c">täältä</a> . Tarvittaessa ota yhteys Suomi.fi-palveluväylän asiakaspalveluun osoitteessa palveluvayla@palveluvayla.fi.</p>
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/settings.html
@@ -143,7 +143,7 @@
             <div class="module__actions">
               <button class="btn btn-primary" type="submit">{{ _('Save') }}</button>
               <a class="btn btn-default" href="{{ h.url_for('apply_permissions.permission_application_settings', subsystem_id=pkg.name) }}">{{ _('Cancel') }}</a>
-              <a data-mutex-value="email" class="btn btn-default btn--preview" href="{{ h.url_for('apply_permissions.preview_permission_application', subsystem_id=pkg.name) }}" target="_blank">{{ _('Preview application') }}</a>
+              <a data-mutex-value="email" class="btn btn-default btn--preview" href="{{ h.url_for('apply_permissions.preview_permission_application', target_subsystem_id=pkg.name) }}" target="_blank">{{ _('Preview application') }}</a>
             </div>
           </div>
         </div>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/additional_application_info.html
@@ -10,7 +10,7 @@
             <i class="fal fa-file-alt"></i>
             {{ pkg.get('service_permission_settings', {}).get('original_additional_filename') }}
         </div>
-        <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('additional_file_url') }}">
+        <a class="btn btn-outline-primary" href="{{ pkg.get('service_permission_settings', {}).get('additional_file_url') }}" target="_blank">
             <i class="far fa-arrow-to-bottom"></i>
             {{ _('Download') }}
         </a>
@@ -19,8 +19,10 @@
 
 <div class="additional_application_info_step">
     <h4>{{ _('2. Add completed file into the application') }}</h4>
+    {% set is_upload = data.file_url and not data.file_url.startswith('http') %}
+    {% set is_url = data.file_url and data.file_url.startswith('http') %}
     {{ form.image_upload_dragndrop(
-        {},
+        data,
         errors,
         upload_label=_('Add your file'),
         is_upload_enabled=h.uploads_enabled(),

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/snippets/application_table.html
@@ -9,18 +9,17 @@
   </thead>
   <tbody>
   {% for application in applications %}
-      {% set subsystem_code = application.subsystem_code.split('.') %}
       <tr>
           <td>
               {{ _('Organization') }} : <b>{% link_for application.organization["title"], named_route='organization.read', id=application.organization_id %}</b><br>
-              {{ _('Subsystem') }} : <b>{% link_for application.requester_subsystem.name, named_route='dataset.read', id=application.requester_subsystem.id %}</b><br>
+              {{ _('Subsystem') }} : <b>{% link_for application.subsystem.name, named_route='dataset.read', id=application.subsystem.id %}</b><br>
           </td>
           {% if "intermediate_organization" in application %}
           <td>
               {{ _('Organization') }} : <b>{% link_for h.get_translated(application.intermediate_organization, 'title'),
                                                        named_route='organization.read',
                                                        id=application.intermediate_organization_id %}</b><br>
-              {{ _('Business code') }} : <b>{{ application.intermediate_business_code }}</b><br>
+              {{ _('Business code') }} : <b>{{ application.intermediate_member_code }}</b><br>
           </td>
           {% else %}
           <td></td>
@@ -29,12 +28,12 @@
               {{ _('Organization') }} : <b>{% link_for h.get_translated(application.target_organization, 'title'),
                                                        named_route='organization.read',
                                                        id=application.target_organization_id %}</b><br>
-              {{ _('Subsystem') }} : <b>{% link_for subsystem_code[3], named_route='dataset.read', id=application.subsystem.id %}</b><br>
+              {{ _('Subsystem') }} : <b>{% link_for  h.get_translated(application.target_subsystem, 'title'), named_route='dataset.read', id=application.target_subsystem.id %}</b><br>
               {{ _('Service code') }} :
               {% for service in application.services %}
                 <b>{% link_for service.name,
                       named_route='dataset_resource.read',
-                      id=application.requester_subsystem.id,
+                      id=application.target_subsystem.id,
                       resource_id=service.id %}
                 </b>
                 <br>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -73,7 +73,7 @@
   <hr>
 
   <h3>{{ _('Additional info') }}</h3>
-  <a href="{{ application.get('application_fileurl')}}">{{ application.get('application_filename') }}</a>
+  <a href="{{ application.get('application_fileurl')}}" target="_blank">{{ application.get('application_filename') }}</a>
   {% endif %}
 
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/view.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
   {{ super() }}
-  <li>{% link_for h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title'), named_route='apply_permissions.view_permission_application', application_id=application.id%}</li>
+  <li>{% link_for h.xroad_subsystem_path(application.target_subsystem) or h.get_translated(application.target_subsystem, 'title'), named_route='apply_permissions.view_permission_application', application_id=application.id%}</li>
 {% endblock %}
 
 {% block prelude %}
@@ -10,13 +10,13 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-{% link_for _('All access applications'), named_route='apply_permissions.manage_permission_applications', class_='btn', icon='arrow-left', subsystem_id=application.subsystem_id %}
+{% link_for _('All access applications'), named_route='apply_permissions.dashboard', class_='btn', icon='arrow-left' %}
 
   <h3>{{ _('Applicant information') }}</h3>
   <table class="table">
     <tbody>
       <tr><th>{{ _('Organization') }}</th><td>{{ h.get_translated(application.organization, 'title') }}</td></tr>
-      <tr><th>{{ _('Business code') }}</th><td>{{ application.business_code }}</td></tr>
+      <tr><th>{{ _('Business code') }}</th><td>{{ application.member_code }}</td></tr>
       <tr><th>{{ _('Contact name') }}</th><td>{{ application.contact_name }}</td></tr>
       <tr><th>{{ _('Contact email') }}</th><td>{{ application.contact_email }}</td></tr>
     </tbody>
@@ -33,7 +33,7 @@
         </tr>
         <tr>
             <th>{{ _('Business code') }}</th>
-            <td>{{ application.intermediate_business_code }}</td>
+            <td>{{ application.intermediate_member_code }}</td>
         </tr>
     </tbody>
     </table>
@@ -44,7 +44,7 @@
   <table class="table">
     <tbody>
       <tr><th>{{ _('IP address') }}</th><td>{{ application.ip_address_list|join(', ') }}</td></tr>
-      <tr><th>{{ _('Subsystem code') }}</th><td>{{ h.xroad_subsystem_path(application.requester_subsystem) or h.get_translated(application.requester_subsystem, 'title') }}</td></tr>
+      <tr><th>{{ _('Subsystem code') }}</th><td>{{ h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') }}</td></tr>
     </tbody>
   </table>
 
@@ -54,7 +54,7 @@
   <table class="table">
     <tbody>
       <tr><th>{{ _('Organization name') }}</th><td>{{ h.get_translated(application.target_organization, 'title') }}</td></tr>
-      <tr><th>{{ _('Subsystem') }}</th><td>{{ h.xroad_subsystem_path(application.subsystem) or h.get_translated(application.subsystem, 'title') }}</td></tr>
+      <tr><th>{{ _('Subsystem') }}</th><td>{{ h.xroad_subsystem_path(application.target_subsystem) or h.get_translated(application.target_subsystem, 'title') }}</td></tr>
       <tr>
         <th>{{ _('Service code') }}</th>
           <td>
@@ -68,7 +68,7 @@
       <tr><th>{{ _('Date when access is needed') }}</th><td>{{ application.request_date }}</td></tr>
     </tbody>
   </table>
-  
+
   {% if application.get('application_filename') %}
   <hr>
 

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/package/read_base.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/package/read_base.html
@@ -2,5 +2,5 @@
 
 {% block side_navigation %}
     {{ super() }}
-    {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), subsystem_id=pkg.name) }}
+    {{ h.build_nav_icon('apply_permissions.manage_permission_applications', _('Received access requests'), target_subsystem_id=pkg.name) }}
 {% endblock %}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
@@ -1,9 +1,20 @@
 import pytest
 
 import ckanext.apply_permissions_for_service.model as apply_permissions_for_service_model
+from ckan import model
 
 
 @pytest.fixture
 def apply_permissions_for_service_setup():
     import ckan.model as model
     apply_permissions_for_service_model.init_table(model.meta.engine)
+
+
+@pytest.fixture
+def drop_db():
+    model.Session.close_all()
+
+    model.repo.clean_db()
+    model.repo.init_db()
+
+

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/fixtures.py
@@ -16,5 +16,3 @@ def drop_db():
 
     model.repo.clean_db()
     model.repo.init_db()
-
-

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -267,7 +267,6 @@ class TestApplyPermissionsForServicePlugin():
                     {u"user": user3["name"], "ignore_auth": False},
                     **application)
 
-
         applications = call_action('service_permission_application_list',
                                    {'user': user3['name'], 'ignore_auth': True},
                                    target_subsystem_id=target_subsystem['id'])

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -206,10 +206,9 @@ class TestApplyPermissionsForServicePlugin():
         assert app['organization']['id'] == application['organization_id']
         assert app['target_organization']['id'] == application['target_organization_id']
 
-    @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'apply_permissions_for_service_setup')
-    def test_application_with_intermediate_organization(self):
-        orgs = call_action('organization_list', {})
-        print(orgs)
+    def test_application_with_intermediate_organization(self, drop_db, migrate_db_for):
+
+        migrate_db_for('apply_permissions_for_service')
 
         user1 = User()
         org1_users = [{"name": user1["name"], "capacity": "admin"}]
@@ -268,14 +267,11 @@ class TestApplyPermissionsForServicePlugin():
                     {u"user": user3["name"], "ignore_auth": False},
                     **application)
 
-        print(application)
 
         applications = call_action('service_permission_application_list',
                                    {'user': user3['name'], 'ignore_auth': True},
                                    target_subsystem_id=target_subsystem['id'])
 
-        from pprint import pprint
-        pprint(applications)
         assert len(applications) == 1
         app = applications[0]
         assert app['organization_id'] == application['organization_id']

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -37,13 +37,13 @@ class TestApplyPermissionsForServicePlugin():
         application = dict(
                     organization_id=organization2['id'],
                     target_organization_id=organization1['id'],
-                    business_code=organization2['xroad_membercode'],
+                    member_code=organization2['xroad_membercode'],
                     contact_name=user2['name'],
                     contact_email=user2['email'],
                     ip_address_list=['1.2.3.4'],
-                    subsystem_id=dataset1['id'],
-                    subsystem_code=dataset2['xroad_subsystemcode'],
-                    service_code_list=[resource1['id']]
+                    target_subsystem_id=dataset1['id'],
+                    subsystem_id=dataset2['xroad_subsystemcode'],
+                    service_id_list=[resource1['id']]
                     )
         call_action('service_permission_application_create',
                     {u"user": user2["name"], "ignore_auth": False},
@@ -82,19 +82,19 @@ class TestApplyPermissionsForServicePlugin():
                         {u"user": user2["name"], "ignore_auth": False},
                         organization_id=organization2['id'],
                         target_organization_id=organization1['id'],
-                        business_code=organization2['xroad_membercode'],
+                        member_code=organization2['xroad_membercode'],
                         contact_name=user2['name'],
                         contact_email=user2['email'],
                         ip_address_list=['1.2.3.4'],
-                        subsystem_id=dataset1['id'],
-                        subsystem_code=dataset1['xroad_subsystemcode'],
-                        service_code_list='.'.join([resource1['xroad_servicecode'],
-                                                    resource1['xroad_serviceversion']])
+                        target_subsystem_id=dataset1['id'],
+                        subsystem_id=dataset1['xroad_subsystemcode'],
+                        service_id_list='.'.join([resource1['xroad_servicecode'],
+                                                 resource1['xroad_serviceversion']])
                         )
 
         applications = call_action('service_permission_application_list',
                                    {'ignore_auth': True},
-                                   subsystem_id=dataset1['id'])
+                                   target_subsystem_id=dataset1['id'])
         assert len(applications) == 0
 
     def test_user_creates_application_with_an_invalid_ip_list(self):
@@ -121,13 +121,13 @@ class TestApplyPermissionsForServicePlugin():
         application = dict(
                     organization_id=organization2['id'],
                     target_organization_id=organization1['id'],
-                    business_code=organization2['xroad_membercode'],
+                    member_code=organization2['xroad_membercode'],
                     contact_name=user2['name'],
                     contact_email=user2['email'],
                     ip_address_list=[''],
-                    subsystem_id=dataset1['id'],
-                    subsystem_code=dataset2['xroad_subsystemcode'],
-                    service_code_list=[resource1['id']]
+                    target_subsystem_id=dataset1['id'],
+                    subsystem_id=dataset2['xroad_subsystemcode'],
+                    service_id_list=[resource1['id']]
                     )
 
         with pytest.raises(ValidationError):
@@ -135,3 +135,73 @@ class TestApplyPermissionsForServicePlugin():
                         {u"user": user2["name"], "ignore_auth": False},
                         **application
                         )
+
+    def test_application_format(self):
+        user1 = User()
+        org1_users = [{"name": user1["name"], "capacity": "admin"}]
+        target_organization = Organization(id='TEST.ORG.1234567-1',
+                                           users=org1_users,
+                                           xroad_instance='TEST',
+                                           xroad_memberclass='ORG',
+                                           xroad_membercode='1234567-1')
+
+        target_subsystem = Dataset(owner_org=target_organization['id'],
+                                   name='target_subsystem_name',
+                                   id='TEST.ORG.1234567-1.target_subsystem_name')
+
+        resource1 = Resource(package_id=target_subsystem['id'],
+                             id='TEST.ORG.1234567-1.target_subsystem_name.service_name',
+                             xroad_servicecode='service_name',
+                             xroad_serviceversion='v1',
+                             harvested_from_xroad=True)
+
+        user2 = User()
+        org2_users = [{"name": user2["name"], "capacity": "admin"}]
+        organization = Organization(id='TEST.ORG.7654321-2',
+                                    users=org2_users,
+                                    xroad_instance='TEST',
+                                    xroad_memberclass='ORG',
+                                    xroad_membercode='7654321-2')
+
+        subsystem = Dataset(owner_org=organization['id'],
+                            name='subsystem_name',
+                            xroad_subsystemcode='subsystem_name',
+                            id='TEST.ORG.7654321-2.subsystem_name')
+
+        application = dict(
+                    organization_id=organization['id'],
+                    member_code=organization['xroad_membercode'],
+                    target_organization_id=target_organization['id'],
+                    contact_name=user2['name'],
+                    contact_email=user2['email'],
+                    ip_address_list=['1.2.3.4'],
+                    target_subsystem_id=target_subsystem['id'],
+                    subsystem_id=subsystem['id'],
+                    service_id_list=[resource1['id']]
+                    )
+
+        call_action('service_permission_application_create',
+                    {u"user": user2["name"], "ignore_auth": False},
+                    **application
+                    )
+
+        applications = call_action('service_permission_application_list',
+                                   {'user': user2['name'], 'ignore_auth': True},
+                                   target_subsystem_id=target_subsystem['id'])
+
+        assert len(applications) == 1
+        app = applications[0]
+        assert app['organization_id'] == application['organization_id']
+        assert app['target_organization_id'] == application['target_organization_id']
+        assert app['member_code'] == application['member_code']
+        assert app['contact_name'] == application['contact_name']
+        assert app['contact_email'] == application['contact_email']
+        assert app['ip_address_list'] == application['ip_address_list']
+        assert app['target_subsystem_id'] == application['target_subsystem_id']
+        assert app['subsystem_id'] == application['subsystem_id']
+        assert app['service_id_list'] == application['service_id_list']
+        assert app['target_subsystem']['id'] == application['target_subsystem_id']
+        assert app['subsystem']['id'] == application['subsystem_id']
+        assert app['services'][0]['id'] == resource1['id']
+        assert app['organization']['id'] == application['organization_id']
+        assert app['target_organization']['id'] == application['target_organization_id']

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -243,6 +243,15 @@ def settings_post(context, subsystem_id):
                 qualified=True
             )
             data_dict['additional_file_url'] = additional_file_url
+        elif not data_dict['original_additional_filename'] in additional_file_url:
+            ''' If additional_file_url doesn't contain the original filename but it does contain
+                http(s) we can assume it's been updated with an url instead of a file and we need
+                to update the filename as well in order not to show the old filename for the
+                download button '''
+            # full url
+            data_dict['original_additional_filename'] = additional_file_url
+            # vs filename?
+            # data_dict['original_additional_filename'] = additional_file_url.split('/')[-1]
 
     try:
         toolkit.get_action('service_permission_settings_update')(context, data_dict)

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -142,7 +142,7 @@ def view(application_id):
 def preview(target_subsystem_id):
     try:
         context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
-        toolkit.check_access('service_permission_settings', context, {"target_subsystem_id": target_subsystem_id})
+        toolkit.check_access('service_permission_settings', context, {"subsystem_id": target_subsystem_id})
         return new_get(context, target_subsystem_id, preview=True)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -12,18 +12,6 @@ log = getLogger(__name__)
 apply_permissions = Blueprint("apply_permissions", __name__, url_prefix=u'/apply_permissions_for_service')
 
 
-def index():
-    try:
-        subsystem_id = toolkit.request.args.get('id')
-        context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
-        data_dict = {'subsystem_id': subsystem_id}
-        applications = toolkit.get_action('service_permission_application_list')(context, data_dict)
-        extra_vars = {'applications': applications}
-        return toolkit.render('apply_permissions_for_service/index.html', extra_vars=extra_vars)
-    except toolkit.NotAuthorized:
-        toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
-
-
 def dashboard(app_type='sent'):
     context = {
         u'user': toolkit.g.user,
@@ -47,28 +35,28 @@ def new_post(context, subsystem_id):
 
     data_dict = {
             'target_organization_id': form.get('target_organization_id'),
-            'intermediate_organization': None,
-            'business_code': form.get('businessCode'),
-            'intermediate_business_code': None,
-            'contact_name': form.get('contactName'),
-            'contact_email': form.get('contactEmail'),
-            'subsystem_id': form.get('subsystemId'),
-            'subsystem_code': form.get('subsystemCode'),
-            'service_code_list': form.getlist('serviceCode'),
-            'ip_address_list': [ip for ip in form.getlist('ipAddress') if ip],
-            'request_date': form.get('requestDate'),
-            'usage_description': form.get('usageDescription'),
+            'intermediate_organization_id': None,
+            'member_code': form.get('member_code'),
+            'intermediate_member_code': None,
+            'contact_name': form.get('contact_name'),
+            'contact_email': form.get('contact_email'),
+            'target_subsystem_id': form.get('target_subsystem_id'),
+            'subsystem_id': form.get('subsystem_id'),
+            'service_id_list': form.getlist('service_id_list'),
+            'ip_address_list': [ip for ip in form.getlist('ip_address_list') if ip],
+            'request_date': form.get('request_date'),
+            'usage_description': form.get('usage_description'),
             'file': files.get('file'),
             'file_url': form.get('file_url'),
             'clear_upload': form.get('clear_upload'),
             }
 
-    if form.get('enableIntermediateOrganization'):
-        data_dict['intermediate_organization'] = form.get('intermediateOrganization')
-        data_dict['intermediate_business_code'] = form.get('intermediateBusinessCode')
+    if form.get('enable_intermediate_organization'):
+        data_dict['intermediate_organization_id'] = form.get('intermediate_organization_id')
+        data_dict['intermediate_member_code'] = form.get('intermediate_member_code')
 
     try:
-        organization = toolkit.get_action('organization_show')(context, {'id': form['organization']})
+        organization = toolkit.get_action('organization_show')(context, {'id': form['organization_id']})
         data_dict['organization_id'] = organization['id']
 
         if toolkit.check_ckan_version(min_version='2.5'):
@@ -90,9 +78,9 @@ def new_post(context, subsystem_id):
     return toolkit.render('apply_permissions_for_service/sent.html')
 
 
-def new_get(context, subsystem_id, errors={}, values={}, preview=False):
+def new_get(context, target_subsystem_id, errors={}, values={}, preview=False):
     service_id = toolkit.request.args.get('service_id')
-    package = toolkit.get_action('package_show')(context, {'id': subsystem_id})
+    package = toolkit.get_action('package_show')(context, {'id': target_subsystem_id})
 
     if (package.get('service_permission_settings', {}).get('delivery_method') == "none"
             or package.get('service_permission_settings', {}).get('delivery_method') is None) and preview is False:
@@ -109,7 +97,7 @@ def new_get(context, subsystem_id, errors={}, values={}, preview=False):
         }).get('results', []) if user_managed_organizations else []
 
     extra_vars = {
-            'subsystem_id': subsystem_id,
+            'target_subsystem_id': target_subsystem_id,
             'service_id': service_id,
             'pkg': package,
             'service': next((r for r in package.get('resources', []) if r['id'] == service_id), None),
@@ -127,15 +115,15 @@ def new_get(context, subsystem_id, errors={}, values={}, preview=False):
     return toolkit.render('apply_permissions_for_service/new.html', extra_vars=extra_vars)
 
 
-def new(subsystem_id):
+def new(target_subsystem_id):
     try:
         context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
         toolkit.check_access('service_permission_application_create', context, {})
 
         if toolkit.request.method == u'POST':
-            return new_post(context, subsystem_id)
+            return new_post(context, target_subsystem_id)
         else:
-            return new_get(context, subsystem_id)
+            return new_get(context, target_subsystem_id)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
@@ -151,24 +139,24 @@ def view(application_id):
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
 
-def preview(subsystem_id):
+def preview(target_subsystem_id):
     try:
         context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
-        toolkit.check_access('service_permission_settings', context, {"subsystem_id": subsystem_id})
-        return new_get(context, subsystem_id, preview=True)
+        toolkit.check_access('service_permission_settings', context, {"target_subsystem_id": target_subsystem_id})
+        return new_get(context, target_subsystem_id, preview=True)
     except toolkit.NotAuthorized:
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
 
-def manage(subsystem_id):
+def manage(target_subsystem_id):
     context = {u'user': toolkit.g.user, u'auth_user_obj': toolkit.g.userobj}
-    package = toolkit.get_action('package_show')(context, {'id': subsystem_id})
+    package = toolkit.get_action('package_show')(context, {'id': target_subsystem_id})
     toolkit.c.pkg_dict = package
 
-    data_dict = {'subsystem_id': package.get('id')}
+    data_dict = {'target_subsystem_id': package.get('id')}
     applications = toolkit.get_action('service_permission_application_list')(context, data_dict)
     extra_vars = {
-            'subsystem_id': subsystem_id,
+            'target_subsystem_id': target_subsystem_id,
             'pkg_dict': package,
             'applications': applications
             }
@@ -277,13 +265,13 @@ def settings(subsystem_id):
         toolkit.abort(403, toolkit._(u'Not authorized to see this page'))
 
 
-apply_permissions.add_url_rule('/', 'list_permission_applications', view_func=index)
 apply_permissions.add_url_rule('/dashboard/<app_type>', 'dashboard', view_func=dashboard)
 apply_permissions.add_url_rule('/dashboard', 'dashboard', view_func=dashboard)
-apply_permissions.add_url_rule('/new/<subsystem_id>', 'new_permission_application', view_func=new, methods=['GET', 'POST'])
+apply_permissions.add_url_rule('/new/<target_subsystem_id>', 'new_permission_application',
+                               view_func=new, methods=['GET', 'POST'])
 apply_permissions.add_url_rule('/view/<application_id>', 'view_permission_application', view_func=view)
-apply_permissions.add_url_rule('/preview/<subsystem_id>', 'preview_permission_application', view_func=preview)
-apply_permissions.add_url_rule('/manage/<subsystem_id>', 'manage_permission_applications', view_func=manage)
+apply_permissions.add_url_rule('/preview/<target_subsystem_id>', 'preview_permission_application', view_func=preview)
+apply_permissions.add_url_rule('/manage/<target_subsystem_id>', 'manage_permission_applications', view_func=manage)
 apply_permissions.add_url_rule('/settings/<subsystem_id>', 'permission_application_settings',
                                view_func=settings, methods=['GET', 'POST'])
 

--- a/ckanext/ckanext-apply_permissions_for_service/conftest.py
+++ b/ckanext/ckanext-apply_permissions_for_service/conftest.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+pytest_plugins = [
+    u'ckanext.apply_permissions_for_service.tests.fixtures'
+]


### PR DESCRIPTION
# Description
There were quite a bit wrong with apply_permissions_for_service so close to the feature release. A lot of time went to (mostly manual) testing of the feature and unfortunately big chunk of it went to trying to understand the code with all the inconsistencies in naming conventions both in casing (camelCase vs snake_case) and names themselves (subsystem_id instead of target_subsystem_id, subsystem_code instead of subsystem_id, business_code instead of member_code, etc etc.). In addition this change includes a number of fixes ranging from minor tweak to rather significant fix (links didn't open in new tabs & application reception notification email talked about accepting the application when such functionality doesn't exist VS requester subsystem and target subsystem were reversed everywhere)

## Jira ticket reference: [LIKA-572](https://jira.dvv.fi/browse/LIKA-572)

## What has changed:
* Fixed the mix up with requester and target subsystems
* Did a sizeable refactoring to apply_permissions model (while it's still not in production) for clarity and consistency with naming elsewhere in the project
   * Renamed 'subsystem_id' to 'target_subsystem_id' and 'subsystem' to 'target_subsystem'
   * Renamed 'subsystem_code' to 'subsystem_id' and 'requester_subsystem' to 'subsystem'
   * Renamed  'business_code' to 'member_code'
   * Renamed 'intermediate_business_code' to 'intermediate_member_code'
   * Renamed 'service_code_list' to 'service_id_list'
   * Renamed 'organization' to 'organization_id'
   * Renamed 'intermediate_organization' to 'intermediate_organization_id'
* Removed the word accept ('hyväksyä') from the notification email and replaced it with check ('tarkistaa') as there's no way to accept the applications in api-catalog
* Fixed additional_application_info file upload to show the selected file/url
* Fixed additional_application_info file download to show correct filename/url if uploaded file was replaced with an url
* Fixed FILE delivery (c89d77aaf4d62383a4a6c1b0e0642baec7fee0ba mistakenly refers to web delivery) link to correctly handle external url to the application pdf (previously always appended site_url thus breaking the external url) 
* Changed a number of links to open into a new tab instead of taking out of api-catalog (for example the additional info file download when the next step still asks you to upload the filled file)
* Added created timestamp to apply_permissions model for future use (sorting/filtering of applications as they can't be deleted or handled in any other way)


## Checklist  

- [x] Contains schema changes.
- [x] Schema changes require migration of existing data.
- [x] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No


