### PR TITLE
LIKA-542: Fix api-verifier install

### DIFF
--- a/ansible/roles/diagnostics/tasks/api-verifier.yml
+++ b/ansible/roles/diagnostics/tasks/api-verifier.yml
@@ -1,5 +1,21 @@
 ---
+- name: Ensure api-verifier path exists
+  when: api_verifier is defined
+  file: path={{ api_verifier.path }} state=directory mode="0700"
+
+- name: Install api-verifier
+  when: api_verifier is defined
+  copy:
+    src: "../tools/api-verifier/{{ item }}"
+    dest: "{{ api_verifier.path }}"
+  with_items:
+    - "api-verifier.py"
+    - "requirements.txt"
+    - "{{ api_verifier.spec }}"
+    - "{{ api_verifier.validation }}"
+
 - name: Install api-verifier requirements
+  when: api_verifier is defined
   pip: requirements="{{ api_verifier.path }}/requirements.txt" virtualenv={{ virtualenv }} chdir="{{ api_verifier.path }}/"
 
 - name: Install api-verifier cronjob
@@ -9,7 +25,8 @@
     special_time: weekly
     job: >
       {{ virtualenv }}/bin/python {{ api_verifier.path }}/api-verifier.py
-      {{ api_verifier.spec }} {{ api_verifier.validation }}
+      {{ api_verifier.path }}/{{ api_verifier.spec }}
+      {{ api_verifier.path }}/{{ api_verifier.validation }}
       --email-server {{ email.smtp_server }}
       --email-from {{ email.from }}
       --email-to {{ api_verifier.email }}

--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -142,6 +142,6 @@ developers:
 
 api_verifier:
   path: "{{ server_path }}/tools/api-verifier"
-  spec: "{{ server_path }}/tools/api-verifier/xroad-catalog-qa_spec.json"
-  validation: "{{ server_path }}/tools/api-verifier/xroad-catalog-qa_validation.json"
+  spec: "xroad-catalog-qa_spec.json"
+  validation: "xroad-catalog-qa_validation.json"
   email: "{{ ckan_fault_recipients|join(',') }}"


### PR DESCRIPTION
# Description
Api-verifier was not correctly installed to remote

## Jira ticket reference: [LIKA-542](https://jira.dvv.fi/browse/LIKA-542)

## What has changed:
- Add copying the files to ansible
- Use relative paths for spec/validation files in config

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No



