### PR TITLE
LIKA-270: Always show broken links menu item in organizations

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
@@ -21,9 +21,7 @@
       {{ h.build_nav_icon(group_type + '_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
       {% if h.check_access('organization_update', {'id': c.group_dict.name} ) %}
         {{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=c.group_dict.id) }}
-        {% if h.organization_has_broken_links(c.group_dict.id) %}
-          {{ h.build_nav_icon('broken_links.organization_read', _('Broken links'), organization_id=c.group_dict.id) }}
-        {% endif %}
+        {{ h.build_nav_icon('broken_links.organization_read', _('Broken links'), organization_id=c.group_dict.id) }}
       {% endif %}
       {% if h.check_access('read_members') %}
         {{ h.build_nav_icon('organization.members', _('Members'), id=c.group_dict.name) }}


### PR DESCRIPTION
# Description
...provided the user can access it

## Jira ticket reference: [LIKA-270](https://jira.dvv.fi/browse/LIKA-270)

## What has changed:
- Remove condition from organization template

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

