### PR TITLE
LIKA-565: Fix permission application email

### DIFF
--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/logic/action.py
@@ -95,7 +95,7 @@ def service_permission_application_create(context, data_dict):
 
     # Need sysadmin privileges to see permission_application_settings
     sysadmin_context = {'ignore_auth': True, 'use_cache': False}
-    package = tk.get_action('package_show')(sysadmin_context, {'id': subsystem_id})
+    package = tk.get_action('package_show')(sysadmin_context, {'id': target_subsystem_id})
     owner_org = tk.get_action('organization_show')(context, {'id': package['owner_org']})
 
     application_id = model.ApplyPermission.create(organization_id=organization_id,

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -66,7 +66,7 @@
 
   <p>Voit halutessasi tarkistaa pyynnön alijärjestelmäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.target_subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
 
-  <p>Ohjeita ja lisätietoja liitynnän luvittamisesta ja alijärjestelmien liittämisestä toisiinsa löydät <a href="https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/591ac1e314bbb10001966f9c">täältä</a> . Tarvittaessa ota yhteys Suomi.fi-palveluväylän asiakaspalveluun osoitteessa palveluvayla@palveluvayla.fi.</p>
+  <p>Ohjeita ja lisätietoja alijärjestelmän luvittamisesta ja alijärjestelmien liittämisestä toisiinsa löydät <a href="https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/591ac1e314bbb10001966f9c">täältä</a> . Tarvittaessa ota yhteys Suomi.fi-palveluväylän asiakaspalveluun osoitteessa palveluvayla@palveluvayla.fi.</p>
 
 
   <p>Tähän viestiin ei voi vastata.</p>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/templates/apply_permissions_for_service/notification_email.html
@@ -64,7 +64,7 @@
   </blockquote>
   </p>
 
-  <p>Voit halutessasi tarkistaa pyynnön Liityntäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.target_subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
+  <p>Voit halutessasi tarkistaa pyynnön alijärjestelmäsi sivulla {% link_for 'Liityntäkatalogissa', named_route='dataset.read', id=application.target_subsystem.name, _external=True %}. Sovi sen jälkeen luvan pyytäjän kanssa erikseen palomuuriavaukset ja muut käytännön toimet.</p>
 
   <p>Ohjeita ja lisätietoja liitynnän luvittamisesta ja alijärjestelmien liittämisestä toisiinsa löydät <a href="https://palveluhallinta.suomi.fi/fi/tuki/artikkelit/591ac1e314bbb10001966f9c">täältä</a> . Tarvittaessa ota yhteys Suomi.fi-palveluväylän asiakaspalveluun osoitteessa palveluvayla@palveluvayla.fi.</p>
 


### PR DESCRIPTION
# Description
Service permission application email sending did not work.

## Jira ticket reference: [LIKA-565](https://jira.dvv.fi/browse/LIKA-565)

## What has changed:
- Use target subsystem information when determining email recipient
- Fix email terminology

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

