### PR TITLE
LIKA-579: Add privacy statement to the footer

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-16 06:35+0000\n"
+"POT-Creation-Date: 2023-06-19 10:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,24 +26,24 @@ msgstr ""
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:854
+#: ckanext/apicatalog/plugin.py:855
 #: ckanext/apicatalog/templates/package/read.html:67
 #: ckanext/apicatalog/templates/package/snippets/resources.html:8
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:855
+#: ckanext/apicatalog/plugin.py:856
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:856
+#: ckanext/apicatalog/plugin.py:857
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:857
+#: ckanext/apicatalog/plugin.py:858
 msgid "Formats"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:10
 #: ckanext/apicatalog/templates/apicatalog_header.html:41
-#: ckanext/apicatalog/templates/footer.html:6
+#: ckanext/apicatalog/templates/footer.html:8
 msgid "API Catalog"
 msgstr ""
 
@@ -512,21 +512,25 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:7
+#: ckanext/apicatalog/templates/footer.html:9
 msgid ""
 "The service is being developed by the Digital and Population Data Services "
 "Agency."
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:12
+#: ckanext/apicatalog/templates/footer.html:14
+msgid "Privacy statement"
+msgstr ""
+
+#: ckanext/apicatalog/templates/footer.html:15
 msgid "Give feedback"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:22
+#: ckanext/apicatalog/templates/footer.html:25
 msgid "@Suomifiyritys"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:27
+#: ckanext/apicatalog/templates/footer.html:30
 msgid "@Suomifiyritykselle"
 msgstr ""
 
@@ -1317,7 +1321,7 @@ msgid "X-Road errors"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:32
-#: ckanext/apicatalog/templates/organization/read_base.html:29
+#: ckanext/apicatalog/templates/organization/read_base.html:27
 msgid "Members"
 msgstr ""
 
@@ -1432,7 +1436,7 @@ msgstr ""
 msgid "There are currently no APIs for this organization"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/read_base.html:25
+#: ckanext/apicatalog/templates/organization/read_base.html:24
 msgid "Broken links"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/fi/LC_MESSAGES/ckanext-apicatalog.po
@@ -17,10 +17,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-01-16 06:35+0000\n"
+"POT-Creation-Date: 2023-06-19 10:32+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
 "Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023\n"
-"Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
+"Language-Team: Finnish (https://app.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -37,24 +37,24 @@ msgstr ""
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:854
+#: ckanext/apicatalog/plugin.py:855
 #: ckanext/apicatalog/templates/package/read.html:67
 #: ckanext/apicatalog/templates/package/snippets/resources.html:8
 msgid "Services"
 msgstr "Palvelut"
 
-#: ckanext/apicatalog/plugin.py:855
+#: ckanext/apicatalog/plugin.py:856
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr "Organisaatio"
 
-#: ckanext/apicatalog/plugin.py:856
+#: ckanext/apicatalog/plugin.py:857
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr "Asiasanat"
 
-#: ckanext/apicatalog/plugin.py:857
+#: ckanext/apicatalog/plugin.py:858
 msgid "Formats"
 msgstr "Tiedostomuodot"
 
@@ -519,7 +519,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:10
 #: ckanext/apicatalog/templates/apicatalog_header.html:41
-#: ckanext/apicatalog/templates/footer.html:6
+#: ckanext/apicatalog/templates/footer.html:8
 msgid "API Catalog"
 msgstr "Liityntäkatalogi"
 
@@ -567,21 +567,25 @@ msgstr "Kirjaudu sisään"
 msgid "Register"
 msgstr "Rekisteröidy"
 
-#: ckanext/apicatalog/templates/footer.html:7
+#: ckanext/apicatalog/templates/footer.html:9
 msgid ""
 "The service is being developed by the Digital and Population Data Services "
 "Agency."
 msgstr "Verkkopalvelun kehittämisestä vastaa Digi- ja väestötietovirasto."
 
-#: ckanext/apicatalog/templates/footer.html:12
+#: ckanext/apicatalog/templates/footer.html:14
+msgid "Privacy statement"
+msgstr "Tietosuojaseloste"
+
+#: ckanext/apicatalog/templates/footer.html:15
 msgid "Give feedback"
 msgstr "Anna palautetta"
 
-#: ckanext/apicatalog/templates/footer.html:22
+#: ckanext/apicatalog/templates/footer.html:25
 msgid "@Suomifiyritys"
 msgstr "@Suomifiyritys"
 
-#: ckanext/apicatalog/templates/footer.html:27
+#: ckanext/apicatalog/templates/footer.html:30
 msgid "@Suomifiyritykselle"
 msgstr "@Suomifiyritykselle"
 
@@ -1423,7 +1427,7 @@ msgid "X-Road errors"
 msgstr "Liityntäpalvelimen virhetilanteet"
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:32
-#: ckanext/apicatalog/templates/organization/read_base.html:29
+#: ckanext/apicatalog/templates/organization/read_base.html:27
 msgid "Members"
 msgstr "Jäsenet"
 
@@ -1542,7 +1546,7 @@ msgstr "Luettelo valitun organisaation alijärjestelmistä"
 msgid "There are currently no APIs for this organization"
 msgstr "Organisaatiolla ei ole aktiivisia alijärjestelmiä"
 
-#: ckanext/apicatalog/templates/organization/read_base.html:25
+#: ckanext/apicatalog/templates/organization/read_base.html:24
 msgid "Broken links"
 msgstr ""
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/sv/LC_MESSAGES/ckanext-apicatalog.po
@@ -1,24 +1,24 @@
 # Translations template for ckanext-apicatalog.
-# Copyright (C) 2022 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-apicatalog
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 # 
 # Translators:
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2022
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2022
-# Suvi Nuttunen, 2022
-# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022
+# Suvi Nuttunen, 2023
+# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-12-21 14:22+0000\n"
+"POT-Creation-Date: 2023-06-19 10:32+0000\n"
 "PO-Revision-Date: 2022-05-05 05:41+0000\n"
-"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2022\n"
-"Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
+"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023\n"
+"Language-Team: Swedish (https://app.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -35,23 +35,24 @@ msgstr ""
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:852
+#: ckanext/apicatalog/plugin.py:855
 #: ckanext/apicatalog/templates/package/read.html:67
+#: ckanext/apicatalog/templates/package/snippets/resources.html:8
 msgid "Services"
 msgstr "Tjänster"
 
-#: ckanext/apicatalog/plugin.py:853
+#: ckanext/apicatalog/plugin.py:856
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr "Organisation"
 
-#: ckanext/apicatalog/plugin.py:854
+#: ckanext/apicatalog/plugin.py:857
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr "Ämnesord"
 
-#: ckanext/apicatalog/plugin.py:855
+#: ckanext/apicatalog/plugin.py:858
 msgid "Formats"
 msgstr ""
 
@@ -81,21 +82,22 @@ msgstr "Namn på engelska"
 
 #: ckanext/apicatalog/translations.py:15
 msgid "Organization description"
-msgstr ""
+msgstr "Beskrivning av organisation"
 
 #: ckanext/apicatalog/translations.py:16
 msgid ""
 "A general, concise, and easy-to-understand description of the organization."
 msgstr ""
+"En allmän, kortfattad och lättförståelig beskrivning av organisationen."
 
 #: ckanext/apicatalog/translations.py:17
 msgid ""
 "A general, concise, and easy-to-understand description of the attachment."
-msgstr ""
+msgstr "En allmän, kortfattad och lättförståelig beskrivning av bilagan."
 
 #: ckanext/apicatalog/translations.py:18
 msgid "A general, concise, and easy-to-understand description of the service."
-msgstr ""
+msgstr "En allmän, kortfattad och lättförståelig beskrivning av tjänsten."
 
 #: ckanext/apicatalog/translations.py:19
 msgid "Description in Finnish"
@@ -111,7 +113,7 @@ msgstr "Beskrivning på engelska"
 
 #: ckanext/apicatalog/translations.py:22
 msgid "Write the organization's description"
-msgstr ""
+msgstr "Skriv organisationens beskrivning"
 
 #: ckanext/apicatalog/translations.py:23
 msgid "Other information and settings"
@@ -119,7 +121,7 @@ msgstr "Övrig information och inställningar"
 
 #: ckanext/apicatalog/translations.py:24
 msgid "Organization logo"
-msgstr ""
+msgstr "Organisationens logo"
 
 #: ckanext/apicatalog/translations.py:25
 msgid "The logo is displayed on the organization page in API Catalogue."
@@ -203,12 +205,16 @@ msgid ""
 "When service visibility is private, it is only visible to the owner "
 "organization or users from allowed organizations"
 msgstr ""
+"När tjänstens synlighet är begränsad är den endast synlig för "
+"ägarorganisationen eller användare från tillåtna organisationer"
 
 #: ckanext/apicatalog/translations.py:45
 msgid ""
 "When attachment visibility is private, it is only visible to the owner "
 "organization or users from allowed organizations"
 msgstr ""
+"När bilagans synlighet är begränsad är den endast synlig för "
+"ägarorganisationen eller användare från tillåtna organisationer"
 
 #: ckanext/apicatalog/translations.py:47
 msgid "Chargeable"
@@ -417,39 +423,59 @@ msgstr "Mellanhand organisation"
 msgid "Data processing"
 msgstr "Databehandling"
 
-#: ckanext/apicatalog/validators.py:54
+#: ckanext/apicatalog/translations.py:105
+msgid ""
+"Choose this if your organization acts as an intermediary for other "
+"organizations."
+msgstr ""
+"Välj detta om din organisation agerar som mellanhand för andra "
+"organisationer."
+
+#: ckanext/apicatalog/translations.py:106
+msgid ""
+"Choose this if your organization processes data outside the EU/EAA "
+"countries."
+msgstr "Välj detta om din organisation behandlar data utanför EU-/ESS-länder."
+
+#: ckanext/apicatalog/translations.py:107
+msgid "{number} dataset found for \"{query}\""
+msgid_plural "{number} datasets found for \"{query}\""
+msgstr[0] "{number} API hittades för \"{query}\""
+msgstr[1] "{number} API:er hittades för \"{query}\""
+
+#: ckanext/apicatalog/validators.py:56
 msgid "Package contains invalid resources"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:78 ckanext/apicatalog/validators.py:246
-#: ckanext/apicatalog/validators.py:284
+#: ckanext/apicatalog/validators.py:80 ckanext/apicatalog/validators.py:252
+#: ckanext/apicatalog/validators.py:290
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:81 ckanext/apicatalog/validators.py:249
-#: ckanext/apicatalog/validators.py:281
+#: ckanext/apicatalog/validators.py:83 ckanext/apicatalog/validators.py:255
+#: ckanext/apicatalog/validators.py:287
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:85 ckanext/apicatalog/validators.py:252
-#: ckanext/apicatalog/validators.py:286
+#: ckanext/apicatalog/validators.py:87 ckanext/apicatalog/validators.py:258
+#: ckanext/apicatalog/validators.py:292
 msgid "expecting JSON object"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:89
+#: ckanext/apicatalog/validators.py:91
 #, python-format
 msgid "Required language \"%s\" missing"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:97
+#: ckanext/apicatalog/validators.py:99
 msgid "Missing value"
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:131
+#: ckanext/apicatalog/validators.py:137
 msgid "Business id is incorrect format."
 msgstr ""
 
-#: ckanext/apicatalog/validators.py:149
+#: ckanext/apicatalog/validators.py:155
 msgid "Business id verification number does not match business id."
 msgstr ""
 
@@ -487,7 +513,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:10
 #: ckanext/apicatalog/templates/apicatalog_header.html:41
-#: ckanext/apicatalog/templates/footer.html:6
+#: ckanext/apicatalog/templates/footer.html:8
 msgid "API Catalog"
 msgstr "API-katalogen"
 
@@ -535,7 +561,7 @@ msgstr "Logga in"
 msgid "Register"
 msgstr "Registrera dig"
 
-#: ckanext/apicatalog/templates/footer.html:7
+#: ckanext/apicatalog/templates/footer.html:9
 msgid ""
 "The service is being developed by the Digital and Population Data Services "
 "Agency."
@@ -543,15 +569,19 @@ msgstr ""
 "Myndigheten för digitalisering och befolkningsdata ansvarar för utvecklingen"
 " av webbtjänsten."
 
-#: ckanext/apicatalog/templates/footer.html:12
+#: ckanext/apicatalog/templates/footer.html:14
+msgid "Privacy statement"
+msgstr "Dataskyddsbeskrivning"
+
+#: ckanext/apicatalog/templates/footer.html:15
 msgid "Give feedback"
 msgstr "Ge respons"
 
-#: ckanext/apicatalog/templates/footer.html:22
+#: ckanext/apicatalog/templates/footer.html:25
 msgid "@Suomifiyritys"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:27
+#: ckanext/apicatalog/templates/footer.html:30
 msgid "@Suomifiyritykselle"
 msgstr ""
 
@@ -677,6 +707,7 @@ msgid "Total package count"
 msgstr "Totalt antal subsystem"
 
 #: ckanext/apicatalog/templates/admin/dashboard.html:58
+#: ckanext/apicatalog/templates/organization/bulk_process.html:71
 #: ckanext/apicatalog/templates/package/read.html:8
 #: ckanext/apicatalog/templates/snippets/package_item.html:34
 msgid "Private"
@@ -893,6 +924,7 @@ msgid "Not in menu"
 msgstr ""
 
 #: ckanext/apicatalog/templates/ckanext_pages/page.html:15
+#: ckanext/apicatalog/templates/organization/bulk_process.html:62
 #: ckanext/apicatalog/templates/organization/read_base.html:5
 #: ckanext/apicatalog/templates/package/read_base.html:10
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:28
@@ -1293,6 +1325,62 @@ msgstr ""
 msgid "Activity Stream"
 msgstr "Uppdateringshistorik"
 
+#: ckanext/apicatalog/templates/organization/bulk_process.html:3
+#: ckanext/apicatalog/templates/organization/bulk_process.html:11
+msgid "Edit datasets"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:15
+#: ckanext/apicatalog/templates/organization/index.html:19
+#: ckanext/apicatalog/templates/package/search.html:70
+msgid "Name Ascending"
+msgstr "Stigande enligt namn"
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:16
+#: ckanext/apicatalog/templates/organization/index.html:19
+#: ckanext/apicatalog/templates/package/search.html:71
+msgid "Name Descending"
+msgstr "Sjunkande enligt namn"
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:17
+msgid "Last Modified"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:29
+msgid "Make public"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:32
+msgid "Make private"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:36
+#: ckanext/apicatalog/templates/organization/members.html:75
+#: ckanext/apicatalog/templates/package/snippets/package_form.html:25
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
+#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:81
+#: ckanext/apicatalog/templates/user/edit_user_form.html:53
+msgid "Delete"
+msgstr "Radera"
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:46
+msgid "Select all"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:66
+#: ckanext/apicatalog/templates/snippets/package_item.html:41
+msgid "Draft"
+msgstr "Utkast"
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:68
+#: ckanext/apicatalog/templates/snippets/package_item.html:43
+msgid "Deleted"
+msgstr "Raderade"
+
+#: ckanext/apicatalog/templates/organization/bulk_process.html:83
+msgid "This organization has no datasets associated to it"
+msgstr ""
+
 #: ckanext/apicatalog/templates/organization/edit_base.html:15
 #: ckanext/apicatalog/templates/package/edit_base.html:14
 #: ckanext/apicatalog/templates/package/resource_edit_base.html:4
@@ -1304,19 +1392,19 @@ msgstr "Avbryt redigering"
 #: ckanext/apicatalog/templates/organization/read_base.html:20
 #: ckanext/apicatalog/templates/scheming/organization/about.html:5
 msgid "About the organization"
-msgstr ""
+msgstr "Organisationens uppgifter"
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:28
 msgid "Dataset visibility"
-msgstr ""
+msgstr "Subsystems synlighet"
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:29
 #: ckanext/apicatalog/templates/organization/read_base.html:23
 msgid "X-Road errors"
-msgstr ""
+msgstr "Anslutningsservers fel"
 
 #: ckanext/apicatalog/templates/organization/edit_base.html:32
-#: ckanext/apicatalog/templates/organization/read_base.html:26
+#: ckanext/apicatalog/templates/organization/read_base.html:27
 msgid "Members"
 msgstr "Medlemmar"
 
@@ -1331,54 +1419,58 @@ msgstr ""
 "användarrättigheter på olika nivåer för att skapa, redigera och publicera "
 "subsystem."
 
-#: ckanext/apicatalog/templates/organization/index.html:8
+#: ckanext/apicatalog/templates/organization/index.html:9
 msgid "{0} organizations"
 msgstr "{0} organisationer"
 
 #: ckanext/apicatalog/templates/organization/index.html:11
+msgid "with filter"
+msgstr ""
+
+#: ckanext/apicatalog/templates/organization/index.html:11
+#: ckanext/apicatalog/templates/organization/snippets/search_form.html:9
+msgid "Show only service providers"
+msgstr "Visa endast tjänsteleverantörer"
+
+#: ckanext/apicatalog/templates/organization/index.html:13
+#: ckanext/apicatalog/templates/organization/snippets/search_form.html:14
+msgid "Show organizations without APIs"
+msgstr "Visa alla organisationer"
+
+#: ckanext/apicatalog/templates/organization/index.html:19
 msgid "Service providers first"
 msgstr "Tjänsteleverantörerna först"
 
-#: ckanext/apicatalog/templates/organization/index.html:11
-#: ckanext/apicatalog/templates/package/search.html:70
-msgid "Name Ascending"
-msgstr "Stigande enligt namn"
-
-#: ckanext/apicatalog/templates/organization/index.html:11
-#: ckanext/apicatalog/templates/package/search.html:71
-msgid "Name Descending"
-msgstr "Sjunkande enligt namn"
-
-#: ckanext/apicatalog/templates/organization/index.html:25
+#: ckanext/apicatalog/templates/organization/index.html:33
 msgid "There are currently no organizations for this site"
 msgstr "Sidor"
 
-#: ckanext/apicatalog/templates/organization/index.html:27
+#: ckanext/apicatalog/templates/organization/index.html:35
 msgid "How about creating one?"
 msgstr "Vad sägs om att göra en?"
 
-#: ckanext/apicatalog/templates/organization/index.html:35
+#: ckanext/apicatalog/templates/organization/index.html:43
 #: ckanext/apicatalog/templates/package/search.html:64
 msgid "Filter list"
 msgstr "Avgränsa listan"
 
-#: ckanext/apicatalog/templates/organization/index.html:40
+#: ckanext/apicatalog/templates/organization/index.html:48
 msgid "Type in name of organization"
 msgstr "Skriv organisationens namn"
 
-#: ckanext/apicatalog/templates/organization/index.html:47
+#: ckanext/apicatalog/templates/organization/index.html:55
 #: ckanext/apicatalog/templates/organization/read.html:38
 #: ckanext/apicatalog/templates/package/search.html:29
 msgid "Next"
 msgstr "Nästa"
 
-#: ckanext/apicatalog/templates/organization/index.html:50
+#: ckanext/apicatalog/templates/organization/index.html:58
 #: ckanext/apicatalog/templates/organization/read.html:41
 #: ckanext/apicatalog/templates/package/search.html:32
 msgid "Previous"
 msgstr "Föregående"
 
-#: ckanext/apicatalog/templates/organization/index.html:52
+#: ckanext/apicatalog/templates/organization/index.html:60
 #: ckanext/apicatalog/templates/organization/read.html:43
 #: ckanext/apicatalog/templates/package/search.html:34
 msgid "Go to page"
@@ -1418,14 +1510,6 @@ msgstr ""
 msgid "Are you sure you want to delete this member?"
 msgstr "Är du säker på att du vill ta bort medlemmen?"
 
-#: ckanext/apicatalog/templates/organization/members.html:75
-#: ckanext/apicatalog/templates/package/snippets/package_form.html:25
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
-#: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:81
-#: ckanext/apicatalog/templates/user/edit_user_form.html:53
-msgid "Delete"
-msgstr "Radera"
-
 #: ckanext/apicatalog/templates/organization/new.html:3
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:45
 msgid "Create an Organization"
@@ -1433,11 +1517,15 @@ msgstr "Skapa en organisation"
 
 #: ckanext/apicatalog/templates/organization/read.html:17
 msgid "List of organization's subsystems"
-msgstr ""
+msgstr "Lista över subsystem av den valda organisationen"
 
 #: ckanext/apicatalog/templates/organization/read.html:29
 msgid "There are currently no APIs for this organization"
 msgstr "Organisationen har inga aktiva subsystem"
+
+#: ckanext/apicatalog/templates/organization/read_base.html:24
+msgid "Broken links"
+msgstr ""
 
 #: ckanext/apicatalog/templates/organization/snippets/organization_item.html:25
 msgid "View {organization_name}"
@@ -1451,14 +1539,6 @@ msgstr ""
 #: ckanext/apicatalog/templates/organization/snippets/search_form.html:5
 msgid "Filter by role"
 msgstr "Avgränsa organisationslistan"
-
-#: ckanext/apicatalog/templates/organization/snippets/search_form.html:9
-msgid "Show only service providers"
-msgstr "Visa endast tjänsteleverantörer"
-
-#: ckanext/apicatalog/templates/organization/snippets/search_form.html:14
-msgid "Show organizations without APIs"
-msgstr "Visa alla organisationer"
 
 #: ckanext/apicatalog/templates/package/edit_base.html:7
 msgid "Edit subsystem"
@@ -1514,7 +1594,7 @@ msgid "Request permission in organizations website"
 msgstr "Ansök om tillstånd på organisationens webbplats"
 
 #: ckanext/apicatalog/templates/package/read.html:47
-#: ckanext/apicatalog/templates/scheming/organization/about.html:9
+#: ckanext/apicatalog/templates/scheming/organization/about.html:13
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -1524,6 +1604,7 @@ msgid "Service bus identifier"
 msgstr "Kod i Informationsleden"
 
 #: ckanext/apicatalog/templates/package/read.html:68
+#: ckanext/apicatalog/templates/package/snippets/resources.html:20
 msgid "Attachments"
 msgstr "Bilagor"
 
@@ -1695,21 +1776,21 @@ msgstr ""
 "När tjänstens synlighet är begränsad är den endast synlig för "
 "ägarorganisationen eller användare från tillåtna organisationer"
 
-#: ckanext/apicatalog/templates/scheming/organization/about.html:17
+#: ckanext/apicatalog/templates/scheming/organization/about.html:8
+msgid "Logo of organization {org}"
+msgstr "Organisationens {org} logo"
+
+#: ckanext/apicatalog/templates/scheming/organization/about.html:21
 msgid "Contact Information"
 msgstr "Kontaktuppgifter"
 
-#: ckanext/apicatalog/templates/scheming/organization/about.html:59
+#: ckanext/apicatalog/templates/scheming/organization/about.html:63
 msgid "X-Road related information"
 msgstr "Uppgifter som hänför sig till X-Road"
 
-#: ckanext/apicatalog/templates/scheming/organization/about.html:85
+#: ckanext/apicatalog/templates/scheming/organization/about.html:92
 msgid "Additional information"
 msgstr "Mer information"
-
-#: ckanext/apicatalog/templates/scheming/organization/about.html:123
-msgid "Logo of organization {org}"
-msgstr "Organisationens {org} logo"
 
 #: ckanext/apicatalog/templates/scheming/organization/group_form.html:39
 msgid "Are you sure you want to delete this Organization?"
@@ -1861,14 +1942,6 @@ msgstr "vald"
 #: ckanext/apicatalog/templates/snippets/multiselect.html:25
 msgid "Not selected"
 msgstr "Inget valt"
-
-#: ckanext/apicatalog/templates/snippets/package_item.html:41
-msgid "Draft"
-msgstr "Utkast"
-
-#: ckanext/apicatalog/templates/snippets/package_item.html:43
-msgid "Deleted"
-msgstr "Raderade"
 
 #: ckanext/apicatalog/templates/snippets/package_item.html:51
 msgid "Popular"

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/footer.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/footer.html
@@ -1,4 +1,6 @@
 {% block footer %}
+{% set current_lang = request.environ.CKAN_LANG %}
+{% set lang_code = 'en' if current_lang == 'en_GB' else current_lang %}
 	<footer>
 		<div class="footer-top clearfix">
 			<div class="container">
@@ -9,6 +11,7 @@
 				<div class="footer-top-links col-xs-12 col-sm-8 col-lg-9">
 					<ul class="nav navbar footer-nav">
 						{{ h.build_nav_main() }}
+						<li><a href="{{'https://palveluhallinta.suomi.fi/%s/sivut/palveluvayla/palvelukuvaus/tietosuoja' % lang_code}}" target="_blank">{{_('Privacy statement')}}&nbsp;<i class="fal fa-external-link"></i></a></li>
 						{{ h.build_nav('contact.form', _('Give feedback')) }}
 					</ul>
 				</div>

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests/test_plugin.py
@@ -150,7 +150,6 @@ class TestApplyPermissionsForServicePlugin():
                                    id='TEST.ORG.1234567-1.target_subsystem_name')
 
         resource1 = Resource(package_id=target_subsystem['id'],
-                             id='TEST.ORG.1234567-1.target_subsystem_name.service_name',
                              xroad_servicecode='service_name',
                              xroad_serviceversion='v1',
                              harvested_from_xroad=True)
@@ -223,7 +222,6 @@ class TestApplyPermissionsForServicePlugin():
                                    id='TEST.ORG.1234567-1.target_subsystem_name')
 
         resource1 = Resource(package_id=target_subsystem['id'],
-                             id='TEST.ORG.1234567-1.target_subsystem_name.service_name',
                              xroad_servicecode='service_name',
                              xroad_serviceversion='v1',
                              harvested_from_xroad=True)


### PR DESCRIPTION
# Description
This PR adds localized but hardcoded link to the footer pointing to [Data Exchange Layer's privacy statement](https://palveluhallinta.suomi.fi/en/sivut/palveluvayla/palvelukuvaus/tietosuoja) as the leftmost hardcoded link (after the CMS page links)

## Jira ticket reference: [LIKA-579](https://jira.dvv.fi/browse/LIKA-579)

## What has changed:
* Add 'Privacy statement' link to the footer
* Update localizations

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No



