### PR TITLE
Update dependency generation to support newer pip

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -42,6 +42,12 @@
    virtualenv: "{{ virtualenv }}"
   register: ckan_installation
 
+- name: Install ckan
+  pip:
+    name: git+https://github.com/ckan/ckan.git@ckan-2.9.9#egg=ckan
+    editable: true
+    virtualenv: "{{ virtualenv }}"
+
 #- name: Install CKAN requirements
 #  pip: requirements={{ virtualenv }}/src/ckan/requirements.txt virtualenv={{ virtualenv }} state=latest
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,7 @@
--e git+https://github.com/ckan/ckan.git@ckan-2.9.9#egg=ckan[requirements]
+ckan[requirements] @ git+https://github.com/ckan/ckan.git@ckan-2.9.9
 
 # requirements of apicatalog
 testrepository==0.0.20
-typing
 uwsgi
 
 # harvest requires newer six

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile
 #
--e git+https://github.com/ckan/ckan.git@ckan-2.9.9#egg=ckan # [requirements] removed manually to stop resolving
-    # via -r requirements.in
 alembic==1.0.0
     # via ckan
 babel==2.7.0
@@ -24,6 +22,9 @@ chardet==4.0.0
     # via
     #   ckan
     #   requests
+# Removed manually, ckan is installed with ansible as this convention does not allow editable installs
+#ckan @ git+https://github.com/ckan/ckan.git@ckan-2.9.9
+    # via -r requirements.in
 click==7.1.2
     # via
     #   ckan
@@ -58,7 +59,7 @@ idna==2.10
     # via
     #   ckan
     #   requests
-importlib-metadata==5.0.0
+importlib-metadata==7.0.0
     # via markdown
 itsdangerous==1.1.0
     # via
@@ -168,8 +169,6 @@ testtools==2.5.0
     # via
     #   python-subunit
     #   testrepository
-typing==3.7.4.3
-    # via -r requirements.in
 tzlocal==1.3
     # via ckan
 unicodecsv==0.14.1
@@ -199,7 +198,7 @@ werkzeug[watchdog]==1.0.0
     # via
     #   ckan
     #   flask
-zipp==3.10.0
+zipp==3.17.0
     # via importlib-metadata
 zope-interface==4.3.2
     # via


### PR DESCRIPTION
Pip did not parse dependencies with old convention anymore, this updates it to new convention. ckan is installed separately as one cannot install it as editable anymore with requirements.