### PR TITLE
Replace deprecated ansible includes with import_tasks

### DIFF
--- a/ansible/deploy-all.yml
+++ b/ansible/deploy-all.yml
@@ -50,4 +50,4 @@
     - solr-reindex
     - diagnostics
   handlers:
-    - include: handlers/handlers.yml
+    - import_tasks: handlers/handlers.yml

--- a/ansible/deploy-extensions.yml
+++ b/ansible/deploy-extensions.yml
@@ -26,4 +26,4 @@
     - ckan
     - ckan-translations
   handlers:
-    - include: handlers/handlers.yml
+    - import_tasks: handlers/handlers.yml

--- a/ansible/frontend-build.yml
+++ b/ansible/frontend-build.yml
@@ -16,4 +16,4 @@
     - { role: ckan-ui }
     - ckan-translations
   handlers:
-    - include: handlers/handlers.yml
+    - import_tasks: handlers/handlers.yml

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -130,9 +130,9 @@
 - name: Install CKAN frontend requirements
   shell: npm install --only=prod chdir={{ virtualenv }}/src/ckan
 
-- include: patch.yml
+- import_tasks: patch.yml
 
-- include: database.yml
+- import_tasks: database.yml
 
 - name: Disable emails in cron
   cronvar: name="MAILTO" value="\"\""

--- a/ansible/roles/diagnostics/tasks/main.yml
+++ b/ansible/roles/diagnostics/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 
-- include: filebeat.yml
-- include: api-verifier.yml
+- import_tasks: filebeat.yml
+- import_tasks: api-verifier.yml

--- a/ansible/roles/os-base/tasks/main.yml
+++ b/ansible/roles/os-base/tasks/main.yml
@@ -6,8 +6,8 @@
   tags:
   - clear-cache
 
-- include: timezone.yml
-- include: hosts.yml
+- import_tasks: timezone.yml
+- import_tasks: hosts.yml
 
 
 - name: Copy apt sources.list
@@ -66,4 +66,4 @@
     name: fi_FI.UTF-8
     state: present
 
-- include: developer-users.yml
+- import_tasks: developer-users.yml

--- a/ansible/roles/piwik/tasks/main.yml
+++ b/ansible/roles/piwik/tasks/main.yml
@@ -3,14 +3,14 @@
 - name: Copy environment
   template: src=environment.j2 dest=/etc/environment mode="0644" owner=root group=root
 
-- include: packages_apt.yml
+- import_tasks: packages_apt.yml
   when: ansible_pkg_mgr == 'apt'
 
-- include: packages_yum.yml
+- import_tasks: packages_yum.yml
   when: ansible_pkg_mgr == 'yum'
 
-- include: piwik_ubuntu.yml
+- import_tasks: piwik_ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- include: piwik_redhat.yml
+- import_tasks: piwik_redhat.yml
   when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'

--- a/ansible/update-extension.yml
+++ b/ansible/update-extension.yml
@@ -17,4 +17,4 @@
   roles:
     - ckan-extension
   handlers:
-    - include: handlers/handlers.yml
+    - import_tasks: handlers/handlers.yml

--- a/ansible/vagrant-recreate-database.yml
+++ b/ansible/vagrant-recreate-database.yml
@@ -56,4 +56,4 @@
       service: name=supervisor state=restarted
 
   handlers:
-    - include: handlers/handlers.yml
+    - import_tasks: handlers/handlers.yml


### PR DESCRIPTION
# Description
Include statements have been deprecated in Ansible. Replace them with import_tasks

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
Add list of changes here.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

