### PR TITLE
LIKA-593: Only show subsystems with a description and services on front page

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -203,8 +203,17 @@ def get_homepage_organizations(count=1):
 
 
 def get_homepage_datasets(count=1):
-    datasets = get_action('package_search')({}, {'q': 'type:dataset', 'rows': count}).get('results', [])
-    return datasets
+    context = {}
+    datasets = package_generator(context=context,
+                                 query='res_name:*',
+                                 page_size=count*5,
+                                 sort='metadata_created desc',
+                                 dataset_type='dataset')
+
+    def criteria(dataset):
+        return dataset.get('notes') and len(dataset.get('resources', [])) > 0
+
+    return list(itertools.islice(filter(criteria, datasets), count))
 
 
 NEWS_CACHE = None

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/utils.py
@@ -5,14 +5,15 @@ from typing import List, Dict, Any
 ResourceDict = Dict[str, Any]
 
 
-def package_generator(context, query='*:*', page_size=1000, dataset_type='dataset'):
+def package_generator(context, query='*:*', page_size=1000,
+                      sort='score desc, metadata_modified desc', dataset_type='dataset'):
     package_search = toolkit.get_action('package_search')
 
     # Loop through all items. Each page has {page_size} items.
     # Stop iteration when all items have been looped.
     for index in itertools.count(start=0, step=page_size):
         data_dict = {'include_private': True, 'rows': page_size, 'q': query, 'start': index,
-                     'fq': '+dataset_type:' + dataset_type}
+                     'fq': '+dataset_type:' + dataset_type, 'sort': sort}
         data = package_search(context, data_dict)
         packages = data.get('results', [])
         for package in packages:


### PR DESCRIPTION
# Description
Front page featured subsystems should contain only subsystems with a description and at least one service

## Jira ticket reference: [LIKA-593](https://jira.dvv.fi/browse/LIKA-593)

## What has changed:
- Added `sort` parameter to `package_generator`, defaults to default sorting
- Modified `get_homepage_datasets` to filter the results based on criteria
  - The implementation fetches candidates in a paged fashion to reduce the likely amount of data fetched each front page load

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

