### PR TITLE
LIKA-604: Fix adding pdfs to permission applications

### DIFF
--- a/ansible/roles/ckan/files/patches/fix_detection_of_xlsx_mimetype.patch
+++ b/ansible/roles/ckan/files/patches/fix_detection_of_xlsx_mimetype.patch
@@ -1,0 +1,13 @@
+diff --git a/ckan/lib/uploader.py b/ckan/lib/uploader.py
+index ec4a6dfd0..360ebfbe0 100644
+--- a/ckan/lib/uploader.py
++++ b/ckan/lib/uploader.py
+@@ -220,7 +220,7 @@ class Upload(object):
+         if not mimetypes and not types:
+             return
+ 
+-        actual = magic.from_buffer(self.upload_file.read(1024), mime=True)
++        actual = magic.from_buffer(self.upload_file.read(2048), mime=True)
+         self.upload_file.seek(0, os.SEEK_SET)
+         err = {self.file_field: [
+             "Unsupported upload type: {actual}".format(actual=actual)]}

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -160,6 +160,10 @@ ckan.tracking_enabled = true
 
 ckan.max_resource_size = {{ ckan_max_resource_size }}
 
+ckan.upload.apply_permission.mimetypes = application/pdf image/png image/jpeg application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/vnd.ms-powerpoint application/vnd.openxmlformats-officedocument.presentationml.presentation application/vnd.oasis.opendocument.text application/vnd.oasis.opendocument.spreadsheet text/plain
+ckan.upload.apply_permission.types = application image text
+
+
 [loggers]
 
 keys = root, ckan, ckanext

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -33,6 +33,7 @@ ckan_patches:
   - { file: "email_attachment" }
   - { file: "fix_updating_resource_filesize" } # https://github.com/ckan/ckan/pull/7103
   - { file: "fix_resource_delete_auth" } # https://github.com/ckan/ckan/pull/7132
+  - { file: "fix_detection_of_xlsx_mimetype"} # https://github.com/ckan/ckan/pull/8088
 
 files_created_by_patches:
   - { file: '/usr/lib/ckan/default/src/ckan/ckan/lib/csrf_token.py'}

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -249,7 +249,7 @@ def settings_post(context, subsystem_id):
             upload.upload(max_size=uploader.get_max_resource_size())
         except toolkit.ValidationError as e:
             return settings_get(context, subsystem_id, e.error_dict, values=data_dict)
-        
+
         file_url = data_dict.get('file_url', '')
         if re.match('https?:', file_url) is None:
             # File has been updated, so update filename too

--- a/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
+++ b/ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/views.py
@@ -244,8 +244,12 @@ def settings_post(context, subsystem_id):
     if (data_dict.get('delivery_method') == 'file' and data_dict.get('file_url', None)):
         upload.update_data_dict(data_dict, 'file_url',
                                 'file', 'clear_upload')
-        upload.upload(max_size=uploader.get_max_resource_size())
 
+        try:
+            upload.upload(max_size=uploader.get_max_resource_size())
+        except toolkit.ValidationError as e:
+            return settings_get(context, subsystem_id, e.error_dict, values=data_dict)
+        
         file_url = data_dict.get('file_url', '')
         if re.match('https?:', file_url) is None:
             # File has been updated, so update filename too


### PR DESCRIPTION
# Description
In CKAN 2.9.8 default files types were limited in uploader due to security reasons, this adds allowed filetypes to permission applications, the list is based on what the UI says are allowed.

## Jira ticket reference: [LIKA-604](https://jira.dvv.fi/browse/LIKA-604)

## What has changed:
Adds exception handling to uploading permission application files.
Adds allowed file types to permission applications.
Fixes detection of XLSX files in ckan core.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

