### PR TITLE
Remove ckanext-contact submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "ckanext/ckanext-pages"]
 	path = ckanext/ckanext-pages
 	url = https://github.com/ckan/ckanext-pages.git
-[submodule "ckanext/ckanext-contact"]
-	path = ckanext/ckanext-contact
-	url = https://github.com/vrk-kpa/ckanext-contact.git
 [submodule "ckanext/ckanext-harvest"]
 	path = ckanext/ckanext-harvest
 	url = https://github.com/vrk-kpa/ckanext-harvest.git


### PR DESCRIPTION
# Description
Ckanext-contact was still in the repo. Remove the submodule.

## Jira ticket reference: [LIKA-597](https://jira.dvv.fi/browse/LIKA-597)

## What has changed:
- Remove submodule

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

