### PR TITLE
LIKA-599: disable swagger validation

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
@@ -85,7 +85,8 @@ window.onload = function() {
       SwaggerUIBundle.plugins.DownloadUrl
     ],
     layout: "StandaloneLayout",
-    translationLanguage: "{{ h.lang() }}"
+    translationLanguage: "{{ h.lang() }}",
+    validatorUrl: "none"
   })
 
   window.ui = ui


### PR DESCRIPTION
# Description
Disable OpenAPI validation with validation.swagger.io

## Jira ticket reference: [LIKA-599](https://jira.dvv.fi/browse/LIKA-599)

## What has changed:
- Set validation URL to "none", which disables validation

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

