### PR TITLE
LIKA-600: OpenAPI viewer style improvements

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
@@ -4,11 +4,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link rel="stylesheet" href="/fonts/source-sans-pro/css/source-sans-pro.css">
   <link rel="stylesheet" type="text/css" href="/swagger-ui/dist/swagger-ui.css" >
   {% asset 'apicatalog/openapi_view_css' %}
   {{ h.render_assets('style') }}
-  <link rel="icon" type="image/png" href="https://www2.gov.bc.ca/favicon.ico" />
+  <link rel="shortcut icon" href="/base/images/favicon.ico" />
   <style>
     html
     {
@@ -26,6 +26,20 @@
     body {
       margin:0;
       background: #fafafa;
+    }
+    .swagger-ui,
+    .swagger-ui .info .title,
+    .swagger-ui .info a,
+    .swagger-ui .opblock-tag,
+    .swagger-ui .opblock .opblock-summary-operation-id,
+    .swagger-ui .opblock .opblock-summary-path,
+    .swagger-ui .opblock .opblock-summary-path__deprecated,
+    .swagger-ui .opblock-description-wrapper p,
+    .swagger-ui .opblock-external-docs-wrapper p,
+    .swagger-ui .opblock-title_normal p,
+    .swagger-ui .opblock .opblock-section-header h4
+    {
+      font-family: 'SourceSansPro-Regular', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     }
   </style>
 </head>
@@ -86,7 +100,9 @@ window.onload = function() {
     ],
     layout: "StandaloneLayout",
     translationLanguage: "{{ h.lang() }}",
-    validatorUrl: "none"
+    validatorUrl: "none", // disable validation.swagger.io validation
+    supportedSubmitMethods: [], // remove "Try it out" button
+    requestSnippetsEnabled: false,
   })
 
   window.ui = ui


### PR DESCRIPTION
# Description
OpenAPI viewer had unnecessary and confusing default features enabled.

## Jira ticket reference: [LIKA-600](https://jira.dvv.fi/browse/LIKA-600)

## What has changed:
- Disable "Try it out" functionality as it doesn't work without a server address
- Remove snippets for the same reason
- Add a description to generated OpenAPI files to fix infinite spinner issue
- Harmonize fonts used with rest of the site

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

Add screenshots of design changes here if yes.

![image](https://github.com/vrk-kpa/api-catalog/assets/726461/3c73893e-2446-4218-9bf3-e3e7fcbb9b85)
