### PR TITLE
LIKA-600: Hide redundant OpenAPI description URL in preview

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/dataviewer/openapi_view.html
@@ -41,6 +41,9 @@
     {
       font-family: 'SourceSansPro-Regular', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     }
+    .info .title + .link {
+      display: none;
+    }
   </style>
 </head>
 


### PR DESCRIPTION
# Description
Duplicate OpenAPI description URL in Swagger preview

## Jira ticket reference: [LIKA-600](https://jira.dvv.fi/browse/LIKA-600)

## What has changed:
- Hide the link using CSS as there is no configuration for it

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://github.com/vrk-kpa/api-catalog/assets/726461/e2107b12-a4fa-468c-b2c7-60bf659f4caf)

