### PR TITLE
LIKA-606: Fix subsystem search result count, hide removed subsystems

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -919,6 +919,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
             result['num_resources'] = len(allowed_resources)
 
         search_results['results'] = results
+        search_results['count'] = len(results)
         return search_results
 
     # After package_show, filter out the resources which the user doesn't have access to
@@ -930,6 +931,9 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
         # Skip access check if sysadmin or auth is ignored
         if context.get('ignore_auth') or (context.get('auth_user_obj') and context.get('auth_user_obj').sysadmin):
             return data_dict
+
+        if data_dict.get('xroad_removed') is True:
+            raise toolkit.ObjectNotFound
 
         user_name = context.get('user')
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -238,3 +238,18 @@ class TestApicatalogPlugin():
         organization_with_python_list = Organization(old_business_ids=['1', '2'])
 
         assert organization_with_python_list['old_business_ids'] == ['1', '2']
+
+    def test_user_should_not_see_subsystems_removed_from_xroad(self, app):
+        org = factories.Organization()
+        subsystem = factories.Dataset(
+            owner_org=org["id"],
+            xroad_removed=True
+        )
+
+        with app.flask_app.test_request_context():
+            app.flask_app.preprocess_request()
+            with pytest.raises(ObjectNotFound):
+                get_action('package_show')({}, {"id": subsystem['id']})
+
+            search = get_action('package_search')({}, {})
+            assert all(result['id'] != subsystem['id'] for result in search['results'])


### PR DESCRIPTION
# Description
Subsystems removed form X-Road were visible with a direct link

## Jira ticket reference: [LIKA-606](https://jira.dvv.fi/browse/LIKA-606)

## What has changed:
- Raise ObjectNotFound for removed subsystems if the user is not a sysadmin
- Fix subsystem search result count

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

