### PR TITLE
LIKA-605: Added Zulip notification support to harvester checks

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -117,6 +117,12 @@ ckanext.apicatalog.news.ssl_verify = {{ content.news.ssl_verify | default(True) 
 ckanext.apicatalog.news.tags = palveluvaeylae
 ckanext.apicatalog.news.url_template = {{ content.news.url_template }}
 
+ckanext.apicatalog.harvester_status_zulip_stream = {{ harvester_status.zulip_stream }}
+ckanext.apicatalog.harvester_status_zulip_topic = {{ harvester_status.zulip_topic }}
+ckanext.apicatalog.zulip.api_url = {{ zulip.api_url }}
+ckanext.apicatalog.zulip.api_user = {{ zulip.api_user }}
+ckanext.apicatalog.zulip.api_key = {{ zulip.api_key }}
+
 ckanext-archiver.archive_dir = /tmp/archive
 ckanext-archiver.max_content_length = 50000000
 ckan.celery.queues = celery bulk priority

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -57,3 +57,13 @@ blocked_bots:
   - PetalBot
   - AhrefsBot
   - SemrushBot
+
+harvester_status:
+  zulip_stream: "Liityntäkatalogi"
+  zulip_topic: "Harvester status"
+
+zulip:
+  api_url: "turina.dvv.fi"
+  api_user: "apicatalog-bot@turina.dvv.fi"
+  api_key: "{{ secret.zulip_api_key }}"
+    

--- a/ansible/vars/secrets-defaults.yml
+++ b/ansible/vars/secrets-defaults.yml
@@ -19,3 +19,4 @@ secret:
     - "vagrant@localhost"
   ckan_harvester_instruction_url: "http://example.com"
   analytics_auth_token: ""
+  zulip_api_key: ""


### PR DESCRIPTION
# Description
Add Zulip notification support to harvester checks

## Jira ticket reference: [LIKA-605](https://jira.dvv.fi/browse/LIKA-605)

## What has changed:
- Modify CLI tools to send Zulip notifications
- Add zulip/notification configuration to ckan.ini

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

