### PR TITLE
LIKA-605: Don't send unnecessary harvester status notifications

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -174,7 +174,7 @@
     name: "Send harvester status report emails"
     minute: "0"
     hour: "11"
-    job: "{{ virtualenv }}/bin/ckan --config '{{ ckan_ini }}' apicatalog-harvest send-status-emails --force"
+    job: "{{ virtualenv }}/bin/ckan --config '{{ ckan_ini }}' apicatalog-harvest send-status-emails"
 
 - name: Send batch run report emails as a cron job
   cron:


### PR DESCRIPTION
# Description
Cronjob sent unnecessary notifications due to `--force`

## Jira ticket reference: [LIKA-605](https://jira.dvv.fi/browse/LIKA-605)

## What has changed:
- Remove --force from cron job parameters

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

