### PR TITLE
LIKA-606: use permission labels to hide removed subsystems

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -931,9 +931,6 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
         if context.get('ignore_auth') or (context.get('auth_user_obj') and context.get('auth_user_obj').sysadmin):
             return data_dict
 
-        if data_dict.get('xroad_removed') is True:
-            raise toolkit.ObjectNotFound
-
         user_name = context.get('user')
 
         org_id = data_dict.get('organization', {}).get('id', '')
@@ -995,6 +992,10 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
                 continue
 
         pkg_dict = get_action('package_show')(context, {'id': dataset_obj.id})
+
+        if pkg_dict.get('xroad_removed') is True:
+            # Only sysadmin can view subsystems removed from xroad
+            return []
 
         if pkg_dict.get('private') and \
                 pkg_dict.get('private') is True:

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -906,9 +906,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
         except ObjectNotFound:
             pass
 
-        # Filter subsystems removed from X-Road
-        results = [result for result in search_results.get('results', [])
-                   if result.get('xroad_removed') is not True]
+        results = search_results.get('results', [])
 
         for result in results:
             user_name = toolkit.g.user

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -248,7 +248,7 @@ class TestApicatalogPlugin():
 
         with app.flask_app.test_request_context():
             app.flask_app.preprocess_request()
-            with pytest.raises(ObjectNotFound):
+            with pytest.raises(NotAuthorized):
                 get_action('package_show')({}, {"id": subsystem['id']})
 
             search = get_action('package_search')({}, {})


### PR DESCRIPTION
# Description
Use permission labels to hide subsystems removed from x-road instead of search result filtering

## Jira ticket reference: [LIKA-606](https://jira.dvv.fi/browse/LIKA-606)

## What has changed:
- Remove all permission labels from xroad_removed subsystems
- Fix tests

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [x] Changes should be covered by tests.
- [x] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

