### PR TITLE
LIKA-605: Modify site_titles to differentiate between environments

### DIFF
--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -1,7 +1,7 @@
 ---
 
 public_facing_hostname: liityntakatalogi.qa.suomi.fi
-ckan_site_name: Liityntäkatalogi
+ckan_site_name: Liityntäkatalogi QA
 ckan_site_logo: /base/images/lika-logo-qa.svg
 ckan_featured_orgs: kermitti putki-ville-oy
 ckan_test_environment: True

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -1,7 +1,7 @@
 ---
 
 public_facing_hostname: liityntakatalogi.test.suomi.fi
-ckan_site_name: Liityntäkatalogi
+ckan_site_name: Testiliityntäkatalogi
 ckan_site_logo: /base/images/lika-logo-test.svg
 ckan_featured_orgs: kermitti putki-ville-oy
 ckan_test_environment: True

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -3,7 +3,7 @@ vagrant: true
 
 public_facing_hostname: 10.100.10.10
 internal_hostname: catalog-vagrant
-ckan_site_name: Liityntäkatalogi
+ckan_site_name: Liityntäkatalogi (Vagrant)
 ckan_site_logo: /base/images/lika-logo-test.svg
 ckan_featured_orgs:
 ckan_test_environment: True


### PR DESCRIPTION
# Description
Differentiate between deploy environments based on site_title

## Jira ticket reference: [LIKA-605](https://jira.dvv.fi/browse/LIKA-605)

## What has changed:
- Set a distinct site_title for each environment

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

