### PR TITLE
LIKA-612: Interpret empty old_business_ids as an empty list

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -854,6 +854,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
             'list_to_json_string': validators.list_to_json_string,
             'json_string_to_list': validators.json_string_to_list,
             'debug': validators.debug,
+            'empty_to_list': validators.empty_to_list,
         }
 
     # IFacets

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -172,7 +172,7 @@
       "field_name": "old_business_ids",
       "label": "Old business ids",
       "form_snippet": null,
-      "validators": "ignore_not_sysadmin keep_old_value_if_missing list_to_json_string default_value()",
+      "validators": "ignore_not_sysadmin keep_old_value_if_missing empty_to_list list_to_json_string default_value()",
       "output_validators": "json_string_to_list"
     },
     {

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
@@ -411,3 +411,9 @@ def debug(field, schema):
                   'context': context}
         log.debug(f'Debug validator: {pformat(fields)}')
     return validator
+
+
+def empty_to_list(value):
+    if value == '' or value is None:
+        return []
+    return value


### PR DESCRIPTION
# Description
Some organizations have an empty string or null value in old_business_ids property, which causes a validation error when the organization is updated. Added a validator to interpret those as empty lists for compatibility.

## Jira ticket reference: [LIKA-612](https://jira.dvv.fi/browse/LIKA-612)

## What has changed:
Add list of changes here.

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

