### PR TITLE
Due to changes in xroad, security server in FI-TEST responds in 8443 instead

### DIFF
--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -79,7 +79,7 @@ xroad:
   securityserver:
     host: "vrkkapalpt05.csc.fi"
     alias: "vrkkapalpt05"
-    port: 443
+    port: 8443
   client_id: FI-TEST.GOV.0245437-2.APICatalogClient
   service_id: FI-TEST.GOV.0920632-0.ServiceList
   service_name: api-docs/api

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -74,7 +74,7 @@ xroad:
   securityserver:
     host: "vrkkapalpt05.csc.fi"
     alias: "vrkkapalpt05"
-    port: 443
+    port: 8443
   client_id: FI-TEST.GOV.0245437-2.APICatalogClient
   service_id: FI-TEST.GOV.0920632-0.ServiceList
   service_name: api-docs/api


### PR DESCRIPTION
Changes in xroad security servers reserved 443 to other uses, integrations work from 8443 instead.
