### PR TITLE
Additional fixes for ckan upgrade

### DIFF
--- a/ansible/roles/ckan/files/patches/remove_free_fontawesome.patch
+++ b/ansible/roles/ckan/files/patches/remove_free_fontawesome.patch
@@ -1,5 +1,5 @@
 diff --git a/ckan/public-bs3/base/vendor/webassets.yml b/ckan/public-bs3/base/vendor/webassets.yml
-index 40e09173a..d9cc3d5d4 100644
+index 40e09173a..393ae2cf5 100644
 --- a/ckan/public-bs3/base/vendor/webassets.yml
 +++ b/ckan/public-bs3/base/vendor/webassets.yml
 @@ -4,11 +4,6 @@ select2-css:
@@ -14,3 +14,11 @@ index 40e09173a..d9cc3d5d4 100644
 
  jquery:
    filters: rjsmin
+@@ -39,7 +34,6 @@ bootstrap:
+   output: vendor/%(version)s_bootstrap.js
+   extra:
+     preload:
+-      - vendor/fontawesome
+       - vendor/jquery
+   contents:
+     - bootstrap/javascripts/bootstrap.js


### PR DESCRIPTION
fontawesome generated error in logs.

openapi viewer used old pylons controller routes which do not exist anymore.