### PR TITLE
Fix server error with robots.txt

### DIFF
--- a/ansible/roles/ckan/files/patches/fix_missing_robotstxt.patch
+++ b/ansible/roles/ckan/files/patches/fix_missing_robotstxt.patch
@@ -1,0 +1,18 @@
+diff --git a/ckan/templates-bs3/home/robots.txt b/ckan/templates-bs3/home/robots.txt
+new file mode 100644
+index 000000000..ca60362c7
+--- /dev/null
++++ b/ckan/templates-bs3/home/robots.txt
+@@ -0,0 +1,12 @@
++User-agent: *
++{% block all_user_agents -%}
++Disallow: /dataset/rate/
++Disallow: /revision/
++Disallow: /dataset/*/history
++Disallow: /api/
++Crawl-Delay: 10
++{%- endblock %}
++
++{% block additional_user_agents -%}
++{%- endblock %}
++

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -183,7 +183,7 @@
 - name: Modify allowed robots
   template:
     src: robots.txt.j2
-    dest: "{{ virtualenv }}/src/ckan/ckan/public/robots.txt"
+    dest: "{{ apicatalog_path }}/ckanext/apicatalog/templates/home/robots.txt"
     owner: root
     group: root
     mode: 0644

--- a/ansible/roles/ckan/templates/robots.txt.j2
+++ b/ansible/roles/ckan/templates/robots.txt.j2
@@ -1,15 +1,17 @@
-User-agent: *
+{% raw %}
+{% ckan_extends %}
+
+{% block additional_user_agents -%}
+{% endraw %}
 {% if not robots_allowed %}
+User-agent: *
 Disallow: /
 {% else %}
-Disallow: /dataset/rate/
-Disallow: /revision/
-Disallow: /dataset/*/history
-Disallow: /api/
-Crawl-Delay: 10
-{% endif %}
-
 {% for bot in blocked_bots %}
 User-agent: {{ bot }}
 Disallow: /
 {% endfor %}
+{% endif %}
+{% raw %}
+{%- endblock %}
+{% endraw %}

--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -29,8 +29,10 @@ ckan_patches:
   - { file: "remove_free_fontawesome" }
   - { file: "fix_updating_resource_filesize" } # https://github.com/ckan/ckan/pull/7103
   - { file: "fix_resource_delete_auth" } # https://github.com/ckan/ckan/pull/7132
+  - { file: "fix_missing_robotstxt"} # https://github.com/ckan/ckan/pull/8536
 
-files_created_by_patches: []
+files_created_by_patches:
+  - { file: "/usr/lib/ckan/default/src/ckan/ckan/templates-bs3/home/robots.txt" }
 
 
 ckan_harvester_status_email_recipients: "{{ secret.ckan_harvester_status_email_recipients }}"

--- a/ckanext/ckanext-apicatalog/.gitignore
+++ b/ckanext/ckanext-apicatalog/.gitignore
@@ -46,3 +46,4 @@ vendor
 
 # Translations
 *.mo
+/ckanext/apicatalog/templates/home/robots.txt


### PR DESCRIPTION
CKAN has an issue with robots.txt when using bootstrap 3 templates, this creates the missing template via patch and modifies it in an extension depending on ansible configuration.
