### PR TITLE
Fix read_members auth function

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/auth.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/auth.py
@@ -7,7 +7,7 @@ from ckan.logic.auth import get, update, get_resource_object
 from ckan.plugins.toolkit import auth_allow_anonymous_access, _, chained_auth_function, check_access, NotAuthorized
 
 from ckan.lib.base import config
-from ckan.common import c
+from ckan.common import g
 
 log = logging.getLogger(__name__)
 
@@ -24,8 +24,6 @@ def package_show(context, data_dict):
 
 def read_members(context, data_dict):
 
-    if 'id' not in data_dict and 'group' not in context:
-        data_dict['id'] = c.group_dict['id']
     read_only_users = aslist(config.get('ckanext.apicatalog.readonly_users', []))
 
     if context.get('user') and context.get('user') in read_only_users:

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/auth.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/auth.py
@@ -7,7 +7,6 @@ from ckan.logic.auth import get, update, get_resource_object
 from ckan.plugins.toolkit import auth_allow_anonymous_access, _, chained_auth_function, check_access, NotAuthorized
 
 from ckan.lib.base import config
-from ckan.common import g
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/edit_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/edit_base.html
@@ -28,7 +28,7 @@
                     {{ h.build_nav_icon('organization.bulk_process', _('Dataset visibility'), id=c.group_dict.name) }}
                     {{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=c.group_dict.id) }}
                 {% endif %}
-                {% if h.check_access('read_members') %}
+                {% if h.check_access('read_members', {'id': g.group_dict.id}) %}
                     {{ h.build_nav_icon('organization.members', _('Members'), id=c.group_dict.name) }}
                 {% endif %}
             {% endblock %}

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/organization/read_base.html
@@ -23,7 +23,7 @@
         {{ h.build_nav_icon('xroad_organization.organization_errors', _('X-Road errors'), organization=group_dict.id) }}
         {{ h.build_nav_icon('broken_links.organization_read', _('Broken links'), organization_id=group_dict.id) }}
       {% endif %}
-      {% if h.check_access('read_members') %}
+      {% if h.check_access('read_members', {'id': group_dict.id}) %}
         {{ h.build_nav_icon('organization.members', _('Members'), id=group_dict.name) }}
       {% endif %}
     </div>


### PR DESCRIPTION
Group dict has been removed from globals as it was deprecated feature, fixes by adding id to auth call explicitely.
