### PR TITLE
Upgrade ckan to 2.10.6

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Install ckan
   pip:
-    name: git+https://github.com/ckan/ckan.git@ckan-2.10.5#egg=ckan
+    name: git+https://github.com/ckan/ckan.git@ckan-2.10.6#egg=ckan
     editable: true
     virtualenv: "{{ virtualenv }}"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ckan[requirements]==2.10.5
+ckan[requirements]==2.10.6
 
 # requirements of apicatalog
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 alembic==1.8.1
     # via ckan
-async-timeout==5.0.0
+async-timeout==5.0.1
     # via redis
 babel==2.10.3
     # via
@@ -27,7 +27,7 @@ charset-normalizer==2.0.12
     #   ckan
     #   requests
 # Removed manually, ckan is installed with ansible as this convention does not allow editable installs
-#ckan[requirements]==2.10.5
+#ckan[requirements]==2.10.6
     # via -r requirements.in
 click==8.1.3
     # via


### PR DESCRIPTION
Upgrades ckan to 2.10.6 and compiles requirements.
