### PR TITLE
LIKA-644: Update suomi.fi instruction link URL

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/i18n/ckanext-apicatalog.pot
@@ -1,49 +1,49 @@
 # Translations template for ckanext-apicatalog.
-# Copyright (C) 2024 ORGANIZATION
+# Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the ckanext-apicatalog
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-apicatalog 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-02-05 09:05+0000\n"
+"POT-Creation-Date: 2025-02-03 10:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: ckanext/apicatalog/auth.py:47
+#: ckanext/apicatalog/auth.py:44
 msgid "User {user} not authorized to create users via the API"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:634
+#: ckanext/apicatalog/plugin.py:583
 msgid "User {name} stored in database."
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:855
-#: ckanext/apicatalog/templates/package/read.html:67
+#: ckanext/apicatalog/plugin.py:805
+#: ckanext/apicatalog/templates/package/read.html:64
 #: ckanext/apicatalog/templates/package/snippets/resources.html:8
 msgid "Services"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:856
+#: ckanext/apicatalog/plugin.py:806
 #: ckanext/apicatalog/templates/admin/dashboard.html:205
 #: ckanext/apicatalog/templates/admin/dashboard.html:237
 msgid "Organization"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:857
+#: ckanext/apicatalog/plugin.py:807
 #: ckanext/apicatalog/templates/snippets/tag_list.html:4
 msgid "Tags"
 msgstr ""
 
-#: ckanext/apicatalog/plugin.py:858
+#: ckanext/apicatalog/plugin.py:808
 msgid "Formats"
 msgstr ""
 
@@ -132,13 +132,13 @@ msgid "Email {email} is not a valid format"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:10
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:51
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:52
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:87
 #: ckanext/apicatalog/translations.py:31
 msgid "Discard changes"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:47
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:48
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_edit_form.html:3
 #: ckanext/apicatalog/translations.py:32
 msgid "Save changes"
@@ -442,7 +442,7 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:10
 #: ckanext/apicatalog/templates/apicatalog_header.html:41
-#: ckanext/apicatalog/templates/footer.html:8
+#: ckanext/apicatalog/templates/footer.html:9
 msgid "API Catalog"
 msgstr ""
 
@@ -481,35 +481,35 @@ msgid "More options"
 msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:87
-#: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:20
+#: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:19
 msgid "Log in"
 msgstr ""
 
 #: ckanext/apicatalog/templates/apicatalog_header.html:89
-#: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:22
+#: ckanext/apicatalog/templates/home/snippets/apicatalog_profile.html:21
 msgid "Register"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:9
+#: ckanext/apicatalog/templates/footer.html:10
 msgid ""
 "The service is being developed by the Digital and Population Data Services "
 "Agency."
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:14
+#: ckanext/apicatalog/templates/footer.html:15
 msgid "Privacy statement"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:15
+#: ckanext/apicatalog/templates/footer.html:16
 msgid "Give feedback"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:25
-msgid "@Suomifiyritys"
+#: ckanext/apicatalog/templates/footer.html:27
+msgid "@suomifi"
 msgstr ""
 
-#: ckanext/apicatalog/templates/footer.html:30
-msgid "@Suomifiyritykselle"
+#: ckanext/apicatalog/templates/footer.html:32
+msgid "@Suomi.fi"
 msgstr ""
 
 #: ckanext/apicatalog/templates/page.html:7
@@ -634,7 +634,7 @@ msgid "Total package count"
 msgstr ""
 
 #: ckanext/apicatalog/templates/admin/dashboard.html:58
-#: ckanext/apicatalog/templates/organization/bulk_process.html:71
+#: ckanext/apicatalog/templates/organization/bulk_process.html:72
 #: ckanext/apicatalog/templates/package/read.html:8
 #: ckanext/apicatalog/templates/snippets/package_item.html:34
 msgid "Private"
@@ -764,46 +764,43 @@ msgstr ""
 msgid "Provider organizations:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:9
+#: ckanext/apicatalog/templates/admin/useradd.html:10
 #, python-format
 msgid ""
 "Successfully created user %(name)s &lt;%(email)s&gt;. Password reset mail "
 "sent."
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:13
+#: ckanext/apicatalog/templates/admin/useradd.html:14
 msgid "Add user"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:14
-#: ckanext/apicatalog/templates/user/edit_user_form.html:10
+#: ckanext/apicatalog/templates/admin/useradd.html:15
+#: ckanext/apicatalog/templates/user/edit_user_form.html:7
+#: ckanext/apicatalog/templates/user/edit_user_form.html:9
 msgid "Username"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:16
-#: ckanext/apicatalog/templates/contact/snippets/form_simple.html:14
+#: ckanext/apicatalog/templates/admin/useradd.html:17
 #: ckanext/apicatalog/templates/user/edit_user_form.html:14
 msgid "Email"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:16
+#: ckanext/apicatalog/templates/admin/useradd.html:17
 #: ckanext/apicatalog/templates/user/edit_user_form.html:14
 msgid "eg. joe@example.com"
 msgstr ""
 
-#: ckanext/apicatalog/templates/admin/useradd.html:18
-#: ckanext/apicatalog/templates/contact/snippets/form_simple.html:24
+#: ckanext/apicatalog/templates/admin/useradd.html:19
 msgid "Submit"
 msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:4
-#: ckanext/apicatalog/templates/home/layout1.html:78
 msgid "Announcements"
 msgstr ""
 
 #: ckanext/apicatalog/templates/announcements/index.html:10
 #: ckanext/apicatalog/templates/home/snippets/announcements.html:7
-#: ckanext/apicatalog/templates/home/snippets/news.html:16
 msgid "Published"
 msgstr ""
 
@@ -816,40 +813,40 @@ msgstr ""
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:12
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:13
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:14
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:19
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:23
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:27
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:31
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:35
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:36
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:37
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:32
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:33
 msgid "Content"
 msgstr ""
 
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:12
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:13
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:14
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:35
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:36
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:37
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:31
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:32
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:33
 msgid "Enter content here"
 msgstr ""
 
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:21
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:25
 #: ckanext/apicatalog/templates/ckanext_pages/base_form.html:29
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:33
 msgid "My content"
 msgstr ""
 
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:39
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:35
 msgid "Submenu Order"
 msgstr ""
 
-#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:39
+#: ckanext/apicatalog/templates/ckanext_pages/base_form.html:35
 msgid "Not in menu"
 msgstr ""
 
 #: ckanext/apicatalog/templates/ckanext_pages/page.html:15
-#: ckanext/apicatalog/templates/organization/bulk_process.html:62
+#: ckanext/apicatalog/templates/organization/bulk_process.html:63
 #: ckanext/apicatalog/templates/organization/read_base.html:5
 #: ckanext/apicatalog/templates/package/read_base.html:10
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:28
@@ -870,36 +867,6 @@ msgstr ""
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html:31
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html:33
 msgid "Pages"
-msgstr ""
-
-#: ckanext/apicatalog/templates/contact/form.html:7
-#: ckanext/apicatalog/templates/home/snippets/apicatalog_navmenu.html:8
-msgid "Feedback"
-msgstr ""
-
-#: ckanext/apicatalog/templates/contact/form.html:10
-msgid ""
-"We would like to receive feedback and development ideas regarding the API "
-"Catalogue. You cannot submit feedback on individual APIs at this time. More "
-"information on specific APIs is available through the contact channels stated"
-" in the API."
-msgstr ""
-
-#: ckanext/apicatalog/templates/contact/form.html:11
-msgid ""
-"Please send your feedback or development ideas regarding the API Catalogue "
-"using the feedback form. The feedback will be directed to Customer Services "
-"at the Service Architecture Unit of the Digital and Population Data Services "
-"Agency. If you wish to receive a reply to your feedback, please enclose your "
-"contact information. Fields marked with an asterisk (*) are mandatory."
-msgstr ""
-
-#: ckanext/apicatalog/templates/contact/snippets/form_simple.html:12
-msgid "Name"
-msgstr ""
-
-#: ckanext/apicatalog/templates/contact/snippets/form_simple.html:16
-msgid "Feedback message"
 msgstr ""
 
 #: ckanext/apicatalog/templates/group/snippets/group_item.html:29
@@ -926,7 +893,7 @@ msgstr ""
 msgid "Remove dataset from this group"
 msgstr ""
 
-#: ckanext/apicatalog/templates/home/layout1.html:3
+#: ckanext/apicatalog/templates/home/layout1.html:1
 msgid "hero"
 msgstr ""
 
@@ -952,13 +919,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/home/layout1.html:24
 msgid "service providers"
-msgstr ""
-
-#: ckanext/apicatalog/templates/home/layout1.html:69
-msgid ""
-"This content is not available in English. If you have any questions about "
-"this topic, please contact our customer service at <a "
-"href=\"mailto:organisaatiopalvelut@dvv.fi\">organisaatiopalvelut@dvv.fi</a>."
 msgstr ""
 
 #: ckanext/apicatalog/templates/home/snippets/announcement_content.html:16
@@ -1074,6 +1034,10 @@ msgstr ""
 msgid "Popular tags"
 msgstr ""
 
+#: ckanext/apicatalog/templates/home/snippets/apicatalog_navmenu.html:8
+msgid "Feedback"
+msgstr ""
+
 #: ckanext/apicatalog/templates/home/snippets/apicatalog_profile_items.html:3
 msgid "Sysadmin settings"
 msgstr ""
@@ -1120,14 +1084,6 @@ msgstr ""
 msgid "Browse APIs"
 msgstr ""
 
-#: ckanext/apicatalog/templates/home/snippets/news.html:4
-msgid "News"
-msgstr ""
-
-#: ckanext/apicatalog/templates/home/snippets/news.html:22
-msgid "Browse news"
-msgstr ""
-
 #: ckanext/apicatalog/templates/home/snippets/promoted.html:3
 msgid "Welcome to CKAN"
 msgstr ""
@@ -1140,18 +1096,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/home/snippets/search.html:2
 msgid "E.g. environment"
-msgstr ""
-
-#: ckanext/apicatalog/templates/home/snippets/twitter.html:1
-msgid "Skip twitter feed"
-msgstr ""
-
-#: ckanext/apicatalog/templates/home/snippets/twitter.html:6
-msgid "Show more tweets by Suomi.fi yritys"
-msgstr ""
-
-#: ckanext/apicatalog/templates/home/snippets/twitter.html:15
-msgid "Show more tweets by NIIS"
 msgstr ""
 
 #: ckanext/apicatalog/templates/macros/form.html:5
@@ -1241,38 +1185,37 @@ msgstr ""
 msgid "Last Modified"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:29
+#: ckanext/apicatalog/templates/organization/bulk_process.html:30
 msgid "Make public"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:32
+#: ckanext/apicatalog/templates/organization/bulk_process.html:33
 msgid "Make private"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:36
+#: ckanext/apicatalog/templates/organization/bulk_process.html:37
 #: ckanext/apicatalog/templates/organization/members.html:75
 #: ckanext/apicatalog/templates/package/snippets/package_form.html:25
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:41
 #: ckanext/apicatalog/templates/scheming/package/snippets/resource_form.html:81
-#: ckanext/apicatalog/templates/user/edit_user_form.html:53
 msgid "Delete"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:46
+#: ckanext/apicatalog/templates/organization/bulk_process.html:47
 msgid "Select all"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:66
+#: ckanext/apicatalog/templates/organization/bulk_process.html:67
 #: ckanext/apicatalog/templates/snippets/package_item.html:41
 msgid "Draft"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:68
+#: ckanext/apicatalog/templates/organization/bulk_process.html:69
 #: ckanext/apicatalog/templates/snippets/package_item.html:43
 msgid "Deleted"
 msgstr ""
 
-#: ckanext/apicatalog/templates/organization/bulk_process.html:83
+#: ckanext/apicatalog/templates/organization/bulk_process.html:84
 msgid "This organization has no datasets associated to it"
 msgstr ""
 
@@ -1402,7 +1345,7 @@ msgid "Are you sure you want to delete this member?"
 msgstr ""
 
 #: ckanext/apicatalog/templates/organization/new.html:3
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:45
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:46
 msgid "Create an Organization"
 msgstr ""
 
@@ -1439,23 +1382,23 @@ msgstr ""
 msgid "Subsystem's information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:21
+#: ckanext/apicatalog/templates/package/read.html:18
 msgid "Request permission to use this subsystem"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:26
-#: ckanext/apicatalog/templates/package/read.html:38
+#: ckanext/apicatalog/templates/package/read.html:23
+#: ckanext/apicatalog/templates/package/read.html:35
 msgid ""
 "Request permission if you want to have access on some of this subsystems "
 "services. Please note that some subsystems might require information permit "
 "before you can request permission in API-Catalog"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:28
+#: ckanext/apicatalog/templates/package/read.html:25
 msgid "Request permission"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:32
+#: ckanext/apicatalog/templates/package/read.html:29
 msgid ""
 "Request permission to use this subsystem in the Suomi.fi Data Exchange Layer "
 "if you want to have access to one or several of its services. Download and "
@@ -1466,25 +1409,25 @@ msgid ""
 "Catalogue."
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:34
+#: ckanext/apicatalog/templates/package/read.html:31
 msgid "Download file"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:40
+#: ckanext/apicatalog/templates/package/read.html:37
 msgid "Request permission in organizations website"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:47
+#: ckanext/apicatalog/templates/package/read.html:44
 #: ckanext/apicatalog/templates/scheming/organization/about.html:13
 msgid "Description"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:52
+#: ckanext/apicatalog/templates/package/read.html:49
 #: ckanext/apicatalog/templates/scheming/package/resource_read.html:59
 msgid "Service bus identifier"
 msgstr ""
 
-#: ckanext/apicatalog/templates/package/read.html:68
+#: ckanext/apicatalog/templates/package/read.html:65
 #: ckanext/apicatalog/templates/package/snippets/resources.html:20
 msgid "Attachments"
 msgstr ""
@@ -1494,7 +1437,7 @@ msgid "Cancel edit"
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/resource_edit.html:31
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:11
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:12
 #: ckanext/apicatalog/templates/scheming/package/snippets/package_form.html:21
 msgid "Required field"
 msgstr ""
@@ -1519,9 +1462,10 @@ msgstr ""
 #: ckanext/apicatalog/templates/package/search.html:6
 msgid ""
 "If you wish to implement a service that is listed in the API Catalogue, read "
-"our <a "
-"href=\"https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5f182709341bb40241fa9713\">instructions"
-" on implementing services</a> and contact the service provider."
+"our <a href=\"https://kehittajille.suomi.fi/services/data-exchange-layer"
+"/support-articles/data-exchange/implementing-a-service-provided-through-the-"
+"suomi-fi-data-exchange-layer\">instructions on implementing services</a> and "
+"contact the service provider."
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/search.html:7
@@ -1603,7 +1547,7 @@ msgid "This resource view is not available at the moment."
 msgstr ""
 
 #: ckanext/apicatalog/templates/package/snippets/resource_view.html:20
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:122
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:114
 msgid "Click here for more information."
 msgstr ""
 
@@ -1659,7 +1603,7 @@ msgstr ""
 msgid "Additional information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/organization/group_form.html:39
+#: ckanext/apicatalog/templates/scheming/organization/group_form.html:40
 msgid "Are you sure you want to delete this Organization?"
 msgstr ""
 
@@ -1684,60 +1628,60 @@ msgstr ""
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:116
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:108
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:112
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:125
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:117
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:127
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:119
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:128
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:120
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:129
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:121
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, or"
 " the data may not have been pushed to the DataStore, or the DataStore hasn't "
 "finished processing the data yet"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:148
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:140
 msgid "Additional Information"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:144
 msgid "Field"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:153
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:145
 msgid "Value"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:159
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:151
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:160
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:166
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:172
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:152
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:158
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:164
 msgid "unknown"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:165
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:157
 msgid "Created"
 msgstr ""
 
-#: ckanext/apicatalog/templates/scheming/package/resource_read.html:171
+#: ckanext/apicatalog/templates/scheming/package/resource_read.html:163
 msgid "Format"
 msgstr ""
 
@@ -1754,7 +1698,7 @@ msgid "Finish"
 msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/add_dataset.html:7
-msgid "Add Dataset"
+msgid "Add Subsystem"
 msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/apicatalog_offcanvas-close-button.html:2
@@ -1795,14 +1739,14 @@ msgid "There are no {facet_type} that match this search"
 msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/multiselect.html:14
-#: ckanext/apicatalog/templates/snippets/multiselect.html:35
-#: ckanext/apicatalog/templates/snippets/multiselect.html:64
-#: ckanext/apicatalog/templates/snippets/multiselect.html:70
+#: ckanext/apicatalog/templates/snippets/multiselect.html:34
+#: ckanext/apicatalog/templates/snippets/multiselect.html:63
+#: ckanext/apicatalog/templates/snippets/multiselect.html:69
 msgid "All"
 msgstr ""
 
 #: ckanext/apicatalog/templates/snippets/multiselect.html:20
-#: ckanext/apicatalog/templates/snippets/multiselect.html:36
+#: ckanext/apicatalog/templates/snippets/multiselect.html:35
 msgid "selected"
 msgstr ""
 
@@ -1851,7 +1795,7 @@ msgstr ""
 msgid "Activity from items that I'm following"
 msgstr ""
 
-#: ckanext/apicatalog/templates/user/edit_user_form.html:9
+#: ckanext/apicatalog/templates/user/edit_user_form.html:5
 msgid "Change details"
 msgstr ""
 
@@ -1861,50 +1805,6 @@ msgstr ""
 
 #: ckanext/apicatalog/templates/user/edit_user_form.html:12
 msgid "eg. Joe Bloggs"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:17
-msgid "Subscribe to notification emails"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:26
-msgid "Change password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:29
-msgid "Sysadmin Password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:31
-msgid "Old Password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:33
-msgid "Your Password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:45
-msgid "Password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:47
-msgid "Confirm Password"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:53
-msgid "Are you sure you want to delete this User?"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:58
-msgid "Are you sure you want to regenerate the API key?"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:58
-msgid "Regenerate API Key"
-msgstr ""
-
-#: ckanext/apicatalog/templates/user/edit_user_form.html:62
-msgid "Update Profile"
 msgstr ""
 
 #: ckanext/apicatalog/templates/user/login.html:4

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/search.html
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/templates/package/search.html
@@ -3,7 +3,7 @@
 {% block prelude %}
 <h1>{{ _('Datasets') }}</h1>
 <p>{% trans %}Subsystems lists services and service descriptions offered by organisations that have joined the Suomi.fi Data Exchange Layer. A subsystem is used to provide services through the Data Exchange Layer and connect systems that are used for consuming services to the Data Exchange Layer.{% endtrans %}</p>
-<p>{% trans %}If you wish to implement a service that is listed in the API Catalogue, read our <a href="https://palveluhallinta.suomi.fi/en/tuki/artikkelit/5f182709341bb40241fa9713">instructions on implementing services</a> and contact the service provider.{% endtrans %}</p>
+<p>{% trans %}If you wish to implement a service that is listed in the API Catalogue, read our <a href="https://kehittajille.suomi.fi/services/data-exchange-layer/support-articles/data-exchange/implementing-a-service-provided-through-the-suomi-fi-data-exchange-layer">instructions on implementing services</a> and contact the service provider.{% endtrans %}</p>
 <div class="result-count">{{ _('{0} datasets').format(page.item_count) }}</div>
 {% endblock %}
 {% block primary_content %}


### PR DESCRIPTION
# Description
- Change suomi.fi instruction link url in dataset search

## Jira ticket reference: [LIKA-644](https://jira.dvv.fi/browse/LIKA-644)

## What has changed:
Add list of changes here.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

