### PR TITLE
LIKA-636: Fix validate_links alembic migration breaking on pre-existing tables

### DIFF
--- a/ckanext/ckanext-validate_links/ckanext/validate_links/migration/validate_links/versions/6cf6e534f8f6_add_link_validation_tables.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/migration/validate_links/versions/6cf6e534f8f6_add_link_validation_tables.py
@@ -23,12 +23,14 @@ def upgrade():
                     sa.Column('timestamp', sa.DateTime),
                     sa.Column('url', sa.UnicodeText, nullable=False),
                     sa.Column('reason', sa.UnicodeText, nullable=False),
+                    if_not_exists=True,
                     )
     op.create_table('link_validation_referrer',
                     sa.Column('id', sa.UnicodeText, primary_key=True),
                     sa.Column('result_id', sa.UnicodeText, sa.ForeignKey('link_validation_result.id')),
                     sa.Column('url', sa.UnicodeText, nullable=False),
                     sa.Column('organization', sa.UnicodeText, nullable=True),
+                    if_not_exists=True,
                     )
 
 


### PR DESCRIPTION
# Description
Switching to alembic broke deploy due to pre-existing db tables. 

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
Added `if_not_exists=True` to migration so it doesn't try to overwrite tables

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

