### PR TITLE
LIKA-636: fix alembic create_table if_not_exists not being present in used version

### DIFF
--- a/ckanext/ckanext-validate_links/ckanext/validate_links/migration/validate_links/versions/6cf6e534f8f6_add_link_validation_tables.py
+++ b/ckanext/ckanext-validate_links/ckanext/validate_links/migration/validate_links/versions/6cf6e534f8f6_add_link_validation_tables.py
@@ -7,6 +7,7 @@ Create Date: 2025-02-04 11:10:50.240282
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
 
 
 # revision identifiers, used by Alembic.
@@ -17,21 +18,26 @@ depends_on = None
 
 
 def upgrade():
-    op.create_table('link_validation_result',
-                    sa.Column('id', sa.UnicodeText, primary_key=True),
-                    sa.Column('type', sa.UnicodeText),
-                    sa.Column('timestamp', sa.DateTime),
-                    sa.Column('url', sa.UnicodeText, nullable=False),
-                    sa.Column('reason', sa.UnicodeText, nullable=False),
-                    if_not_exists=True,
-                    )
-    op.create_table('link_validation_referrer',
-                    sa.Column('id', sa.UnicodeText, primary_key=True),
-                    sa.Column('result_id', sa.UnicodeText, sa.ForeignKey('link_validation_result.id')),
-                    sa.Column('url', sa.UnicodeText, nullable=False),
-                    sa.Column('organization', sa.UnicodeText, nullable=True),
-                    if_not_exists=True,
-                    )
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    tables = inspector.get_table_names()
+
+    if 'link_validation_result' not in tables:
+        op.create_table('link_validation_result',
+                        sa.Column('id', sa.UnicodeText, primary_key=True),
+                        sa.Column('type', sa.UnicodeText),
+                        sa.Column('timestamp', sa.DateTime),
+                        sa.Column('url', sa.UnicodeText, nullable=False),
+                        sa.Column('reason', sa.UnicodeText, nullable=False),
+                        )
+
+    if 'link_validation_referrer' not in tables:
+        op.create_table('link_validation_referrer',
+                        sa.Column('id', sa.UnicodeText, primary_key=True),
+                        sa.Column('result_id', sa.UnicodeText, sa.ForeignKey('link_validation_result.id')),
+                        sa.Column('url', sa.UnicodeText, nullable=False),
+                        sa.Column('organization', sa.UnicodeText, nullable=True),
+                        )
 
 
 def downgrade():


### PR DESCRIPTION
# Description
if_not_exists was introduced in alembic 1.13.3. CKAN requires 1.13.2. Create a workaround.

## Jira ticket reference: [LIKA-###](https://jira.dvv.fi/browse/LIKA-###)

## What has changed:
manually check the list of tables before creating.

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No

Add screenshots of design changes here if yes.

