### PR TITLE
Fix error in harvesting, helper check_access assumes user exist, toolkit check_access requires context

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
@@ -180,7 +180,7 @@ def ignore_not_package_maintainer(key, data, errors, context):
     if 'package' not in context:
         return
 
-    if toolkit.h.check_access('package_update', {'id': context['package'].id}):
+    if toolkit.check_access('package_update', context, {'id': context['package'].id}):
         data.pop(key)
 
 


### PR DESCRIPTION
Python code shouldn't use template helpers.
