### PR TITLE
LIKA-687: Make previously harvested organization fields user-modifiable

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/plugin.py
@@ -795,6 +795,7 @@ class ApicatalogPlugin(plugins.SingletonPlugin, DefaultTranslation, DefaultPermi
             'json_string_to_list': validators.json_string_to_list,
             'debug': validators.debug,
             'empty_to_list': validators.empty_to_list,
+            'fluent_core_translated_output_any_field': validators.fluent_core_translated_output_any_field,
         }
 
     # IFacets

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/presets.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/presets.json
@@ -101,13 +101,13 @@
       }
     },
     {
-      "preset_name": "fluent_core_markdown_translated",
+      "preset_name": "fluent_markdown_editor_any_field",
       "values": {
-        "form_snippet": "fluent_markdown_ex.html",
+        "form_snippet": "fluent_markdown_editor.html",
         "display_snippet": "fluent_markdown.html",
         "error_snippet": "fluent_text.html",
         "validators": "fluent_text",
-        "output_validators": "fluent_core_translated_output",
+        "output_validators": "fluent_core_translated_output_any_field",
         "classes": ["control-full"]
       }
     },

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -7,7 +7,7 @@
       "field_name":  "id",
       "display_snippet": null,
       "form_snippet": null,
-      "validators": "ignore_missing empty_if_not_sysadmin unicode_safe"
+      "validators": "ignore_missing unicode_safe"
     },
     {
       "field_name": "title_translated",
@@ -122,11 +122,14 @@
     {
       "field_name": "webpage_address",
       "label": "Webpage address",
-      "preset": "fluent_text",
+      "group_title": "Web page",
       "display_webpage_name_field": "webpage_description",
       "display_snippet": "webpage.html",
-      "form_snippet": null,
-      "validators": "keep_old_value_if_missing fluent_text"
+      "validators": "fluent_text keep_old_value_if_missing",
+      "input_title": ["Finnish web page", "Swedish web page", "English web page"],
+      "output_validators": "fluent_core_translated_output_any_field",
+      "form_snippet": "fluent_text_ex.html",
+      "form_languages": ["fi", "sv", "en"]
     },
     {
       "field_name": "webpage_address_modified_in_catalog",
@@ -136,11 +139,17 @@
     },
     {
       "field_name": "webpage_description",
-      "label": "Webpage description",
-      "preset": "fluent_text",
-      "validators": "keep_old_value_if_missing fluent_text",
-      "form_snippet": null,
-      "display_snippet": null
+      "label": "Web page description",
+      "group_title": "Web page description",
+      "group_description": "A general, concise, and easy-to-understand description of the web page.",
+      "preset": "fluent_markdown_editor_any_field",
+      "validators": "fluent_text keep_old_value_if_missing mark_as_modified_in_catalog_if_changed",
+      "required": false,
+      "form_placeholder": "Write the web page's description",
+      "form_languages": ["fi", "sv", "en"],
+      "display_snippet": null,
+      "form_attrs": {},
+      "group_divider": true
     },
     {
       "field_name": "webpage_description_modified_in_catalog",
@@ -151,34 +160,40 @@
     {
       "field_name": "company_type",
       "label": "Company type",
-      "preset": "fluent_text",
-      "form_snippet": null,
-      "display_snippet": "fluent_text.html"
+      "input_title": ["Company type in Finnish", "Company type in Swedish", "Company type in English"],
+      "form_placeholder": "Company type",
+      "validators": "fluent_text override_translation_with_default_language",
+      "output_validators": "fluent_core_translated_output_any_field",
+      "display_snippet": "fluent_text.html",
+      "form_snippet": "fluent_text_ex.html",
+      "form_languages": ["fi", "sv", "en"]
     },
     {
       "field_name": "company_language",
       "label": "Company language",
-      "preset": "fluent_text",
-      "form_snippet": null,
-      "display_snippet": "fluent_text.html"
+      "input_title": ["Company language in Finnish", "Company language in Swedish", "Company language in English"],
+      "form_placeholder": "Company language",
+      "validators": "fluent_text override_translation_with_default_language",
+      "output_validators": "fluent_core_translated_output_any_field",
+      "display_snippet": "fluent_text.html",
+      "form_snippet": "fluent_text_ex.html",
+      "form_languages": ["fi", "sv", "en"]
     },
     {
       "field_name": "organization_guid",
       "label": "Organization GUID",
-      "form_snippet": null,
-      "validators": "ignore_not_sysadmin keep_old_value_if_missing default_value()"
+      "validators": "keep_old_value_if_missing default_value()"
     },
     {
       "field_name": "company_registration_date",
       "label": "Company registration date",
-      "preset": "datetime",
-      "form_snippet": null
+      "preset": "datetime"
     },
     {
       "field_name": "old_business_ids",
       "label": "Old business ids",
-      "form_snippet": null,
-      "validators": "ignore_not_sysadmin keep_old_value_if_missing empty_to_list list_to_json_string default_value()",
+      "validators": "keep_old_value_if_missing empty_to_list list_to_json_string default_value()",
+      "preset": "multiple_text",
       "output_validators": "json_string_to_list"
     },
     {

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/validators.py
@@ -417,3 +417,28 @@ def empty_to_list(value):
     if value == '' or value is None:
         return []
     return value
+
+
+@scheming_validator
+def fluent_core_translated_output_any_field(field, schema):
+    'fluent_core_translated_output without _translated suffix requirement'
+
+    from ckanext.fluent.validators import fluent_text_output, LANG_SUFFIX
+    from ckanext.scheming.helpers import scheming_language_text
+
+    def validator(key, data, errors, context):
+        """
+        Return a value for a core field using a multilingual dict.
+        """
+        data[key] = fluent_text_output(data[key])
+
+        if field['field_name'].endswith(LANG_SUFFIX):
+            k = key[-1]
+            new_key = key[:-1] + (k[:-len(LANG_SUFFIX)],)
+
+            if new_key in data:
+                default_locale = config.get('ckan.locale_default', 'en')
+                data[new_key] = scheming_language_text(data[key],
+                                                       default_locale)
+
+    return validator


### PR DESCRIPTION
# Description
Some organization fields are no longer provided by xroad-catalog. Make them user-modifiable.

## Jira ticket reference: [LIKA-687](https://jira.dvv.fi/browse/LIKA-687)

## What has changed:
- Support `T` date/time separator in `datetime` scheming preset
- Add fluent core output validator for fields not ending in `_translated`
- Modify organization data model to make the fields modifiable.

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [x] Yes 
- [ ] No

![image](https://github.com/user-attachments/assets/c056bfef-e4b3-4da4-b1b9-dc05b4ba37a7)


