### PR TITLE
LIKA-687: Fix entering exactly one old business ID not being interpreted as a list

### DIFF
--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/schemas/organization.json
@@ -192,7 +192,7 @@
     {
       "field_name": "old_business_ids",
       "label": "Old business IDs",
-      "validators": "keep_old_value_if_missing empty_to_list list_to_json_string default_value()",
+      "validators": "keep_old_value_if_missing empty_to_list scheming_multiple_text default_value()",
       "preset": "multiple_text",
       "output_validators": "json_string_to_list"
     },

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -230,6 +230,11 @@ class TestApicatalogPlugin():
         results = helpers.call_action('create_organization_users', context)['result']
         assert results['added'] == [user['name']]
 
+    def test_old_business_ids_output_with_string(self):
+        organization_with_single_olf_business_id = Organization(old_business_ids='["1","2"]')
+
+        assert organization_with_single_olf_business_id['old_business_ids'] == ['["1","2"]']
+
     def test_old_business_ids_output_with_list(self):
         organization_with_python_list = Organization(old_business_ids=['1', '2'])
 

--- a/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
+++ b/ckanext/ckanext-apicatalog/ckanext/apicatalog/tests/test_plugin.py
@@ -230,10 +230,6 @@ class TestApicatalogPlugin():
         results = helpers.call_action('create_organization_users', context)['result']
         assert results['added'] == [user['name']]
 
-    def test_old_business_ids_output_with_string(self):
-        with pytest.raises(ValidationError):
-            Organization(old_business_ids='["1","2"]')
-
     def test_old_business_ids_output_with_list(self):
         organization_with_python_list = Organization(old_business_ids=['1', '2'])
 


### PR DESCRIPTION
# Description
Previous implementation interpreted none and more than two old business id entries as a list, but exactly one was interpreted as a string, causing an error.

## Jira ticket reference: [LIKA-687](https://jira.dvv.fi/browse/LIKA-687)

## What has changed:
- Switch from `list_to_json_string` to `scheming_multiple_text` which actually does the correct thing after the empty case is handled by `empty_to_list`

## Checklist  

- [x] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [ ] No

Add screenshots of design changes here if yes.

