### PR TITLE
Add codecov to test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --ckan-ini=ckanext/ckanext-apicatalog/test.ini --cov=ckanext.apicatalog --disable-warnings ckanext/ckanext-apicatalog/ckanext/apicatalog/tests
-          pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
+          pytest --ckan-ini=ckanext/ckanext-apicatalog/test.ini --cov=ckanext.apicatalog --cov-report xml:apicatalog.xml --disable-warnings ckanext/ckanext-apicatalog/ckanext/apicatalog/tests
+          pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --cov-report xml:apply_permissions.xml --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
 
       - name: install codecov requirements
         if: ${{ !cancelled() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,11 @@ jobs:
           pytest --ckan-ini=ckanext/ckanext-apicatalog/test.ini --cov=ckanext.apicatalog --disable-warnings ckanext/ckanext-apicatalog/ckanext/apicatalog/tests
           pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
 
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   text-xroad:
     name: Test xroad integration
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run tests
         run: |
           pytest --ckan-ini=ckanext/ckanext-apicatalog/test.ini --cov=ckanext.apicatalog --cov-report xml:apicatalog.xml --disable-warnings ckanext/ckanext-apicatalog/ckanext/apicatalog/tests
-          pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --cov-report xml:apply_permissions.xml --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
+          pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
 
       - name: install codecov requirements
         if: ${{ !cancelled() }}
@@ -91,7 +91,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./apicatalog.xml, ./apply_permissions.xml
+          files: ./apicatalog.xml
 
   text-xroad:
     name: Test xroad integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./apicatalog.xml, ./apply_permissions.xml
 
   text-xroad:
     name: Test xroad integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,15 @@ jobs:
           pytest --ckan-ini=ckanext/ckanext-apicatalog/test.ini --cov=ckanext.apicatalog --disable-warnings ckanext/ckanext-apicatalog/ckanext/apicatalog/tests
           pytest --ckan-ini=ckanext/ckanext-apply_permissions_for_service/test.ini --cov=ckanext.apply_permissions_for_service --disable-warnings ckanext/ckanext-apply_permissions_for_service/ckanext/apply_permissions_for_service/tests
 
+      - name: install codecov requirements
+        if: ${{ !cancelled() }}
+        run: |
+          apt-get update
+          apt-get install -y curl gpg
+
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Code Quality
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   lint:


### PR DESCRIPTION
Adds codecov coverage uploads to unit tests of the repository.

Removes running test workflow on push, as pull requests would run them twice. The workflow can still be run on UI if needed for branch.
