### PR TITLE
LIKA-695: Upgrade ckan to 2.11.4

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Install ckan
   pip:
-    name: git+https://github.com/ckan/ckan.git@ckan-2.11.3#egg=ckan
+    name: git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan
     editable: true
     virtualenv: "{{ virtualenv }}"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ckan[requirements]==2.11.3
+ckan[requirements]==2.11.4
 
 # requirements of apicatalog
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ charset-normalizer==3.3.2
     #   ckan
     #   requests
 # Removed manually, ckan is installed with ansible as this convention does not allow editable installs
-#ckan[requirements]==2.11.3
+#ckan[requirements]==2.11.4
     # via -r requirements.in
 click==8.1.7
     # via
@@ -136,7 +136,7 @@ redis==5.0.7
     # via
     #   ckan
     #   rq
-requests==2.32.3
+requests==2.32.4
     # via
     #   ckan
     #   pysolr
@@ -174,7 +174,7 @@ urllib3==2.2.2
     # via
     #   ckan
     #   requests
-uwsgi==2.0.29
+uwsgi==2.0.31
     # via -r requirements.in
 watchdog==4.0.1
     # via


### PR DESCRIPTION
Upgrades ckan to 2.11.4 and compiles requirements.

