### PR TITLE
Fix provision of empty instance

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
 allow_world_readable_tmpfiles = True
-stdout_callback=yaml
+result_format=yaml
 show_custom_stats = true
 interpreter_python=/usr/bin/python3

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -23,6 +23,11 @@
     state: absent
     virtualenv: "{{ virtualenv }}"
 
+- name: Install required setuptools
+  pip:
+    name: setuptools<81
+    virtualenv: "{{ virtualenv }}"
+
 - name: Install ckan
   pip:
     name: git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan


### PR DESCRIPTION

stdout_callback was deprecated in ansible and extensions break with setuptools 82, they would need to be updated from various places.