### PR TITLE
Ckan upgrade 2.11.5

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
 allow_world_readable_tmpfiles = True
-stdout_callback=yaml
+result_format=yaml
 show_custom_stats = true
 interpreter_python=/usr/bin/python3

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -23,6 +23,11 @@
     state: absent
     virtualenv: "{{ virtualenv }}"
 
+- name: Install required setuptools
+  pip:
+    name: setuptools<81
+    virtualenv: "{{ virtualenv }}"
+
 - name: Install ckan
   pip:
     name: git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan

--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -23,14 +23,9 @@
     state: absent
     virtualenv: "{{ virtualenv }}"
 
-- name: Install required setuptools
-  pip:
-    name: setuptools<81
-    virtualenv: "{{ virtualenv }}"
-
 - name: Install ckan
   pip:
-    name: git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan
+    name: git+https://github.com/ckan/ckan.git@ckan-2.11.5#egg=ckan
     editable: true
     virtualenv: "{{ virtualenv }}"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-ckan[requirements]==2.11.4
+ckan[requirements]==2.11.5
 
 # requirements of apicatalog
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ babel==2.15.0
     #   flask-babel
 bleach==6.1.0
     # via ckan
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   ckan
     #   flask
@@ -22,7 +22,7 @@ cachelib==0.13.0
     # via
     #   ckan
     #   flask-session
-certifi==2024.7.4
+certifi==2026.1.4
     # via
     #   ckan
     #   requests
@@ -31,7 +31,7 @@ charset-normalizer==3.3.2
     #   ckan
     #   requests
 # Removed manually, ckan is installed with ansible as this convention does not allow editable installs
-#ckan[requirements]==2.11.4
+#ckan[requirements]==2.11.5
     # via -r requirements.in
 click==8.1.7
     # via
@@ -42,7 +42,7 @@ dominate==2.9.1
     # via ckan
 feedgen==1.0.0
     # via ckan
-flask==3.0.3
+flask==3.1.3
     # via
     #   ckan
     #   flask-babel
@@ -57,7 +57,7 @@ flask-session==0.8.0
     # via ckan
 flask-wtf==1.2.1
     # via ckan
-greenlet==3.0.3
+greenlet==3.3.1
     # via
     #   ckan
     #   sqlalchemy
@@ -65,8 +65,6 @@ idna==3.7
     # via
     #   ckan
     #   requests
-importlib-metadata==8.0.0
-    # via ckan
 itsdangerous==2.2.0
     # via
     #   ckan
@@ -77,24 +75,25 @@ jinja2==3.1.6
     #   ckan
     #   flask
     #   flask-babel
-lxml==5.2.2
+lxml==6.0.2
     # via
     #   ckan
     #   feedgen
-mako==1.3.5
+mako==1.3.11
     # via
     #   alembic
     #   ckan
-markdown==3.6
+markdown==3.10.2
     # via ckan
 markupsafe==2.1.5
     # via
     #   ckan
+    #   flask
     #   jinja2
     #   mako
     #   werkzeug
     #   wtforms
-msgspec==0.18.6
+msgspec==0.20.0
     # via
     #   ckan
     #   flask-session
@@ -112,13 +111,13 @@ passlib==1.7.4
     # via ckan
 polib==1.2.0
     # via ckan
-psycopg2==2.9.9
+psycopg2==2.9.11
     # via ckan
-pyjwt==2.8.0
+pyjwt==2.12.1
     # via ckan
 pyparsing==3.1.2
     # via ckan
-pysolr==3.9.0
+pysolr==3.11.0
     # via ckan
 python-dateutil==2.9.0.post0
     # via
@@ -126,7 +125,7 @@ python-dateutil==2.9.0.post0
     #   feedgen
 python-magic==0.4.27
     # via ckan
-pytz==2024.1
+pytz==2025.2
     # via
     #   ckan
     #   flask-babel
@@ -136,7 +135,7 @@ redis==5.0.7
     # via
     #   ckan
     #   rq
-requests==2.32.4
+requests==2.33.0
     # via
     #   ckan
     #   pysolr
@@ -158,7 +157,7 @@ sqlalchemy2-stubs==0.0.2a38
     # via
     #   ckan
     #   sqlalchemy
-sqlparse==0.5.0
+sqlparse==0.5.4
     # via ckan
 tomli==2.0.1
     # via ckan
@@ -170,7 +169,7 @@ typing-extensions==4.12.2
     #   sqlalchemy2-stubs
 tzlocal==5.2
     # via ckan
-urllib3==2.2.2
+urllib3==2.6.3
     # via
     #   ckan
     #   requests
@@ -186,7 +185,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   ckan
-werkzeug[watchdog]==3.0.6
+werkzeug[watchdog]==3.1.8
     # via
     #   ckan
     #   flask
@@ -195,10 +194,6 @@ wtforms==3.1.2
     # via
     #   ckan
     #   flask-wtf
-zipp==3.19.2
-    # via
-    #   ckan
-    #   importlib-metadata
 zope-interface==6.4.post2
     # via ckan
 


### PR DESCRIPTION
Built on #525, removes setuptools requirement as ckan itself has it.
