### PR TITLE
Send emails through csc servers

### DIFF
--- a/ansible/roles/postfix/templates/main.cf.j2
+++ b/ansible/roles/postfix/templates/main.cf.j2
@@ -14,7 +14,11 @@ myhostname = {{ email_domain }}
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydestination = {{ email_domain }}, localhost.localdomain, localhost
-relayhost = 
+{% if deployment_environment_id == "vagrant" %}
+relayhost =
+{% else %}
+relayhost = [smtp.sdn.csc.fi]
+{% endif %}
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_size_limit = 0
 recipient_delimiter = +

--- a/ansible/vars/environment-specific/prod.yml
+++ b/ansible/vars/environment-specific/prod.yml
@@ -67,7 +67,7 @@ ckan_admins:
   - "{{ ckan_users.admin.username }}"
   - "{{ ckan_users.harvest.username }}"
 
-email_domain: "{{ public_facing_hostname }}"
+email_domain: palveluvayla.fi
 email:
   smtp_server: localhost
   from: no-reply@{{ email_domain }}

--- a/ansible/vars/environment-specific/qa.yml
+++ b/ansible/vars/environment-specific/qa.yml
@@ -67,7 +67,7 @@ ckan_admins:
   - "{{ ckan_users.admin.username }}"
   - "{{ ckan_users.harvest.username }}"
 
-email_domain: "{{ public_facing_hostname }}"
+email_domain: palveluvayla.fi
 email:
   smtp_server: localhost
   from: no-reply@{{ email_domain }}

--- a/ansible/vars/environment-specific/test.yml
+++ b/ansible/vars/environment-specific/test.yml
@@ -62,7 +62,7 @@ ckan_users:
 ckan_admins:
   - "{{ ckan_users.admin.username }}"
 
-email_domain: "{{ public_facing_hostname }}"
+email_domain: palveluvayla.fi
 email:
   smtp_server: localhost
   from: no-reply@{{ email_domain }}


### PR DESCRIPTION
Due to the difficulties of hosting own email server, send emails through csc servers instead. Those emails will be sent from palveluvayla.fi domain.
